### PR TITLE
Add organization-scoped routes and dashboard layout

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,14 +3,25 @@ import {
   Box,
   Briefcase,
   FolderKanban,
+  LayoutGrid,
   Layers,
   Lock,
+  MapPin,
+  Plus,
   Plug,
+  Settings,
   ShieldCheck,
   Sparkles,
   Users,
   Zap,
 } from "lucide-react";
+import {
+  NavLink,
+  Outlet,
+  RouterProvider,
+  createBrowserRouter,
+  useParams,
+} from "react-router";
 
 const featureCards = [
   {
@@ -59,7 +70,27 @@ const modules = [
   { title: "Agents", description: "AI automation for routine workflows." },
 ];
 
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <MarketingPage />,
+  },
+  {
+    path: "/:org",
+    element: <OrganizationLayout />,
+    children: [
+      { index: true, element: <OrganizationOverview /> },
+      { path: "projects", element: <OrganizationProjects /> },
+      { path: "offering", element: <OrganizationOffering /> },
+    ],
+  },
+]);
+
 export function App() {
+  return <RouterProvider router={router} />;
+}
+
+function MarketingPage() {
   return (
     <div className="min-h-screen bg-[#0b0f14] text-white">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_rgba(11,15,20,0.85)_55%)]" />
@@ -189,9 +220,7 @@ export function App() {
 
           <section className="mt-20" id="careers">
             <div className="rounded-3xl border border-blue-500/30 bg-gradient-to-r from-blue-950 via-blue-900/50 to-slate-900 px-8 py-10 text-center">
-              <h2 className="text-3xl font-semibold">
-                Ready to get started?
-              </h2>
+              <h2 className="text-3xl font-semibold">Ready to get started?</h2>
               <p className="mt-3 text-sm text-white/70">
                 Join teams building better with ViaVai&apos;s unified platform.
               </p>
@@ -219,6 +248,258 @@ export function App() {
       </div>
     </div>
   );
+}
+
+function OrganizationLayout() {
+  const { org = "" } = useParams();
+  const organizationName = formatOrganizationName(org || "org");
+  const navLinkClasses = ({ isActive }: { isActive: boolean }) =>
+    [
+      "flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition",
+      isActive
+        ? "bg-white/10 text-white"
+        : "text-white/70 hover:text-white",
+    ].join(" ");
+
+  return (
+    <div className="min-h-screen bg-[#0b0f14] text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.16),_rgba(11,15,20,0.9)_55%)]" />
+      <div className="relative">
+        <header className="border-b border-white/10">
+          <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-600/20 text-blue-300">
+                <Layers className="h-5 w-5" />
+              </div>
+              <div className="text-sm font-semibold text-white/80">
+                {organizationName}
+              </div>
+            </div>
+            <nav className="hidden items-center gap-2 text-sm md:flex">
+              <NavLink className={navLinkClasses} end to={`/${org}`}>
+                <LayoutGrid className="h-4 w-4" />
+                Overview
+              </NavLink>
+              <NavLink className={navLinkClasses} to={`/${org}/projects`}>
+                <FolderKanban className="h-4 w-4" />
+                Projects
+              </NavLink>
+              <NavLink className={navLinkClasses} to={`/${org}/offering`}>
+                <Briefcase className="h-4 w-4" />
+                Offerings
+              </NavLink>
+            </nav>
+            <button className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-white/80 transition hover:border-white/20">
+              <Settings className="h-4 w-4" />
+              Workspace settings
+            </button>
+          </div>
+        </header>
+
+        <main className="mx-auto grid w-full max-w-6xl gap-8 px-6 pb-16 pt-10 lg:grid-cols-[320px_1fr]">
+          <aside className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.35)]">
+            <div className="flex flex-col items-center text-center">
+              <div className="relative">
+                <div className="flex h-28 w-28 items-center justify-center rounded-full bg-blue-600 text-3xl font-semibold">
+                  {getOrganizationInitials(organizationName)}
+                </div>
+                <button className="absolute bottom-0 right-1 flex h-8 w-8 items-center justify-center rounded-full border border-white/15 bg-slate-900/80 text-white/70">
+                  <Settings className="h-4 w-4" />
+                </button>
+              </div>
+              <h2 className="mt-4 text-xl font-semibold">
+                {organizationName}
+              </h2>
+              <p className="text-sm text-white/60">org-{org || "workspace"}</p>
+              <p className="mt-4 text-sm text-white/60">
+                Your organization workspace
+              </p>
+              <button className="mt-4 w-full rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-600/40 transition hover:bg-blue-500">
+                Edit profile
+              </button>
+              <div className="mt-6 flex items-center gap-2 text-xs text-white/60">
+                <Users className="h-4 w-4 text-blue-400" />
+                5 followers · 0 following
+              </div>
+              <div className="mt-2 flex items-center gap-2 text-xs text-white/50">
+                <MapPin className="h-4 w-4" />
+                Switzerland
+              </div>
+            </div>
+          </aside>
+
+          <section className="space-y-6">
+            <Outlet />
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function OrganizationOverview() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Overview</h1>
+            <p className="mt-2 text-sm text-white/65">
+              Track the operating system for your organization across projects,
+              policy, and compliance readiness.
+            </p>
+          </div>
+          <button className="flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-600/40 transition hover:bg-blue-500">
+            <Plus className="h-4 w-4" />
+            New Initiative
+          </button>
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        {[
+          {
+            title: "Portfolio readiness",
+            detail: "3 active workstreams · 2 pending approvals",
+          },
+          {
+            title: "Compliance signals",
+            detail: "SOC 2 evidence collection on track",
+          },
+          {
+            title: "Operational cadence",
+            detail: "Weekly governance review scheduled",
+          },
+          {
+            title: "Automation coverage",
+            detail: "12 workflows running via agents",
+          },
+        ].map((item) => (
+          <div
+            key={item.title}
+            className="rounded-2xl border border-white/10 bg-slate-900/60 p-5"
+          >
+            <p className="text-sm font-semibold">{item.title}</p>
+            <p className="mt-2 text-xs text-white/60">{item.detail}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function OrganizationProjects() {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Projects</h1>
+          <p className="mt-2 text-sm text-white/65">
+            Keep delivery teams aligned with live initiatives and governance
+            requirements.
+          </p>
+        </div>
+        <button className="flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-600/40 transition hover:bg-blue-500">
+          <Plus className="h-4 w-4" />
+          New Project
+        </button>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        {[
+          {
+            title: "Policy Automation",
+            detail: "Audit workflows, control mapping, and reporting.",
+            meta: "Compliance · 4 teams",
+          },
+          {
+            title: "Portfolio Sync",
+            detail: "Align initiatives across business units and services.",
+            meta: "Strategy · 2 teams",
+          },
+          {
+            title: "Internal Tools Hub",
+            detail: "Unified HR, finance, and knowledge operations.",
+            meta: "Operations · 3 teams",
+          },
+          {
+            title: "Deployment Governance",
+            detail: "Release orchestration for multi-region rollouts.",
+            meta: "Ops · 5 teams",
+          },
+        ].map((project) => (
+          <div
+            key={project.title}
+            className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.35)]"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-600/10 text-blue-400">
+                <FolderKanban className="h-5 w-5" />
+              </div>
+              <div>
+                <h3 className="text-base font-semibold">{project.title}</h3>
+                <p className="text-xs text-white/55">{project.meta}</p>
+              </div>
+            </div>
+            <p className="mt-4 text-sm text-white/70">{project.detail}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function OrganizationOffering() {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Products & Services</h1>
+          <p className="mt-2 text-sm text-white/65">
+            Showcase the offerings, internal services, and bundled programs that
+            power your organization.
+          </p>
+        </div>
+        <button className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/20">
+          <Plus className="h-4 w-4" />
+          Add Offering
+        </button>
+      </div>
+      <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-10 text-center">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-600/20 text-blue-300">
+          <Briefcase className="h-6 w-6" />
+        </div>
+        <h2 className="mt-4 text-lg font-semibold">No offerings yet</h2>
+        <p className="mt-2 text-sm text-white/60">
+          Start with a flagship offering to communicate how you deliver value.
+        </p>
+        <button className="mt-6 inline-flex items-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-blue-600/40 transition hover:bg-blue-500">
+          <Plus className="h-4 w-4" />
+          Create First Offering
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatOrganizationName(value: string) {
+  return value
+    .split("-")
+    .map((segment) =>
+      segment.length > 0
+        ? segment[0].toUpperCase() + segment.slice(1)
+        : segment
+    )
+    .join(" ");
+}
+
+function getOrganizationInitials(name: string) {
+  const parts = name.split(" ").filter(Boolean);
+  if (parts.length === 0) {
+    return "OO";
+  }
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
 }
 
 export default App;


### PR DESCRIPTION
### Motivation
- Provide organization-scoped URLs so the app can serve an org dashboard at `/:org` with subpages for projects and offerings.
- Replace single-page marketing-only navigation with a router-based structure that supports nested org views and preserves the marketing landing page at `/`.

### Description
- Added a router to `web/src/App.tsx` using `createBrowserRouter` and `RouterProvider` and registered routes for `/`, `/:org`, `/:org/projects`, and `/:org/offering`.
- Implemented `OrganizationLayout` and three nested route components: `OrganizationOverview`, `OrganizationProjects`, and `OrganizationOffering`, wired via `Outlet` and `NavLink` to enable the sidebar/profile + content layout.
- Updated imports to include router primitives (`NavLink`, `Outlet`, `RouterProvider`, `createBrowserRouter`, `useParams`) and additional UI icons (`LayoutGrid`, `MapPin`, `Plus`, `Settings`), and added helper functions `formatOrganizationName` and `getOrganizationInitials`.
- Kept the existing marketing landing markup as `MarketingPage` mounted at `/` and committed the changes.

### Testing
- Attempted to run the dev server with `npm run dev`, but Vite failed because `react-router` could not be resolved and pre-bundling was skipped, so the app did not start.
- Attempted `npm install` to fetch dependencies, but the install was blocked by a registry `E403` error for `react-router`, so runtime verification could not complete and no automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b278dd8548323a271735a713667a7)