### PR TITLE
Refine offerings empty state layout

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -480,20 +480,25 @@ function OrganizationOffering() {
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold">Products & Services</h1>
-          <p className="mt-1 text-sm text-white/50">0 active offerings</p>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600/20 text-blue-300">
+            <Box className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold">Products & Services</h1>
+            <p className="mt-1 text-sm text-white/50">0 active offerings</p>
+          </div>
         </div>
-        <button className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/20">
+        <button className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(0,0,0,0.35)] transition hover:border-white/25 hover:bg-white/10">
           <Plus className="h-4 w-4" />
           Add Offering
         </button>
       </div>
-      <div className="rounded-3xl border border-dashed border-white/15 bg-slate-900/60 p-12 text-center">
-        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-600/20 text-blue-300">
+      <div className="rounded-3xl border border-dashed border-white/15 bg-slate-900/60 px-6 py-16 text-center shadow-[0_20px_60px_rgba(0,0,0,0.4)]">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-600/20 text-blue-300 shadow-[0_10px_30px_rgba(37,99,235,0.2)]">
           <Sparkles className="h-6 w-6" />
         </div>
-        <h2 className="mt-4 text-lg font-semibold">No offerings yet</h2>
+        <h2 className="mt-5 text-lg font-semibold">No offerings yet</h2>
         <p className="mt-2 text-sm text-white/60">
           Showcase your products and services to potential customers
         </p>


### PR DESCRIPTION
### Motivation

- Improve the visual fidelity of the Products & Services (offerings) view to better match the provided screenshot. 
- Make the header feel more like other dashboard cards by adding an icon badge and richer button treatment. 
- Improve the empty-state card spacing, shadows, and icon treatment for a stronger, more polished UI.

### Description

- Updated the offerings header to include an icon badge using the `Box` icon and grouped the title/meta with it for consistent alignment. 
- Enhanced the `Add Offering` button with deeper shadowing, subtle hover background, and border adjustments for better contrast. 
- Reworked the empty-state card padding, vertical spacing, and added card and icon shadows to match the reference visual style. 
- All changes are contained in `web/src/App.tsx` and are UI-only (no logic changes).

### Testing

- Launched the Vite dev server and verified the offerings page loads successfully. 
- Ran a Playwright smoke script to navigate to `/longlink/offering` and capture a screenshot of the updated empty state which was produced as an artifact (`artifacts/offerings-empty.png`), confirming the UI renders as expected. 
- No unit tests were modified or added (visual/UX-only changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b353016488323908700c1b2379fc9)