### PR TITLE
Enforce Pydantic response model types and add tests

### DIFF
--- a/sdk/tests/api/response_models.py
+++ b/sdk/tests/api/response_models.py
@@ -1,0 +1,49 @@
+import unittest
+from httpx import AsyncClient, ASGITransport
+
+from pydantic import BaseModel
+
+from viavai import ViaVai, post
+
+
+app = ViaVai()
+
+
+class UserModel(BaseModel):
+    id: int
+    username: str
+
+
+@post("/user")
+async def valid_user() -> UserModel:
+    return UserModel(id=1, username="testuser")
+
+
+@post("/user/bad")
+async def invalid_user() -> UserModel:
+    return {"id": 2, "username": "bad"}
+
+
+class TestResponseModelEnforcement(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_model_when_type_hint_matches(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post("/user")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("content-type"), "application/json")
+        self.assertEqual(response.json(), {"id": 1, "username": "testuser"})
+
+    async def test_returns_error_when_type_hint_mismatch(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post("/user/bad")
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Invalid response type", response.text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/viavai/app.py
+++ b/sdk/viavai/app.py
@@ -1,3 +1,7 @@
+from typing import get_type_hints
+
+from pydantic import BaseModel
+
 from viavai.controllers.routes import match_route
 
 
@@ -33,12 +37,39 @@ class ViaVai:
         else:
             body = await handler()
 
+        return_type = get_type_hints(handler).get("return")
+        if return_type and isinstance(return_type, type) and issubclass(return_type, BaseModel):
+            if not isinstance(body, return_type):
+                await send({
+                    "type": "http.response.start",
+                    "status": 500,
+                    "headers": [(b"content-type", b"text/plain")],
+                })
+                await send({
+                    "type": "http.response.body",
+                    "body": f"Invalid response type. Expected {return_type.__name__}.".encode(),
+                })
+                return
+
+            if hasattr(body, "model_dump_json"):
+                response_body = body.model_dump_json()
+            else:
+                response_body = body.json()
+            headers = [(b"content-type", b"application/json")]
+            body_bytes = response_body.encode()
+        else:
+            headers = [(b"content-type", b"text/plain")]
+            if isinstance(body, bytes):
+                body_bytes = body
+            else:
+                body_bytes = str(body).encode()
+
         await send({
             "type": "http.response.start",
             "status": 200,
-            "headers": [(b"content-type", b"text/plain")],
+            "headers": headers,
         })
         await send({
             "type": "http.response.body",
-            "body": body.encode(),
+            "body": body_bytes,
         })


### PR DESCRIPTION
### Motivation
- Ensure handlers that declare a Pydantic model return type actually return that model so responses are consistent and safe.
- Serialize Pydantic model responses as JSON automatically when the function `return` annotation is a `BaseModel` subclass.
- Surface a clear error when a handler returns a value that does not match the declared Pydantic return type.

### Description
- Update `sdk/viavai/app.py` to inspect handler return annotations via `get_type_hints`, detect `BaseModel` subclasses, enforce instance type checks, and return `500` with an error message on mismatch.
- Serialize valid Pydantic responses using `model_dump_json()` (or `json()` fallback) and set `Content-Type: application/json`, otherwise continue to return plain text responses.
- Adjust response body handling to send bytes directly and set headers accordingly.
- Add tests in `sdk/tests/api/response_models.py` that register two endpoints (`/user` returning a `UserModel` and `/user/bad` returning a plain `dict`) and assert a `200` JSON response for the valid case and a `500` error for the mismatch case.

### Testing
- Added `sdk/tests/api/response_models.py` with two `unittest.IsolatedAsyncioTestCase` tests that exercise the valid and invalid model return cases, but automated tests were not executed in this change set.
- Existing SDK HTTP method and path tests remain unchanged and were not re-run as part of this change.
- No CI/test-run output is included in this PR (tests can be run with the repo test runner to validate behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b76a72a808323a0e8afc6e477a13d)