### PR TITLE
Add query parameter support and brace-style path params to route matching

### DIFF
--- a/sdk/tests/api/methods.py
+++ b/sdk/tests/api/methods.py
@@ -15,6 +15,10 @@ async def sample_get():
 async def sample_post():
     return "POST response"
 
+@post("/params/{object}?{start}&{end}")
+async def sample_post_endpoint_with_params(object: int, start: int = 0, end: int = 10):
+    return "Sample POST endpoint response"
+
 @put("/")
 async def sample_put():
     return "PUT response"
@@ -46,6 +50,24 @@ class TestSimpleMethods(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "POST response")
+
+    async def test_post_with_params(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post("/params/5?start=2&end=8")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "Sample POST endpoint response")
+
+    async def test_post_with_params_defaults(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post("/params/5")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "Sample POST endpoint response")
 
     async def test_put(self):
         transport = ASGITransport(app=app)

--- a/sdk/viavai/app.py
+++ b/sdk/viavai/app.py
@@ -18,7 +18,10 @@ class ViaVai:
         method = scope["method"]
         path = scope["path"]
 
-        handler, params = match_route(method, path)
+        query_string = scope.get("query_string", b"")
+        if isinstance(query_string, bytes):
+            query_string = query_string.decode()
+        handler, params = match_route(method, path, query_string=query_string)
 
         if not handler:
             await send({

--- a/sdk/viavai/controllers/routes.py
+++ b/sdk/viavai/controllers/routes.py
@@ -1,4 +1,5 @@
 from typing import Callable, Awaitable, Any
+from urllib.parse import parse_qs
 
 Handler = Callable[..., Awaitable[Any]]
 
@@ -39,6 +40,50 @@ def _split_path(path: str) -> list[str]:
     return stripped.split("/")
 
 
+def _is_param_segment(segment: str) -> bool:
+    return (segment.startswith("<") and segment.endswith(">")) or (
+        segment.startswith("{") and segment.endswith("}")
+    )
+
+
+def _param_name(segment: str) -> str:
+    if segment.startswith("<") and segment.endswith(">"):
+        return segment[1:-1].strip()
+    if segment.startswith("{") and segment.endswith("}"):
+        return segment[1:-1].strip()
+    return ""
+
+
+def _split_route_template(route_path: str) -> tuple[str, list[str]]:
+    if "?" not in route_path:
+        return route_path, []
+    path_part, query_part = route_path.split("?", 1)
+    query_names: list[str] = []
+    for token in query_part.split("&"):
+        token = token.strip()
+        if not token:
+            continue
+        if token.startswith("{") and token.endswith("}"):
+            name = token[1:-1].strip()
+            if name:
+                query_names.append(name)
+            continue
+        if "=" in token:
+            key, value = token.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if value.startswith("{") and value.endswith("}"):
+                name = value[1:-1].strip()
+                if key:
+                    query_names.append(key)
+                elif name:
+                    query_names.append(name)
+                continue
+        if token:
+            query_names.append(token)
+    return path_part, query_names
+
+
 def _match_route_path(route_path: str, path: str) -> dict[str, str] | None:
     route_parts = _split_path(route_path)
     path_parts = _split_path(path)
@@ -48,8 +93,8 @@ def _match_route_path(route_path: str, path: str) -> dict[str, str] | None:
 
     params: dict[str, str] = {}
     for route_part, path_part in zip(route_parts, path_parts):
-        if route_part.startswith("<") and route_part.endswith(">"):
-            param_name = route_part[1:-1].strip()
+        if _is_param_segment(route_part):
+            param_name = _param_name(route_part)
             if not param_name:
                 return None
             params[param_name] = path_part
@@ -59,7 +104,18 @@ def _match_route_path(route_path: str, path: str) -> dict[str, str] | None:
     return params
 
 
-def match_route(method: str, path: str) -> tuple[Handler | None, dict[str, str]]:
+def _extract_query_params(query_string: str, expected_params: list[str]) -> dict[str, str]:
+    if not query_string or not expected_params:
+        return {}
+    parsed = parse_qs(query_string, keep_blank_values=True)
+    params: dict[str, str] = {}
+    for name in expected_params:
+        if name in parsed and parsed[name]:
+            params[name] = parsed[name][0]
+    return params
+
+
+def match_route(method: str, path: str, query_string: str = "") -> tuple[Handler | None, dict[str, str]]:
     handler = routes.get((method.upper(), path))
     if handler:
         return handler, {}
@@ -67,8 +123,11 @@ def match_route(method: str, path: str) -> tuple[Handler | None, dict[str, str]]
     for (route_method, route_path), route_handler in routes.items():
         if route_method != method.upper():
             continue
-        params = _match_route_path(route_path, path)
+        route_path_part, query_params = _split_route_template(route_path)
+        params = _match_route_path(route_path_part, path)
         if params is not None:
+            query_values = _extract_query_params(query_string, query_params)
+            params.update(query_values)
             return route_handler, params
 
     return None, {}


### PR DESCRIPTION
### Motivation
- Support route templates that include query parameter placeholders (e.g. `/items/{id}?{start}&{end}`) so handlers can receive query values as function args.
- Allow brace-style path parameters (`{param}`) in addition to angle-bracket style (`<param>`) for more flexible route templates.
- Ensure the ASGI app forwards the request query string into the router so query placeholders are resolved at dispatch time.

### Description
- Added route template parsing helpers: `_is_param_segment`, `_param_name`, and `_split_route_template` to extract path and declared query parameter names from route templates in `sdk/viavai/controllers/routes.py`.
- Implemented `_extract_query_params` and extended `match_route` to accept a `query_string` argument, parse it with `urllib.parse.parse_qs`, and merge query values into the returned `params` dict in `sdk/viavai/controllers/routes.py`.
- Updated `ViaVai.__call__` in `sdk/viavai/app.py` to decode the ASGI `scope['query_string']` and pass it into `match_route` so handlers receive query params as kwargs.
- Added a sample endpoint and unit tests demonstrating query placeholder usage and default values in `sdk/tests/api/methods.py` (endpoint: `@post("/params/{object}?{start}&{end}")`).

### Testing
- Ran `python -m unittest sdk/tests/api/methods.py` to exercise the new route matching behavior, but the test run failed with `ModuleNotFoundError: No module named 'httpx'` due to a missing test dependency; tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7a3e0e3083239fab42b9b130f152)