### PR TITLE
Add missing SDK API tests

### DIFF
--- a/sdk/tests/api/body.py
+++ b/sdk/tests/api/body.py
@@ -1,0 +1,61 @@
+import unittest
+from httpx import AsyncClient, ASGITransport
+from viavai import ViaVai, get
+
+
+app = ViaVai()
+
+
+@get("/text-body")
+async def sample_text_body():
+    return "plain text response"
+
+
+@get("/bytes-body")
+async def sample_bytes_body():
+    return b"binary response"
+
+
+@get("/number-body")
+async def sample_number_body():
+    return 12345
+
+
+class TestResponseBodies(unittest.IsolatedAsyncioTestCase):
+    """
+    Test how different response bodies are serialized.
+    """
+
+    async def test_text_body(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/text-body")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("content-type"), "text/plain")
+        self.assertEqual(response.text, "plain text response")
+
+    async def test_bytes_body(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/bytes-body")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("content-type"), "text/plain")
+        self.assertEqual(response.content, b"binary response")
+
+    async def test_number_body(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/number-body")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("content-type"), "text/plain")
+        self.assertEqual(response.text, "12345")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/tests/api/dynamic.py
+++ b/sdk/tests/api/dynamic.py
@@ -12,6 +12,26 @@ async def sample_get(item_id: str):
     return f"GET response for {item_id}"
 
 
+@post("/{item_id}")
+async def sample_post(item_id: str):
+    return f"POST response for {item_id}"
+
+
+@put("/{item_id}")
+async def sample_put(item_id: str):
+    return f"PUT response for {item_id}"
+
+
+@delete("/{item_id}")
+async def sample_delete(item_id: str):
+    return f"DELETE response for {item_id}"
+
+
+@patch("/{item_id}")
+async def sample_patch(item_id: str):
+    return f"PATCH response for {item_id}"
+
+
 class TestDynamicRoutes(unittest.IsolatedAsyncioTestCase):
     """
     Test the HTTP methods with dynamic path parameters
@@ -26,6 +46,41 @@ class TestDynamicRoutes(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "GET response for abc123")
 
+    async def test_post(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post("/item42")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "POST response for item42")
+
+    async def test_put(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.put("/item99")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "PUT response for item99")
+
+    async def test_delete(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.delete("/item7")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "DELETE response for item7")
+
+    async def test_patch(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.patch("/item88")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "PATCH response for item88")
 
 
 if __name__ == '__main__':

--- a/sdk/tests/api/params.py
+++ b/sdk/tests/api/params.py
@@ -1,2 +1,62 @@
-# TODO: Check all the endpoint with params
-# Check @get("/params/{object}?{start}&{end}")
+import unittest
+from httpx import AsyncClient, ASGITransport
+from viavai import ViaVai, get
+
+
+app = ViaVai()
+
+
+@get("/query/{item}?{start}&{end}")
+async def sample_query_params(item: str, start: int = 0, end: int = 0):
+    return f"{item}:{start}-{end}"
+
+
+@get("/query-keyed/{item}?start={start}&end={end}")
+async def sample_query_keyed(item: str, start: int = 5, end: int = 15):
+    return f"{item}:{start}-{end}"
+
+
+class TestQueryParams(unittest.IsolatedAsyncioTestCase):
+    """
+    Test handling of dynamic path and query parameters.
+    """
+
+    async def test_query_params_with_values(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/query/widget?start=2&end=9")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "widget:2-9")
+
+    async def test_query_params_defaults(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/query/widget")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "widget:0-0")
+
+    async def test_query_params_keyed_template(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/query-keyed/gadget?start=7&end=12")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "gadget:7-12")
+
+    async def test_query_params_keyed_defaults(self):
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/query-keyed/gadget")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "gadget:5-15")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide missing API tests to improve SDK coverage for response serialization, dynamic routes, and query parameter handling.
- Ensure the app behavior for different response body types and parameter templates is validated.

### Description
- Add `sdk/tests/api/body.py` to assert text, bytes, and numeric response serialization and `content-type` handling.
- Extend `sdk/tests/api/dynamic.py` to cover POST, PUT, DELETE, and PATCH dynamic route handlers alongside GET.
- Implement `sdk/tests/api/params.py` to validate query parameter extraction for both `{name}` and keyed templates and default values.
- Tests use `httpx`'s `AsyncClient` with `ASGITransport` against the `ViaVai` app to exercise the ASGI interface.

### Testing
- Ran `python sdk/tests/api/body.py` which failed with `ModuleNotFoundError: No module named 'httpx'` due to missing test dependency.
- No other automated tests were executed in this environment because of the missing `httpx` dependency, so test files were added but not yet validated end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8523bb548323af1c2efb5b8026a7)