### PR TITLE
Fix module tabs: Files, Tickets, Settings and redirect index

### DIFF
--- a/web/src/pages/Module.tsx
+++ b/web/src/pages/Module.tsx
@@ -1,50 +1,30 @@
 import { Navigation } from '@/components/navigation';
-import { Route, Routes, useParams } from 'react-router';
-import { Overview } from '@/components/overview';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 import { Tools } from '@/components/tools';
 import { Workflows } from '@/components/workflows';
 import { Solutions } from '@/components/solutions';
-import {
-    GitBranch,
-    LayoutGrid,
-    Layers,
-    Users,
-    Wrench,
-} from 'lucide-react';
+import { FileText, Settings, Ticket } from 'lucide-react';
 
-const orgTabs = [
+const moduleTabs = [
     {
-        value: 'overview',
-        label: 'Overview',
-        path: '',
-        icon: LayoutGrid,
+        value: 'files',
+        label: 'Files',
+        path: 'files',
+        icon: FileText,
     },
     {
-        value: 'tools',
-        label: 'Tools',
-        path: 'tools',
-        icon: Wrench,
+        value: 'tickets',
+        label: 'Tickets',
+        path: 'tickets',
+        icon: Ticket,
     },
     {
-        value: 'solutions',
-        label: 'Solutions',
-        path: 'solutions',
-        icon: Layers,
-    },
-    {
-        value: 'workflows',
-        label: 'Workflows',
-        path: 'workflows',
-        icon: GitBranch,
-    },
-    {
-        value: 'people',
-        label: 'People',
-        path: 'people',
-        icon: Users,
+        value: 'settings',
+        label: 'Settings',
+        path: 'settings',
+        icon: Settings,
     },
 ];
-
 
 export function Module() {
     const { tool } = useParams();
@@ -52,8 +32,15 @@ export function Module() {
 
     return (
         <Routes>
-            <Route element={<Navigation tabs={orgTabs} basePathSuffix={basePathSuffix} />}>
-                <Route index element={<Overview />} />
+            <Route
+                element={
+                    <Navigation
+                        tabs={moduleTabs}
+                        basePathSuffix={basePathSuffix}
+                    />
+                }
+            >
+                <Route index element={<Navigate to="files" replace />} />
                 <Route path="files" element={<Tools />} />
                 <Route path="tickets" element={<Solutions />} />
                 <Route path="settings" element={<Workflows />} />


### PR DESCRIPTION
### Motivation
- Align the module view at `/:org/tools/:tool/*` to show the specific module tabs `Files`, `Tickets`, and `Settings` instead of the previous org-level tabs.

### Description
- Replace the previous `orgTabs` with `moduleTabs` containing `Files`, `Tickets`, and `Settings` and import the matching icons from `lucide-react`.
- Remove the `Overview` tab and update the routes so `files` maps to `Tools`, `tickets` maps to `Solutions`, and `settings` maps to `Workflows`.
- Add a default index redirect using `Navigate` so the module index now redirects to `files`.
- Clean up unused imports in `web/src/pages/Module.tsx` and update the `Navigation` usage to pass `moduleTabs`.

### Testing
- Ran `bun run lint` which completed successfully.
- Ran `bun run format` which completed successfully.
- Ran `bun run build` which failed with TypeScript errors related to `react-resizable-panels` missing `PanelGroup`/`PanelResizeHandle`, an unused `React` import in `scroll-area`, and a missing module `@/hooks/use-mobile`.
- Started the dev server and ran a Playwright script to load `/acme/tools/accounting/files` and capture a screenshot, which completed successfully and produced `artifacts/module-tabs.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bec2118ac8323865a074d3f97dc3e)