### PR TITLE
Add organization Text tab

### DIFF
--- a/web/src/components/text.tsx
+++ b/web/src/components/text.tsx
@@ -1,0 +1,46 @@
+import { FileText, Plus } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const textContent = `ViaVai turns organization knowledge into structured, reusable documentation.
+Capture context, highlight decisions, and keep your teams aligned across tools and workflows.`;
+
+export function Text() {
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
+                        <FileText className="h-5 w-5" />
+                    </div>
+                    <div>
+                        <h1 className="text-lg font-semibold text-white">
+                            Text
+                        </h1>
+                        <p className="text-sm text-white/60">1 entry</p>
+                    </div>
+                </div>
+                <Button variant="outline">
+                    <Plus className="h-4 w-4" />
+                    New Text
+                </Button>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Organization text component</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-white/70">
+                    <p>{textContent}</p>
+                    <p className="text-white/60">
+                        Use this tab to publish announcements, onboarding
+                        guidance, or release notes that should stay visible to
+                        every team.
+                    </p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+export default Text;

--- a/web/src/pages/Organization.tsx
+++ b/web/src/pages/Organization.tsx
@@ -2,17 +2,35 @@ import { Overview } from '@/components/overview';
 import { Tools } from '@/components/tools';
 import { Workflows } from '@/components/workflows';
 import { Solutions } from '@/components/solutions';
+import { Text } from '@/components/text';
 import { Route, Routes } from 'react-router';
-import { GitBranch, LayoutGrid, Layers, Users, Wrench } from 'lucide-react';
+import {
+    FileText,
+    GitBranch,
+    LayoutGrid,
+    Layers,
+    Users,
+    Wrench,
+} from 'lucide-react';
 import { Navigation } from '@/components/navigation';
-
 
 export function Organization() {
     const orgTabs = [
         { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
         { value: 'tools', label: 'Tools', path: 'tools', icon: Wrench },
-        { value: 'solutions', label: 'Solutions', path: 'solutions', icon: Layers },
-        { value: 'workflows', label: 'Workflows', path: 'workflows', icon: GitBranch },
+        { value: 'text', label: 'Text', path: 'text', icon: FileText },
+        {
+            value: 'solutions',
+            label: 'Solutions',
+            path: 'solutions',
+            icon: Layers,
+        },
+        {
+            value: 'workflows',
+            label: 'Workflows',
+            path: 'workflows',
+            icon: GitBranch,
+        },
         { value: 'people', label: 'People', path: 'people', icon: Users },
     ];
 
@@ -21,6 +39,7 @@ export function Organization() {
             <Route element={<Navigation tabs={orgTabs} />}>
                 <Route index element={<Overview />} />
                 <Route path="tools" element={<Tools />} />
+                <Route path="text" element={<Text />} />
                 <Route path="solutions" element={<Solutions />} />
                 <Route path="workflows" element={<Workflows />} />
                 <Route path="people" element={<div>People Page</div>} />

--- a/web/src/types/react-table.d.ts
+++ b/web/src/types/react-table.d.ts
@@ -3,5 +3,6 @@ import '@tanstack/react-table';
 declare module '@tanstack/react-table' {
     interface ColumnMeta<TData, TValue> {
         align?: 'left' | 'center' | 'right';
+        _type?: [TData, TValue];
     }
 }


### PR DESCRIPTION
### Motivation
- Provide an Organization-level "Text" tab that renders a simple text component so teams can publish persistent organization-wide text (announcements, onboarding, notes).
- Fix a small TypeScript typing issue used by the project's `@tanstack/react-table` meta to satisfy linting rules.

### Description
- Added a new `Text` component at `web/src/components/text.tsx` that displays organization text inside a card layout and exposes a "New Text" action.
- Registered the new tab and route in `web/src/pages/Organization.tsx` and added the `FileText` tab icon so the tab appears in organization navigation at `/ :org/text`.
- Adjusted `web/src/types/react-table.d.ts` to avoid unused-type lint errors by adding a `_type` tuple to `ColumnMeta`.

### Testing
- Ran `bun run lint` and the lint pass succeeded after the typing change with only one non-blocking warning reported for `DataTable` (incompatible-library warning). ✅
- Ran `bun run format` and code was formatted successfully. ✅
- Ran `bun run build` and the build failed with TypeScript errors unrelated to this feature, specifically: `react-resizable-panels` typings (`PanelGroup`/`PanelResizeHandle` missing), an unused `React` import in `scroll-area.tsx`, a missing `@/hooks/use-mobile` declaration in `sidebar.tsx`, and a typing mismatch in `pages/Test.tsx`. ❌
- Started the dev server and executed an automated browser script that loaded `/acme/text` and captured a screenshot, confirming the new tab renders in dev. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981400f3ee48323bfdc1196a3e41dc8)