### PR TITLE
Wire GitHub login button to backend OAuth endpoint and apply formatting fixes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { RouterProvider, createBrowserRouter } from 'react-router';
-import { ThemeProvider } from "@/components/theme"
+import { ThemeProvider } from '@/components/theme';
 import { Home } from '@/pages/Home';
 import { Login } from '@/pages/Login';
 import { Module } from '@/pages/Module';
@@ -20,7 +20,6 @@ const router = createBrowserRouter([
         element: <Module />,
     },
 ]);
-
 
 export function App() {
     return (

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -3,7 +3,7 @@ import {
     flexRender,
     getCoreRowModel,
     useReactTable,
-} from "@tanstack/react-table"
+} from '@tanstack/react-table';
 import {
     Table,
     TableBody,
@@ -11,17 +11,17 @@ import {
     TableHead,
     TableHeader,
     TableRow,
-} from "@/components/ui/table"
+} from '@/components/ui/table';
 
 /* =========================
    SCHEMA
 ========================= */
 
 export type ColumnSchema = {
-    key: string
-    align?: "left" | "center" | "right"
-    cell: string[]
-}
+    key: string;
+    align?: 'left' | 'center' | 'right';
+    cell: string[];
+};
 
 /* =========================
    TEMPLATE HELPERS
@@ -29,15 +29,14 @@ export type ColumnSchema = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function resolvePath(obj: any, path: string): any {
-    return path.split(".").reduce((acc, key) => acc?.[key], obj)
+    return path.split('.').reduce((acc, key) => acc?.[key], obj);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function renderTemplate(template: string, data: any): string {
-    return template.replace(
-        /\{([^}]+)\}/g,
-        (_, path) => String(resolvePath(data, path) ?? "")
-    )
+    return template.replace(/\{([^}]+)\}/g, (_, path) =>
+        String(resolvePath(data, path) ?? '')
+    );
 }
 
 /* =========================
@@ -50,17 +49,17 @@ function buildColumns<T extends object>(
     return schema.map((col) => ({
         header: col.key,
         meta: {
-            align: col.align ?? "left",
+            align: col.align ?? 'left',
         },
         cell: ({ row }) => (
-            <div className={`leading-tight text-${col.align ?? "left"}`}>
+            <div className={`leading-tight text-${col.align ?? 'left'}`}>
                 {col.cell.map((line, i) => (
                     <div
                         key={i}
                         className={
                             i === 0
-                                ? "text-sm font-medium"
-                                : "text-xs text-muted-foreground"
+                                ? 'text-sm font-medium'
+                                : 'text-xs text-muted-foreground'
                         }
                     >
                         {renderTemplate(line, row.original)}
@@ -68,7 +67,7 @@ function buildColumns<T extends object>(
                 ))}
             </div>
         ),
-    }))
+    }));
 }
 
 /* =========================
@@ -76,9 +75,9 @@ function buildColumns<T extends object>(
 ========================= */
 
 type DataTableProps<T> = {
-    data: T[]
-    schema: ColumnSchema[]
-}
+    data: T[];
+    schema: ColumnSchema[];
+};
 
 export function DataTable<T extends object>({
     data,
@@ -88,7 +87,7 @@ export function DataTable<T extends object>({
         data,
         columns: buildColumns<T>(schema),
         getCoreRowModel: getCoreRowModel(),
-    })
+    });
 
     return (
         <div className="border overflow-hidden">
@@ -98,7 +97,8 @@ export function DataTable<T extends object>({
                         <TableRow key={hg.id}>
                             {hg.headers.map((header) => {
                                 const align =
-                                    header.column.columnDef.meta?.align ?? "left"
+                                    header.column.columnDef.meta?.align ??
+                                    'left';
 
                                 return (
                                     <TableHead
@@ -108,11 +108,12 @@ export function DataTable<T extends object>({
                                         {header.isPlaceholder
                                             ? null
                                             : flexRender(
-                                                header.column.columnDef.header,
-                                                header.getContext()
-                                            )}
+                                                  header.column.columnDef
+                                                      .header,
+                                                  header.getContext()
+                                              )}
                                     </TableHead>
-                                )
+                                );
                             })}
                         </TableRow>
                     ))}
@@ -123,7 +124,7 @@ export function DataTable<T extends object>({
                         <TableRow key={row.id}>
                             {row.getVisibleCells().map((cell) => {
                                 const align =
-                                    cell.column.columnDef.meta?.align ?? "left"
+                                    cell.column.columnDef.meta?.align ?? 'left';
 
                                 return (
                                     <TableCell
@@ -135,12 +136,12 @@ export function DataTable<T extends object>({
                                             cell.getContext()
                                         )}
                                     </TableCell>
-                                )
+                                );
                             })}
                         </TableRow>
                     ))}
                 </TableBody>
             </Table>
         </div>
-    )
+    );
 }

--- a/web/src/components/Placeholder.tsx
+++ b/web/src/components/Placeholder.tsx
@@ -16,9 +16,7 @@ export function Placeholder({ title }: { title: string }) {
                         <h1 className="text-lg font-semibold text-white">
                             {title}
                         </h1>
-                        <p className="text-sm text-white/60">
-                            0 {lowerTitle}
-                        </p>
+                        <p className="text-sm text-white/60">0 {lowerTitle}</p>
                     </div>
                 </div>
                 <Button variant="outline">

--- a/web/src/components/files.tsx
+++ b/web/src/components/files.tsx
@@ -136,7 +136,8 @@ export function Files() {
                                 </EmptyMedia>
                                 <EmptyTitle>No files found</EmptyTitle>
                                 <EmptyDescription>
-                                    Try adjusting your search query or browse the repository tree.
+                                    Try adjusting your search query or browse
+                                    the repository tree.
                                 </EmptyDescription>
                             </EmptyHeader>
                         </Empty>

--- a/web/src/components/module.tsx
+++ b/web/src/components/module.tsx
@@ -1,13 +1,17 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 interface ModuleCardProps {
     name: string;
     description: string;
     href: string;
 }
-
 
 export function ModuleCard({ name, description, href }: ModuleCardProps) {
     return (

--- a/web/src/components/navigation.tsx
+++ b/web/src/components/navigation.tsx
@@ -1,8 +1,13 @@
 import { BarChart3 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { Link, Outlet, useLocation, useNavigate, useParams } from 'react-router';
+import {
+    Link,
+    Outlet,
+    useLocation,
+    useNavigate,
+    useParams,
+} from 'react-router';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-
 
 export type NavigationTab = {
     value: string;
@@ -11,12 +16,10 @@ export type NavigationTab = {
     icon: LucideIcon;
 };
 
-
 type NavigationProps = {
     tabs: NavigationTab[];
     basePathSuffix?: string;
 };
-
 
 export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
     const { org = '' } = useParams();
@@ -25,7 +28,9 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
 
     const organizationName = formatOrganizationName(org || 'org');
     const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
-    const basePath = normalizedSuffix ? `/${org}/${normalizedSuffix}` : `/${org}`;
+    const basePath = normalizedSuffix
+        ? `/${org}/${normalizedSuffix}`
+        : `/${org}`;
 
     const activeTab = (() => {
         const path = location.pathname;
@@ -62,12 +67,18 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                     <Tabs
                         value={activeTab}
                         onValueChange={(value) => {
-                            const nextTab = tabs.find((tab) => tab.value === value);
+                            const nextTab = tabs.find(
+                                (tab) => tab.value === value
+                            );
                             if (!nextTab) {
                                 return;
                             }
                             const nextPath = nextTab.path ?? '';
-                            navigate(nextPath === '' ? basePath : `${basePath}/${nextPath}`);
+                            navigate(
+                                nextPath === ''
+                                    ? basePath
+                                    : `${basePath}/${nextPath}`
+                            );
                         }}
                     >
                         <TabsList variant="line" className="gap-4">
@@ -98,7 +109,6 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
     );
 }
 
-
 function formatOrganizationName(value: string) {
     return value
         .split('-')
@@ -109,6 +119,5 @@ function formatOrganizationName(value: string) {
         )
         .join(' ');
 }
-
 
 export default Navigation;

--- a/web/src/components/overview.tsx
+++ b/web/src/components/overview.tsx
@@ -2,9 +2,7 @@ import { Plus, Sparkles } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
-
 export function Overview() {
-
     return (
         <div className="space-y-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -16,9 +14,7 @@ export function Overview() {
                         <h1 className="text-lg font-semibold text-white">
                             Overview
                         </h1>
-                        <p className="text-sm text-white/60">
-                            0 overview
-                        </p>
+                        <p className="text-sm text-white/60">0 overview</p>
                     </div>
                 </div>
                 <Button variant="outline">
@@ -31,9 +27,7 @@ export function Overview() {
                 <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
                     <Sparkles className="h-7 w-7" />
                 </div>
-                <h2 className="mt-6 text-lg font-semibold">
-                    No overview yet
-                </h2>
+                <h2 className="mt-6 text-lg font-semibold">No overview yet</h2>
                 <p className="mt-2 text-sm text-white/60">
                     This will be the overview of your organization.
                 </p>

--- a/web/src/components/solutions.tsx
+++ b/web/src/components/solutions.tsx
@@ -2,9 +2,7 @@ import { Plus, Sparkles } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
-
 export function Solutions() {
-
     return (
         <div className="space-y-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -16,9 +14,7 @@ export function Solutions() {
                         <h1 className="text-lg font-semibold text-white">
                             Solutions
                         </h1>
-                        <p className="text-sm text-white/60">
-                            0 solutions
-                        </p>
+                        <p className="text-sm text-white/60">0 solutions</p>
                     </div>
                 </div>
                 <Button variant="outline">
@@ -31,9 +27,7 @@ export function Solutions() {
                 <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
                     <Sparkles className="h-7 w-7" />
                 </div>
-                <h2 className="mt-6 text-lg font-semibold">
-                    No solutions yet
-                </h2>
+                <h2 className="mt-6 text-lg font-semibold">No solutions yet</h2>
                 <p className="mt-2 text-sm text-white/60">
                     Solutions are scope specific level applications.
                 </p>

--- a/web/src/components/theme.tsx
+++ b/web/src/components/theme.tsx
@@ -1,68 +1,74 @@
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useState } from 'react';
 
-type Theme = "dark" | "light" | "system"
+type Theme = 'dark' | 'light' | 'system';
 
 type ThemeProviderProps = {
-    children: React.ReactNode
-    defaultTheme?: Theme
-    storageKey?: string
-}
+    children: React.ReactNode;
+    defaultTheme?: Theme;
+    storageKey?: string;
+};
 
 type ThemeProviderState = {
-    theme: Theme
-    setTheme: (theme: Theme) => void
-}
+    theme: Theme;
+    setTheme: (theme: Theme) => void;
+};
 
 const initialState: ThemeProviderState = {
-    theme: "system",
+    theme: 'system',
     setTheme: () => null,
-}
+};
 
-const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
-export function ThemeProvider({ children, defaultTheme = "system", storageKey = "vite-ui-theme", ...props }: ThemeProviderProps) {
+export function ThemeProvider({
+    children,
+    defaultTheme = 'system',
+    storageKey = 'vite-ui-theme',
+    ...props
+}: ThemeProviderProps) {
     const [theme, setTheme] = useState<Theme>(
         () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-    )
+    );
 
     useEffect(() => {
-        const root = window.document.documentElement
+        const root = window.document.documentElement;
 
-        root.classList.remove("light", "dark")
+        root.classList.remove('light', 'dark');
 
-        if (theme === "system") {
-            const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-                .matches
-                ? "dark"
-                : "light"
+        if (theme === 'system') {
+            const systemTheme = window.matchMedia(
+                '(prefers-color-scheme: dark)'
+            ).matches
+                ? 'dark'
+                : 'light';
 
-            root.classList.add(systemTheme)
-            return
+            root.classList.add(systemTheme);
+            return;
         }
 
-        root.classList.add(theme)
-    }, [theme])
+        root.classList.add(theme);
+    }, [theme]);
 
     const value = {
         theme,
         setTheme: (theme: Theme) => {
-            localStorage.setItem(storageKey, theme)
-            setTheme(theme)
+            localStorage.setItem(storageKey, theme);
+            setTheme(theme);
         },
-    }
+    };
 
     return (
         <ThemeProviderContext.Provider {...props} value={value}>
             {children}
         </ThemeProviderContext.Provider>
-    )
+    );
 }
 
 export const useTheme = () => {
-    const context = useContext(ThemeProviderContext)
+    const context = useContext(ThemeProviderContext);
 
     if (context === undefined)
-        throw new Error("useTheme must be used within a ThemeProvider")
+        throw new Error('useTheme must be used within a ThemeProvider');
 
-    return context
-}
+    return context;
+};

--- a/web/src/components/tools.tsx
+++ b/web/src/components/tools.tsx
@@ -2,7 +2,6 @@ import { Plus, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ModuleCard } from '@/components/module';
 
-
 export function Tools() {
     return (
         <div className="space-y-6">
@@ -15,9 +14,7 @@ export function Tools() {
                         <h1 className="text-lg font-semibold text-white">
                             Tools
                         </h1>
-                        <p className="text-sm text-white/60">
-                            2 tools
-                        </p>
+                        <p className="text-sm text-white/60">2 tools</p>
                     </div>
                 </div>
                 <Button variant="outline">

--- a/web/src/components/workflows.tsx
+++ b/web/src/components/workflows.tsx
@@ -10,7 +10,6 @@ import {
     EmptyTitle,
 } from '@/components/ui/empty';
 
-
 export function Workflows() {
     return (
         <div className="space-y-6">
@@ -23,9 +22,7 @@ export function Workflows() {
                         <h1 className="text-lg font-semibold text-white">
                             Workflows
                         </h1>
-                        <p className="text-sm text-white/60">
-                            0 workflows
-                        </p>
+                        <p className="text-sm text-white/60">0 workflows</p>
                     </div>
                 </div>
                 <Button variant="outline">
@@ -42,7 +39,8 @@ export function Workflows() {
                         </EmptyMedia>
                         <EmptyTitle>No Workflows Yet</EmptyTitle>
                         <EmptyDescription>
-                            You haven&apos;t created any workflows yet. Get started by creating your first workflow.
+                            You haven&apos;t created any workflows yet. Get
+                            started by creating your first workflow.
                         </EmptyDescription>
                     </EmptyHeader>
                     <EmptyContent className="flex-row justify-center gap-2">

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,10 +1,19 @@
 import {
-    ArrowRight, Box, Briefcase, FolderKanban, Layers, Plug, ShieldCheck, Sparkles, Users, Zap,
+    ArrowRight,
+    Box,
+    Briefcase,
+    FolderKanban,
+    Layers,
+    Plug,
+    ShieldCheck,
+    Sparkles,
+    Users,
+    Zap,
 } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from "@/components/ui/card"
+import { Card, CardContent } from '@/components/ui/card';
 
 export function Home() {
     const navigate = useNavigate();
@@ -42,7 +51,8 @@ export function Home() {
                             <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">
                                 The modular platform
                                 <span className="text-blue-400">
-                                    {" "} built for modern teams
+                                    {' '}
+                                    built for modern teams
                                 </span>
                             </h1>
                             <p className="mt-5 text-base text-white/70 md:text-lg">
@@ -77,7 +87,8 @@ export function Home() {
                                     Multi-Tenant Organizations
                                 </h3>
                                 <p className="mt-3 text-sm text-white/65">
-                                    Structure work across portfolios, business units, and compliance boundaries.
+                                    Structure work across portfolios, business
+                                    units, and compliance boundaries.
                                 </p>
                             </CardContent>
                         </Card>
@@ -90,7 +101,8 @@ export function Home() {
                                     Modular App System
                                 </h3>
                                 <p className="mt-3 text-sm text-white/65">
-                                    Install only the capabilities you need—from projects to audit workflows.
+                                    Install only the capabilities you need—from
+                                    projects to audit workflows.
                                 </p>
                             </CardContent>
                         </Card>
@@ -103,7 +115,8 @@ export function Home() {
                                     Developer-First
                                 </h3>
                                 <p className="mt-3 text-sm text-white/65">
-                                    Ship faster with Git-native workflows and programmable automations.
+                                    Ship faster with Git-native workflows and
+                                    programmable automations.
                                 </p>
                             </CardContent>
                         </Card>
@@ -116,7 +129,8 @@ export function Home() {
                                     Secure by Default
                                 </h3>
                                 <p className="mt-3 text-sm text-white/65">
-                                    Enterprise-grade controls for sensitive data, identity, and policy.
+                                    Enterprise-grade controls for sensitive
+                                    data, identity, and policy.
                                 </p>
                             </CardContent>
                         </Card>
@@ -129,7 +143,8 @@ export function Home() {
                                     Team Collaboration
                                 </h3>
                                 <p className="mt-3 text-sm text-white/65">
-                                    Keep delivery teams aligned with shared workspaces and live updates.
+                                    Keep delivery teams aligned with shared
+                                    workspaces and live updates.
                                 </p>
                             </CardContent>
                         </Card>
@@ -142,7 +157,8 @@ export function Home() {
                                     Extensible Platform
                                 </h3>
                                 <p className="mt-3 text-sm text-white/65">
-                                    Build custom modules or use pre-built apps for every operational need.
+                                    Build custom modules or use pre-built apps
+                                    for every operational need.
                                 </p>
                             </CardContent>
                         </Card>
@@ -157,67 +173,71 @@ export function Home() {
                             pre-built modules or custom apps.
                         </p>
 
-
-                        <Card className='mt-10'>
-                            <CardContent className='grid gap-6 p-8 text-left md:grid-cols-[1.1fr_1fr]'>
+                        <Card className="mt-10">
+                            <CardContent className="grid gap-6 p-8 text-left md:grid-cols-[1.1fr_1fr]">
                                 <div>
                                     <div className="flex items-center gap-3 text-lg font-semibold">
                                         <Briefcase className="h-5 w-5 text-blue-400" />
                                         Available Modules
                                     </div>
                                     <div className="mt-6 space-y-4">
-                                        <div className="flex gap-3" >
+                                        <div className="flex gap-3">
                                             <div className="mt-1 h-5 w-5 rounded-full border border-blue-500/40 bg-blue-500/20" />
                                             <div>
                                                 <p className="text-sm font-semibold">
                                                     Issues
                                                 </p>
                                                 <p className="text-xs text-white/60">
-                                                    Track bugs, risks, and operational tasks.
+                                                    Track bugs, risks, and
+                                                    operational tasks.
                                                 </p>
                                             </div>
                                         </div>
-                                        <div className="flex gap-3" >
+                                        <div className="flex gap-3">
                                             <div className="mt-1 h-5 w-5 rounded-full border border-blue-500/40 bg-blue-500/20" />
                                             <div>
                                                 <p className="text-sm font-semibold">
                                                     Docs
                                                 </p>
                                                 <p className="text-xs text-white/60">
-                                                    Team documentation and governance policies.
+                                                    Team documentation and
+                                                    governance policies.
                                                 </p>
                                             </div>
                                         </div>
-                                        <div className="flex gap-3" >
+                                        <div className="flex gap-3">
                                             <div className="mt-1 h-5 w-5 rounded-full border border-blue-500/40 bg-blue-500/20" />
                                             <div>
                                                 <p className="text-sm font-semibold">
                                                     Secrets
                                                 </p>
                                                 <p className="text-xs text-white/60">
-                                                    Secure credentials with audit trails.
+                                                    Secure credentials with
+                                                    audit trails.
                                                 </p>
                                             </div>
                                         </div>
-                                        <div className="flex gap-3" >
+                                        <div className="flex gap-3">
                                             <div className="mt-1 h-5 w-5 rounded-full border border-blue-500/40 bg-blue-500/20" />
                                             <div>
                                                 <p className="text-sm font-semibold">
                                                     Compliance
                                                 </p>
                                                 <p className="text-xs text-white/60">
-                                                    Ensure adherence to regulations and standards.
+                                                    Ensure adherence to
+                                                    regulations and standards.
                                                 </p>
                                             </div>
                                         </div>
-                                        <div className="flex gap-3" >
+                                        <div className="flex gap-3">
                                             <div className="mt-1 h-5 w-5 rounded-full border border-blue-500/40 bg-blue-500/20" />
                                             <div>
                                                 <p className="text-sm font-semibold">
                                                     Agents
                                                 </p>
                                                 <p className="text-xs text-white/60">
-                                                    AI automation for routine workflows.
+                                                    AI automation for routine
+                                                    workflows.
                                                 </p>
                                             </div>
                                         </div>
@@ -240,7 +260,6 @@ export function Home() {
                                 </div>
                             </CardContent>
                         </Card>
-
                     </section>
 
                     <section className="mt-20" id="careers">
@@ -250,8 +269,8 @@ export function Home() {
                                     Ready to get started?
                                 </h2>
                                 <p className="mt-3 text-sm text-white/70">
-                                    Join teams building better with ViaVai&apos;s
-                                    unified platform.
+                                    Join teams building better with
+                                    ViaVai&apos;s unified platform.
                                 </p>
                                 <Button className="mt-6 inline-flex items-center gap-2 rounded-full bg-blue-600 px-6 py-3 text-sm font-semibold shadow-lg shadow-blue-600/40 transition hover:bg-blue-500">
                                     Start Building Now
@@ -275,6 +294,6 @@ export function Home() {
                     </div>
                 </footer>
             </div>
-        </div >
+        </div>
     );
 }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -2,8 +2,15 @@ import { Chrome, Github, Layers } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
-
 export function Login() {
+    const apiBaseUrl =
+        import.meta.env.VITE_API_BASE_URL?.toString() ??
+        'http://localhost:8000';
+
+    const handleGithubLogin = () => {
+        window.location.href = `${apiBaseUrl}/login/github`;
+    };
+
     return (
         <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
             <Card className="w-full max-w-md border-white/10 bg-white/5">
@@ -12,9 +19,7 @@ export function Login() {
                         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-600/20 text-blue-300">
                             <Layers className="h-6 w-6" />
                         </div>
-                        <h1 className="text-2xl font-semibold">
-                            Welcome back
-                        </h1>
+                        <h1 className="text-2xl font-semibold">Welcome back</h1>
                         <p className="text-sm text-white/60">
                             Choose a provider to continue to ViaVai.
                         </p>
@@ -25,7 +30,11 @@ export function Login() {
                             <Chrome className="h-4 w-4" />
                             Login with Google
                         </Button>
-                        <Button variant="outline" className="h-11 gap-2">
+                        <Button
+                            variant="outline"
+                            className="h-11 gap-2"
+                            onClick={handleGithubLogin}
+                        >
                             <Github className="h-4 w-4" />
                             Login with GitHub
                         </Button>

--- a/web/src/pages/Test.tsx
+++ b/web/src/pages/Test.tsx
@@ -1,29 +1,39 @@
-import * as React from "react"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Input } from "@/components/ui/input"
+import * as React from 'react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
 import {
     Select,
     SelectContent,
     SelectItem,
     SelectTrigger,
     SelectValue,
-} from "@/components/ui/select"
-import { Label } from "@/components/ui/label"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Navigation } from '@/components/navigation';
 import { GitBranch, LayoutGrid, Layers, Users, Wrench } from 'lucide-react';
 
 export function Test() {
-    const [enabled, setEnabled] = React.useState(false)
-    const [textValue, setTextValue] = React.useState("")
-    const [numberValue, setNumberValue] = React.useState(10)
-    const [option, setOption] = React.useState("medium")
+    const [enabled, setEnabled] = React.useState(false);
+    const [textValue, setTextValue] = React.useState('');
+    const [numberValue, setNumberValue] = React.useState(10);
+    const [option, setOption] = React.useState('medium');
 
     const orgTabs = [
         { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
         { value: 'tools', label: 'Tools', path: 'tools', icon: Wrench },
-        { value: 'solutions', label: 'Solutions', path: 'solutions', icon: Layers },
-        { value: 'workflows', label: 'Workflows', path: 'workflows', icon: GitBranch },
+        {
+            value: 'solutions',
+            label: 'Solutions',
+            path: 'solutions',
+            icon: Layers,
+        },
+        {
+            value: 'workflows',
+            label: 'Workflows',
+            path: 'workflows',
+            icon: GitBranch,
+        },
         { value: 'people', label: 'People', path: 'people', icon: Users },
     ];
 
@@ -78,10 +88,12 @@ export function Test() {
                             type="number"
                             min={0}
                             max={100}
-                            value={Number.isFinite(numberValue) ? numberValue : 0}
+                            value={
+                                Number.isFinite(numberValue) ? numberValue : 0
+                            }
                             onChange={(e) => {
-                                const next = e.target.value
-                                setNumberValue(next === "" ? 0 : Number(next))
+                                const next = e.target.value;
+                                setNumberValue(next === '' ? 0 : Number(next));
                             }}
                         />
                     </div>
@@ -106,5 +118,5 @@ export function Test() {
                 </CardContent>
             </Card>
         </>
-    )
+    );
 }


### PR DESCRIPTION
### Motivation
- Enable the web app to start the GitHub OAuth flow by redirecting the login button to the API backend via a configurable base URL.
- Keep the frontend codebase consistent by applying formatting and small TypeScript/style adjustments across web components.

### Description
- Add `VITE_API_BASE_URL` usage and `handleGithubLogin` to `web/src/pages/Login.tsx` to redirect the GitHub login button to `${apiBaseUrl}/login/github` with a `http://localhost:8000` fallback.
- Attach `onClick={handleGithubLogin}` to the GitHub login `Button` so the frontend triggers the backend OAuth route.
- Apply Prettier/formatting and minor TypeScript/style cleanups across many `web/src` files (imports, quotes, semicolons, spacing, and small JSX formatting changes).
- No backend code was changed; this only wires the existing frontend to the already-present backend OAuth endpoints.

### Testing
- Ran `bun run lint`, which completed but reported a warning about incompatible library usage in `DataTable.tsx`.
- Ran `bun run format`, which succeeded and reformatted multiple files.
- Ran `bun run build`, which failed due to pre-existing TypeScript errors in `resizable`, `scroll-area`, `sidebar`, and `Test` components (these errors are unrelated to the login wiring).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698203d81e4483239bc0ea7d095c6139)