### PR TITLE
Fix SDK router matching and add unit tests

### DIFF
--- a/sdk/tests/router/test_router.py
+++ b/sdk/tests/router/test_router.py
@@ -1,0 +1,63 @@
+import unittest
+
+from viavai.router import Router
+
+
+class TestRouter(unittest.TestCase):
+    def test_match_includes_path_and_query_params(self):
+        router = Router()
+
+        @router.get("/users/{user_id}/posts?{filter}&sort={sort_order}")
+        async def get_user_posts(user_id: str, filter: str = "", sort_order: str = "asc"):
+            return {"user_id": user_id, "filter": filter, "sort": sort_order}
+
+        handler, params = router.match(
+            "GET",
+            "/users/admin/posts",
+            query_string="filter=any&sort=desc",
+        )
+
+        self.assertIs(handler, get_user_posts)
+        self.assertEqual(
+            params,
+            {"user_id": "admin", "filter": "any", "sort_order": "desc"},
+        )
+
+    def test_match_applies_defaults_for_missing_query(self):
+        router = Router()
+
+        @router.get("/users/{user_id}/posts?{filter}&sort={sort_order}")
+        async def get_user_posts(user_id: str, filter: str = "", sort_order: str = "asc"):
+            return {"user_id": user_id, "filter": filter, "sort": sort_order}
+
+        handler, params = router.match(
+            "GET",
+            "/users/admin/posts",
+            query_string="sort=desc",
+        )
+
+        self.assertIs(handler, get_user_posts)
+        self.assertEqual(
+            params,
+            {"user_id": "admin", "filter": "", "sort_order": "desc"},
+        )
+
+    def test_match_ignores_unknown_template_params(self):
+        router = Router()
+
+        @router.get("/users/{user_id}/posts?{filter}")
+        async def get_user_posts(user_id: str):
+            return {"user_id": user_id}
+
+        handler, params = router.match(
+            "GET",
+            "/users/admin/posts",
+            query_string="filter=any",
+        )
+
+        self.assertIs(handler, get_user_posts)
+        self.assertEqual(params, {"user_id": "admin"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/viavai/app.py
+++ b/sdk/viavai/app.py
@@ -22,7 +22,7 @@ class ViaVai(Router, Cron):
         if isinstance(query_string, bytes):
             query_string = query_string.decode()
 
-        handler, params = match_route(method, path, query_string=query_string)
+        handler, params = self.match(method, path, query_string=query_string)
 
         if not handler:
             await send({

--- a/sdk/viavai/router/__init__.py
+++ b/sdk/viavai/router/__init__.py
@@ -16,26 +16,38 @@ class Router:
             return func
         return decorator
 
-    def _match(self, method: str, path: str) -> Handler | None:
+    def match(self, method: str, path: str, query_string: str = "") -> tuple[Handler | None, dict[str, Any]]:
+        full_path = path
+        if query_string:
+            separator = "&" if "?" in path else "?"
+            full_path = f"{path}{separator}{query_string}"
+
         for route in self._routes:
             if route.method != method.upper():
                 continue
 
-            params = route.match(path)
+            params = route.match(full_path)
             if params is None:
                 continue
 
             sig = inspect.signature(route.handler)
-            bound = sig.bind_partial(**params)
+            filtered = {name: value for name, value in params.items() if name in sig.parameters}
+            bound = sig.bind_partial(**filtered)
             bound.apply_defaults()
+            return route.handler, bound.arguments
 
-            async def wrapper(*_):
-                return await route.handler(**bound.arguments)
+        return None, {}
 
-            wrapper.__name__ = route.handler.__name__
-            return wrapper
+    def _match(self, method: str, path: str, query_string: str = "") -> Handler | None:
+        handler, params = self.match(method, path, query_string=query_string)
+        if handler is None:
+            return None
 
-        return None
+        async def wrapper(*_):
+            return await handler(**params)
+
+        wrapper.__name__ = handler.__name__
+        return wrapper
 
     def get(self, path: str): return self._route("GET", path)
     def post(self, path: str): return self._route("POST", path)
@@ -49,10 +61,10 @@ if __name__ == "__main__":
     router = Router()
 
     @router.get("/users/{user_id}/posts?{filter}&sort={sort_order}")
-    async def get_user_posts(user_id: str, filter: str = "", sort: str = "asc"):
-        return {"user_id": user_id, "filter": filter, "sort": sort}
+    async def get_user_posts(user_id: str, filter: str = "", sort_order: str = "asc"):
+        return {"user_id": user_id, "filter": filter, "sort": sort_order}
 
-    fn = router._match("GET", "/users/admin/posts?filter=any&sort=desc")
+    fn, params = router.match("GET", "/users/admin/posts", query_string="filter=any&sort=desc")
     assert fn is not None, "Handler not found for registered route"
     assert fn.__name__ == "get_user_posts", "Handler function name does not match expected"
-
+    assert params == {"user_id": "admin", "filter": "any", "sort_order": "desc"}


### PR DESCRIPTION
### Motivation
- The router previously did not correctly handle combining path and query string parameters or binding defaults to handler signatures for dispatching.
- The application entrypoint relied on an old `match_route` API and needed to use a consistent router matching function.
- Improve robustness by ignoring template query params that do not appear in the handler signature.

### Description
- Added `Router.match(method, path, query_string="")` which composes a full path, runs route matching, filters parameters to the handler signature, and applies defaults, returning `(handler, params)`; the old `_match` now wraps `match` for backward compatibility (changes in `sdk/viavai/router/__init__.py`).
- Updated `ViaVai.__call__` to use `self.match(...)` for request dispatching (change in `sdk/viavai/app.py`).
- Adjusted the example route and assertions in the module demo to reflect the new `match` return shape and parameter names (change in `sdk/viavai/router/__init__.py`).
- Added unit tests exercising path + query parameter extraction, default application, and ignoring unknown template params in `sdk/tests/router/test_router.py`.

### Testing
- Ran `python -m unittest discover -s tests` in the SDK, which executed 3 tests and completed with `OK`.
- The new test file `sdk/tests/router/test_router.py` contains three unit tests that passed under the above command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982042a256883238bd89adbd7bc4c58)