### PR TITLE
Add organization creation and read endpoints with owner assignment

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -26,6 +26,7 @@ app.add_middleware(
 
 # Register routers
 import src.routes.auth
+import src.routes.org
 app.include_router(router)
 
 

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -2,3 +2,6 @@ from .users import get_user_by_id
 from .users import get_user_by_email
 from .users import get_user_by_github_id
 from .users import add_user
+from .orgs import add_org
+from .orgs import add_org_member
+from .orgs import get_org_by_id

--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -1,0 +1,37 @@
+from sqlalchemy import select
+from src.db.models import Organization, OrganizationMember
+from src.db.session import get_session
+
+
+async def add_org(name: str) -> Organization:
+    """Add a new organization to the database."""
+    Session = await get_session()
+    async with Session() as session:
+        org = Organization(name=name)
+        session.add(org)
+        await session.commit()
+        await session.refresh(org)
+        return org
+
+
+async def add_org_member(org_id: int, user_id: int, role: str) -> OrganizationMember:
+    """Add a new member to an organization."""
+    Session = await get_session()
+    async with Session() as session:
+        member = OrganizationMember(
+            id_org=org_id,
+            id_user=user_id,
+            role=role,
+        )
+        session.add(member)
+        await session.commit()
+        await session.refresh(member)
+        return member
+
+
+async def get_org_by_id(org_id: int) -> Organization | None:
+    """Retrieve an organization by its ID."""
+    Session = await get_session()
+    async with Session() as session:
+        result = await session.execute(select(Organization).where(Organization.id == org_id))
+        return result.scalars().first()

--- a/api/src/routes/org.py
+++ b/api/src/routes/org.py
@@ -1,3 +1,29 @@
-# TODO: Return basic auth
+from fastapi import Depends, HTTPException
+from src.auth import user as get_user
+from src.db import add_org, add_org_member, get_org_by_id, User
+from src.router import router
+from src.types import OrgCreate, OrgRead
 
+
+@router.post("/org", response_model=OrgRead)
+async def create_org(payload: OrgCreate, current_user: User = Depends(get_user)):
+    org = await add_org(payload.name)
+    await add_org_member(org.id, current_user.id, "owner")
+    return OrgRead(
+        id=org.id,
+        name=org.name,
+        date_creation=org.date_creation,
+    )
+
+
+@router.get("/org/{org_id}", response_model=OrgRead)
+async def get_org(org_id: int, current_user: User = Depends(get_user)):
+    org = await get_org_by_id(org_id)
+    if org is None:
+        raise HTTPException(404, "Organization not found")
+    return OrgRead(
+        id=org.id,
+        name=org.name,
+        date_creation=org.date_creation,
+    )
 

--- a/api/src/types/__init__.py
+++ b/api/src/types/__init__.py
@@ -1,2 +1,4 @@
 from .countries import CountryCode
 from .address import AddressType
+from .orgs import OrgCreate
+from .orgs import OrgRead

--- a/api/src/types/orgs.py
+++ b/api/src/types/orgs.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class OrgCreate(BaseModel):
+    name: str
+
+
+class OrgRead(BaseModel):
+    id: int
+    name: str
+    date_creation: datetime


### PR DESCRIPTION
### Motivation

- Provide API support to create organizations and retrieve organization information. 
- Ensure that the authenticated user who creates an organization is recorded as its owner. 
- Add lightweight DB service and request/response types to keep routing thin and business logic in services.

### Description

- Added `api/src/db/services/orgs.py` implementing `add_org`, `add_org_member`, and `get_org_by_id` to manage organization persistence. 
- Introduced request/response schemas `OrgCreate` and `OrgRead` in `api/src/types/orgs.py` and exported them via `api/src/types/__init__.py`. 
- Implemented `POST /org` and `GET /org/{org_id}` routes in `api/src/routes/org.py` that depend on the authenticated user (`src.auth.user`), create an organization, attach the creator as `owner`, and return the `OrgRead` payload. 
- Registered the org routes in `api/main.py` and exported the new service functions from `api/src/db/services/__init__.py`.

### Testing

- No automated tests were executed for this change. 
- Basic manual checks were performed on the code layout and imports during development (no test runner was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821c91e7048323a94429f135390947)