### PR TITLE
Copy SDK sample scaffold during init

### DIFF
--- a/sdk/viavai/cli/init.py
+++ b/sdk/viavai/cli/init.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import click
 from pathlib import Path
 from viavai.constants import PATH
@@ -6,7 +7,7 @@ from viavai.constants import PATH
 
 def setup(folder: Path):
     """Initialize a new viavai project"""
-
+    sample_path = PATH / "sample"
     os.makedirs(folder, exist_ok=True)
+    shutil.copytree(sample_path, folder, dirs_exist_ok=True)
     click.echo(f"Project initialized in {folder}")
-


### PR DESCRIPTION
### Motivation

- Make `viavai init` populate the target folder with the bundled SDK sample scaffold instead of only creating an empty directory so new projects start from a working template.

### Description

- Updated `sdk/viavai/cli/init.py` to import `shutil`, locate the bundled sample at `PATH / "sample"`, and copy it into the destination using `shutil.copytree(..., dirs_exist_ok=True)` while still ensuring the folder exists.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821d0bb7a083238895f898682b1a47)