### PR TITLE
Add apps DB model and AppsService; create default app on org creation

### DIFF
--- a/api/src/db/README.md
+++ b/api/src/db/README.md
@@ -1,0 +1,32 @@
+# Database Layer
+
+The database layer wraps SQLAlchemy models and service classes so the rest of the
+API can work with a consistent `src.db` interface.
+
+## Structure
+
+```text
+src/db/
+├── models/    # SQLAlchemy models
+├── services/  # Async database operations
+├── session.py # Session management
+└── __init__.py
+```
+
+## Usage
+
+Import the database layer once and use the service instances:
+
+```python
+import src.db as db
+
+org = await db.orgs.create('Acme')
+await db.orgs.add(org.id, user.id, 'owner')
+app = await db.apps.create(org.id, 'Acme')
+```
+
+## Adding new models
+
+1. Create a SQLAlchemy model in `models/`.
+2. Add a service in `services/` for the database operations.
+3. Export the model and service in `src/db/__init__.py`.

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,5 +1,6 @@
-from .models import User, Organization
-from .services import OrgsService, UsersService
+from .models import App, User, Organization
+from .services import AppsService, OrgsService, UsersService
 
+apps = AppsService()
 orgs = OrgsService()
 users = UsersService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -1,6 +1,6 @@
-from .__base__ import Base
-
 # Import all models here to ensure they are registered with Base
+from .apps import App
 from .users import User
+from .__base__ import Base
 from .organizations import Organization
 from .organizations import OrganizationMember

--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from src.db.models.__base__ import Base
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import String, DateTime, BigInteger, ForeignKey, func
+
+
+class App(Base):
+    """Represent an application installed in an organization."""
+
+    __tablename__ = 'apps'
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -1,2 +1,3 @@
+from .apps import AppsService
 from .orgs import OrgsService
 from .users import UsersService

--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -1,0 +1,15 @@
+from src.db.models import App
+from src.db.session import get_session
+
+
+class AppsService:
+    async def create(self, org_id: int, name: str) -> App:
+        """Add a new app to an organization."""
+
+        Session = await get_session()
+        async with Session() as session:
+            app = App(id_org=org_id, name=name)
+            session.add(app)
+            await session.commit()
+            await session.refresh(app)
+            return app

--- a/api/src/routes/org.py
+++ b/api/src/routes/org.py
@@ -1,14 +1,15 @@
 import src.db as db
-from fastapi import Depends, HTTPException
+from src.router import router
 from src.auth import user as get_user
 from src.types import OrgCreate, OrgRead
-from src.router import router
+from fastapi import Depends, HTTPException
 
 
 @router.post('/org', response_model=OrgRead)
 async def create_org(payload: OrgCreate, current_user: db.User = Depends(get_user)):
     org = await db.orgs.create(payload.name)
     await db.orgs.add(org.id, current_user.id, 'owner')
+    await db.apps.create(org.id, payload.name)
     return OrgRead(
         id=org.id,
         name=org.name,


### PR DESCRIPTION
### Motivation

- Track and manage applications installed per organization by adding an `App` model and corresponding service, and ensure a default app record is created when an organization is created.
- Improve developer ergonomics by exposing the new model and service via the `src.db` package and documenting the DB layer usage.

### Description

- Add `App` SQLAlchemy model in `api/src/db/models/apps.py` representing applications tied to an organization with `id_org`, `name`, and `date_creation` fields.
- Add `AppsService` in `api/src/db/services/apps.py` with an async `create` method to insert app records using `get_session()`.
- Export the `App` model and `AppsService` in `api/src/db/models/__init__.py`, `api/src/db/services/__init__.py`, and instantiate `apps = AppsService()` in `api/src/db/__init__.py` for `import src.db as db` usage.
- Create a default app when a new organization is created by calling `await db.apps.create(org.id, payload.name)` in `api/src/routes/org.py`.
- Add `api/src/db/README.md` documenting the DB layer structure and usage examples with `src.db` service instances.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849812d4d48323a1d29220801b4f20)