### PR TITLE
Show app-specific tabs only on apps/:app/* routes

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
     BarChart3,
@@ -9,7 +9,13 @@ import {
     Users,
     Wrench,
 } from 'lucide-react';
-import { Link, Outlet, useLocation, useNavigate, useParams } from 'react-router';
+import {
+    Link,
+    Outlet,
+    useLocation,
+    useNavigate,
+    useParams,
+} from 'react-router';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export type NavigationTab = {
@@ -24,39 +30,37 @@ type NavigationProps = {
     basePathSuffix?: string;
 };
 
-
 const staticTabs: NavigationTab[] = [
     { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
     { value: 'tools', label: 'Tools', path: 'tools', icon: Wrench },
     { value: 'solutions', label: 'Solutions', path: 'solutions', icon: Layers },
-    { value: 'workflows', label: 'Workflows', path: 'workflows', icon: GitBranch },
+    {
+        value: 'workflows',
+        label: 'Workflows',
+        path: 'workflows',
+        icon: GitBranch,
+    },
     { value: 'people', label: 'People', path: 'people', icon: Users },
 ];
 
 export default function Layout() {
-    const { org = '' } = useParams();
-    const [appTabs, setAppTabs] = useState<NavigationTab[]>([]);
-
-    useEffect(() => {
-        setAppTabs([]);
-        const timer = window.setTimeout(() => {
-            const apps = [
-                { slug: 'viavai', name: 'ViaVai' },
-                { slug: 'atlas', name: 'Atlas' },
-                { slug: 'pulse', name: 'Pulse' },
-            ];
-            setAppTabs(
-                apps.map((app) => ({
-                    value: `apps-${app.slug}`,
-                    label: app.name,
-                    path: `apps/${app.slug}`,
-                    icon: Plug,
-                }))
-            );
-        }, 450);
-
-        return () => window.clearTimeout(timer);
-    }, [org]);
+    const { app } = useParams();
+    const appTabs = useMemo<NavigationTab[]>(() => {
+        if (!app) {
+            return [];
+        }
+        const apps = [
+            { slug: 'viavai', name: 'ViaVai' },
+            { slug: 'atlas', name: 'Atlas' },
+            { slug: 'pulse', name: 'Pulse' },
+        ];
+        return apps.map((app) => ({
+            value: `apps-${app.slug}`,
+            label: app.name,
+            path: `apps/${app.slug}`,
+            icon: Plug,
+        }));
+    }, [app]);
 
     const tabs = useMemo(() => [...staticTabs, ...appTabs], [appTabs]);
 


### PR DESCRIPTION
### Motivation
- App-specific module tabs should only be visible when an app route is active (under `apps/:app/*`) to avoid showing irrelevant navigation outside module pages.

### Description
- Updated `web/src/Layout.tsx` to read the `app` route param and build `appTabs` only when `app` is present, replacing the previous `useState` + `useEffect` timer logic with a `useMemo`.
- Merged `appTabs` with the static navigation tabs and kept the `Navigation` component behavior unchanged.
- Minor import/layout formatting adjustments in `web/src/Layout.tsx`.

### Testing
- Ran `cd web && bun run lint` which completed with a warning about TanStack Table React Compiler compatibility and no blocking errors.
- Ran `cd web && bun run format` which completed successfully.
- Ran `cd web && bun run build` which failed due to existing unrelated TypeScript errors in other files (`Test.tsx`, `ui/resizable.tsx`, `ui/scroll-area.tsx`, `ui/sidebar.tsx`, and `pages/Organization.tsx`).
- Launched the dev server and executed a Playwright script which navigated to `http://127.0.0.1:4173/org/apps/atlas` and produced a screenshot showing app tabs when on an app route (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984af3c4bfc83238319672b5088de7b)