### PR TITLE
Add `/user` endpoints and list user organizations

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -27,6 +27,7 @@ app.add_middleware(
 # Register routers
 import src.routes.auth
 import src.routes.org
+import src.routes.user
 app.include_router(router)
 
 

--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -37,3 +37,15 @@ class OrgsService:
         async with Session() as session:
             result = await session.execute(select(Organization).where(Organization.id == org_id))
             return result.scalars().first()
+
+    async def list_by_user(self, user_id: int) -> list[Organization]:
+        """Retrieve organizations assigned to a user."""
+
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(
+                select(Organization)
+                .join(OrganizationMember, Organization.id == OrganizationMember.id_org)
+                .where(OrganizationMember.id_user == user_id)
+            )
+            return list(result.scalars().all())

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,7 +1,7 @@
 from typing import cast
 import src.db as db
-from fastapi import Request, HTTPException
 from src.auth import oauth
+from fastapi import Request
 from src.router import router
 from fastapi.responses import RedirectResponse
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
@@ -58,11 +58,3 @@ async def logout(request: Request):
     request.session.clear()
     return {'ok': True}
     
-
-
-@router.get('/me')
-async def me(request: Request):
-    user = request.session.get('user')
-    if not user:
-        raise HTTPException(401, 'Not authenticated')
-    return user

--- a/api/src/routes/user.py
+++ b/api/src/routes/user.py
@@ -1,0 +1,23 @@
+import src.db as db
+from fastapi import Depends
+from src.router import router
+from src.types import OrgRead
+from src.auth import user as get_user
+
+
+@router.get('/user')
+async def get_user_details(current_user: db.User = Depends(get_user)):
+    return current_user
+
+
+@router.get('/user/orgs', response_model=list[OrgRead])
+async def get_user_orgs(current_user: db.User = Depends(get_user)):
+    orgs = await db.orgs.list_by_user(current_user.id)
+    return [
+        OrgRead(
+            id=org.id,
+            name=org.name,
+            date_creation=org.date_creation,
+        )
+        for org in orgs
+    ]


### PR DESCRIPTION
### Motivation
- Provide a consistent authenticated user endpoint (`/user`) replacing the older `/me` route for retrieving the current user's profile.
- Expose the organizations assigned to the current user via a new `/user/orgs` endpoint to support client-side organization listings.

### Description
- Added `api/src/routes/user.py` with `GET /user` returning the authenticated user and `GET /user/orgs` returning the list of organizations for the current user using the `src.auth.user` dependency.
- Implemented `OrgsService.list_by_user` in `api/src/db/services/orgs.py` to query organizations linked to a user via `OrganizationMember` using `select` and `join`.
- Removed the legacy `/me` route from `api/src/routes/auth.py` to avoid duplicate user endpoints.
- Registered the new routes by importing `src.routes.user` in `api/main.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984af9863d083238043c634140a5f05)