### PR TITLE
Hide organization tabs on app pages

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -46,9 +46,6 @@ const staticTabs: NavigationTab[] = [
 export default function Layout() {
     const { app } = useParams();
     const appTabs = useMemo<NavigationTab[]>(() => {
-        if (!app) {
-            return [];
-        }
         const apps = [
             { slug: 'viavai', name: 'ViaVai' },
             { slug: 'atlas', name: 'Atlas' },
@@ -60,9 +57,12 @@ export default function Layout() {
             path: `apps/${app.slug}`,
             icon: Plug,
         }));
-    }, [app]);
+    }, []);
 
-    const tabs = useMemo(() => [...staticTabs, ...appTabs], [appTabs]);
+    const tabs = useMemo(
+        () => (app ? appTabs : [...staticTabs, ...appTabs]),
+        [app, appTabs]
+    );
 
     return <Navigation tabs={tabs} />;
 }


### PR DESCRIPTION
### Motivation
- When navigating into an application route the UI should show only the application-specific tabs and not the default organization tabs.

### Description
- Always construct the `appTabs` list so it can be reused across views by moving its creation out of the `app`-guard in `web/src/Layout.tsx`.
- Change tab selection logic to return `appTabs` when inside an app route and to return `staticTabs + appTabs` for organization routes by updating the `tabs` `useMemo` in `web/src/Layout.tsx`.
- No other files were functionally changed; the change only affects how the `Navigation` tabs array is assembled and supplied to `Navigation`.

### Testing
- Ran `bun run lint` which completed with an existing warning in `src/components/DataTable.tsx` (no new lint errors introduced). 
- Ran `bun run format` which succeeded and formatted files. 
- Ran `bun run build` which failed due to existing unrelated TypeScript errors elsewhere in the project (errors present prior to this change). 
- Started the dev server and captured a Playwright screenshot of `/:org/apps/viavai` which verifies that only app tabs are rendered for the app route (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b20bc08883239fcdd611d03453d2)