### PR TITLE
Rename Organization models to Org and OrgMember

### DIFF
--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,4 +1,4 @@
-from .models import App, User, Organization
+from .models import App, Org, User
 from .services import AppsService, OrgsService, UsersService
 
 apps = AppsService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -1,6 +1,6 @@
 # Import all models here to ensure they are registered with Base
 from .apps import App
+from .orgs import Org
 from .users import User
+from .orgs import OrgMember
 from .__base__ import Base
-from .organizations import Organization
-from .organizations import OrganizationMember

--- a/api/src/db/models/orgs.py
+++ b/api/src/db/models/orgs.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-from sqlalchemy import String, DateTime, BigInteger, ForeignKey, func
-from sqlalchemy.orm import Mapped, mapped_column
 from src.db.models.__base__ import Base
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import BigInteger, DateTime, ForeignKey, String, func
 
 
-class Organization(Base):
+class Org(Base):
     """Represent an organization account in the platform"""
-    __tablename__ = "organizations"
+    __tablename__ = 'organizations'
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
@@ -15,14 +15,14 @@ class Organization(Base):
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
     
 
-class OrganizationMember(Base):
+class OrgMember(Base):
     """Represent a member of an organization"""
-    __tablename__ = "organizations_members"
+    __tablename__ = 'organizations_members'
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
 
-    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey("organizations.id"), nullable=False)
-    id_user: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"), nullable=False)
+    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
+    id_user: Mapped[int] = mapped_column(BigInteger, ForeignKey('users.id'), nullable=False)
     
     role = mapped_column(String(50), nullable=False)
     

--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -1,26 +1,26 @@
 from sqlalchemy import select
-from src.db.models import Organization, OrganizationMember
 from src.db.session import get_session
+from src.db.models import Org, OrgMember
 
 
 class OrgsService:
-    async def create(self, name: str) -> Organization:
+    async def create(self, name: str) -> Org:
         """Add a new organization to the database."""
 
         Session = await get_session()
         async with Session() as session:
-            org = Organization(name=name)
+            org = Org(name=name)
             session.add(org)
             await session.commit()
             await session.refresh(org)
             return org
 
-    async def add(self, org_id: int, user_id: int, role: str) -> OrganizationMember:
+    async def add(self, org_id: int, user_id: int, role: str) -> OrgMember:
         """Add a new member to an organization."""
 
         Session = await get_session()
         async with Session() as session:
-            member = OrganizationMember(
+            member = OrgMember(
                 id_org=org_id,
                 id_user=user_id,
                 role=role,
@@ -30,22 +30,22 @@ class OrgsService:
             await session.refresh(member)
             return member
 
-    async def get(self, org_id: int) -> Organization | None:
+    async def get(self, org_id: int) -> Org | None:
         """Retrieve an organization by its ID."""
 
         Session = await get_session()
         async with Session() as session:
-            result = await session.execute(select(Organization).where(Organization.id == org_id))
+            result = await session.execute(select(Org).where(Org.id == org_id))
             return result.scalars().first()
 
-    async def list_by_user(self, user_id: int) -> list[Organization]:
+    async def list_by_user(self, user_id: int) -> list[Org]:
         """Retrieve organizations assigned to a user."""
 
         Session = await get_session()
         async with Session() as session:
             result = await session.execute(
-                select(Organization)
-                .join(OrganizationMember, Organization.id == OrganizationMember.id_org)
-                .where(OrganizationMember.id_user == user_id)
+                select(Org)
+                .join(OrgMember, Org.id == OrgMember.id_org)
+                .where(OrgMember.id_user == user_id)
             )
             return list(result.scalars().all())


### PR DESCRIPTION
### Motivation
- Standardize model names to shorter forms and reflect the `orgs.py` module naming for clarity in the DB layer.
- Keep table names and DB schema unchanged while improving in-code model identifiers.
- Ensure services and exports reference the renamed models to avoid import/typing mismatches.

### Description
- Renamed ORM classes `Organization` -> `Org` and `OrganizationMember` -> `OrgMember` and moved the model file from `api/src/db/models/organizations.py` to `api/src/db/models/orgs.py` while preserving `__tablename__` values.
- Updated model exports in `api/src/db/models/__init__.py` to import `Org` and `OrgMember` from `orgs.py`.
- Updated `api/src/db/__init__.py` to export `Org` in the DB package interface.
- Updated `api/src/db/services/orgs.py` to use the new model names in type hints, object construction, and query joins (`Org`, `OrgMember`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b745e3448323b52ff4f06e688df9)