### PR TITLE
Add profile dropdown to header

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,9 +1,13 @@
 import type { LucideIcon } from 'lucide-react';
 import {
     BarChart3,
+    Building2,
     GitBranch,
     Layers,
     LayoutGrid,
+    LogOut,
+    Smile,
+    User,
     Users,
     Wrench,
 } from 'lucide-react';
@@ -21,7 +25,16 @@ import {
     BreadcrumbList,
     BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 export type NavigationTab = {
     value: string;
@@ -81,48 +94,97 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
         <div className="min-h-screen text-white">
             <header className="border-b border-white/10">
                 <div className="mx-auto w-full px-6 pb-2 pt-4">
-                    <div className="flex items-center gap-4 text-white/80">
-                        <Link
-                            to="/"
-                            className="flex h-9 w-9 items-center justify-center rounded-full bg-white/5 text-blue-300 transition hover:bg-white/10"
-                        >
-                            <BarChart3 className="h-5 w-5" />
-                        </Link>
-                        <Breadcrumb>
-                            <BreadcrumbList>
-                                <BreadcrumbItem>
-                                    <BreadcrumbLink
-                                        render={(props) => (
-                                            <Link
-                                                {...props}
-                                                to={org ? `/${org}` : '/'}
-                                                className="text-sm font-semibold text-white/70"
-                                            >
-                                                {organizationName}
-                                            </Link>
-                                        )}
+                    <div className="flex items-center justify-between gap-4 text-white/80">
+                        <div className="flex items-center gap-4">
+                            <Link
+                                to="/"
+                                className="flex h-9 w-9 items-center justify-center rounded-full bg-white/5 text-blue-300 transition hover:bg-white/10"
+                            >
+                                <BarChart3 className="h-5 w-5" />
+                            </Link>
+                            <Breadcrumb>
+                                <BreadcrumbList>
+                                    <BreadcrumbItem>
+                                        <BreadcrumbLink
+                                            render={(props) => (
+                                                <Link
+                                                    {...props}
+                                                    to={org ? `/${org}` : '/'}
+                                                    className="text-sm font-semibold text-white/70"
+                                                >
+                                                    {organizationName}
+                                                </Link>
+                                            )}
+                                        />
+                                    </BreadcrumbItem>
+                                    {appName ? (
+                                        <>
+                                            <BreadcrumbSeparator />
+                                            <BreadcrumbItem>
+                                                <BreadcrumbLink
+                                                    render={(props) => (
+                                                        <Link
+                                                            {...props}
+                                                            to={`/${org}/apps/${app}`}
+                                                            className="text-sm font-semibold text-white/70"
+                                                        >
+                                                            {appName}
+                                                        </Link>
+                                                    )}
+                                                />
+                                            </BreadcrumbItem>
+                                        </>
+                                    ) : null}
+                                </BreadcrumbList>
+                            </Breadcrumb>
+                        </div>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger className="group flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2 py-1 transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30">
+                                <Avatar className="size-7">
+                                    <AvatarImage
+                                        src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=facearea&w=80&h=80&q=80"
+                                        alt="User profile"
                                     />
-                                </BreadcrumbItem>
-                                {appName ? (
-                                    <>
-                                        <BreadcrumbSeparator />
-                                        <BreadcrumbItem>
-                                            <BreadcrumbLink
-                                                render={(props) => (
-                                                    <Link
-                                                        {...props}
-                                                        to={`/${org}/apps/${app}`}
-                                                        className="text-sm font-semibold text-white/70"
-                                                    >
-                                                        {appName}
-                                                    </Link>
-                                                )}
-                                            />
-                                        </BreadcrumbItem>
-                                    </>
-                                ) : null}
-                            </BreadcrumbList>
-                        </Breadcrumb>
+                                    <AvatarFallback>SS</AvatarFallback>
+                                </Avatar>
+                                <span className="text-sm font-medium text-white/80">
+                                    Sau1707
+                                </span>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-64">
+                                <DropdownMenuLabel className="space-y-1">
+                                    <p className="text-sm font-semibold text-white">
+                                        Sau1707
+                                    </p>
+                                    <p className="text-xs text-white/60">
+                                        Leonardo Saurwein
+                                    </p>
+                                </DropdownMenuLabel>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem>
+                                    <Smile className="mr-2 h-4 w-4 text-white/70" />
+                                    Set status
+                                </DropdownMenuItem>
+                                <DropdownMenuItem>
+                                    <User className="mr-2 h-4 w-4 text-white/70" />
+                                    Profile
+                                </DropdownMenuItem>
+                                <DropdownMenuItem>
+                                    <Building2 className="mr-2 h-4 w-4 text-white/70" />
+                                    Organizations
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem>
+                                    <Users className="mr-2 h-4 w-4 text-white/70" />
+                                    Settings
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem className="text-red-300 focus:text-red-200">
+                                    <LogOut className="mr-2 h-4 w-4" />
+                                    Sign out
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     </div>
                 </div>
 

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,13 +1,9 @@
 import type { LucideIcon } from 'lucide-react';
 import {
     BarChart3,
-    Building2,
     GitBranch,
     Layers,
     LayoutGrid,
-    LogOut,
-    Smile,
-    User,
     Users,
     Wrench,
 } from 'lucide-react';
@@ -25,16 +21,8 @@ import {
     BreadcrumbList,
     BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { UserProfile } from '@/components/user-profile';
 
 export type NavigationTab = {
     value: string;
@@ -138,53 +126,7 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                 </BreadcrumbList>
                             </Breadcrumb>
                         </div>
-                        <DropdownMenu>
-                            <DropdownMenuTrigger className="group flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2 py-1 transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30">
-                                <Avatar className="size-7">
-                                    <AvatarImage
-                                        src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=facearea&w=80&h=80&q=80"
-                                        alt="User profile"
-                                    />
-                                    <AvatarFallback>SS</AvatarFallback>
-                                </Avatar>
-                                <span className="text-sm font-medium text-white/80">
-                                    Sau1707
-                                </span>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="w-64">
-                                <DropdownMenuLabel className="space-y-1">
-                                    <p className="text-sm font-semibold text-white">
-                                        Sau1707
-                                    </p>
-                                    <p className="text-xs text-white/60">
-                                        Leonardo Saurwein
-                                    </p>
-                                </DropdownMenuLabel>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem>
-                                    <Smile className="mr-2 h-4 w-4 text-white/70" />
-                                    Set status
-                                </DropdownMenuItem>
-                                <DropdownMenuItem>
-                                    <User className="mr-2 h-4 w-4 text-white/70" />
-                                    Profile
-                                </DropdownMenuItem>
-                                <DropdownMenuItem>
-                                    <Building2 className="mr-2 h-4 w-4 text-white/70" />
-                                    Organizations
-                                </DropdownMenuItem>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem>
-                                    <Users className="mr-2 h-4 w-4 text-white/70" />
-                                    Settings
-                                </DropdownMenuItem>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem className="text-red-300 focus:text-red-200">
-                                    <LogOut className="mr-2 h-4 w-4" />
-                                    Sign out
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
+                        <UserProfile />
                     </div>
                 </div>
 

--- a/web/src/components/user-profile.tsx
+++ b/web/src/components/user-profile.tsx
@@ -1,0 +1,76 @@
+import { Building2, LogOut, Smile, User, Users } from 'lucide-react';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+type UserProfileProps = {
+    username?: string;
+    fullName?: string;
+    avatarUrl?: string;
+};
+
+const defaultUser = {
+    username: 'Sau1707',
+    fullName: 'Leonardo Saurwein',
+    avatarUrl:
+        'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=facearea&w=80&h=80&q=80',
+};
+
+export function UserProfile({
+    username = defaultUser.username,
+    fullName = defaultUser.fullName,
+    avatarUrl = defaultUser.avatarUrl,
+}: UserProfileProps) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger className="group flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2 py-1 transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30">
+                <Avatar className="size-7">
+                    <AvatarImage src={avatarUrl} alt={`${username} profile`} />
+                    <AvatarFallback>
+                        {username.slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                </Avatar>
+                <span className="text-sm font-medium text-white/80">
+                    {username}
+                </span>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-64">
+                <DropdownMenuLabel className="space-y-1">
+                    <p className="text-sm font-semibold text-white">
+                        {username}
+                    </p>
+                    <p className="text-xs text-white/60">{fullName}</p>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                    <Smile className="mr-2 h-4 w-4 text-white/70" />
+                    Set status
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                    <User className="mr-2 h-4 w-4 text-white/70" />
+                    Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                    <Building2 className="mr-2 h-4 w-4 text-white/70" />
+                    Organizations
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                    <Users className="mr-2 h-4 w-4 text-white/70" />
+                    Settings
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="text-red-300 focus:text-red-200">
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Sign out
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a top-right user profile area with an avatar and dropdown menu to match the provided design and surface user actions.

### Description
- Updated `web/src/Layout.tsx` to align the breadcrumb left and add a right-aligned `DropdownMenu` trigger containing an `Avatar` and username.
- Added imports for `DropdownMenu` components, `Avatar` components, and additional `lucide-react` icons, and implemented menu items: `Set status`, `Profile`, `Organizations`, `Settings`, and `Sign out`.
- The menu currently uses a placeholder avatar image and hardcoded identity (`Sau1707` / `Leonardo Saurwein`) as a UI scaffold for integration with real user data.

### Testing
- Ran `bun run lint`, which completed but reported a warning about TanStack Table's `useReactTable()` in `DataTable.tsx` (pre-existing warning).
- Ran `bun run format`, which succeeded and formatted project files.
- Ran `bun run build`, which failed due to existing TypeScript errors unrelated to this change (missing modules and type issues elsewhere).
- Started the dev server and executed an automated Playwright script to capture screenshots of the header and the open dropdown, which produced artifacts showing the new UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b95df45c83238902b4c650ba23c6)