### PR TITLE
Move user organization lookup into UsersService

### DIFF
--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -1,6 +1,6 @@
 from sqlalchemy import select
-from src.db.session import get_session
 from src.db.models import Org, OrgMember
+from src.db.session import get_session
 
 
 class OrgsService:
@@ -37,15 +37,3 @@ class OrgsService:
         async with Session() as session:
             result = await session.execute(select(Org).where(Org.id == org_id))
             return result.scalars().first()
-
-    async def list_by_user(self, user_id: int) -> list[Org]:
-        """Retrieve organizations assigned to a user."""
-
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(
-                select(Org)
-                .join(OrgMember, Org.id == OrgMember.id_org)
-                .where(OrgMember.id_user == user_id)
-            )
-            return list(result.scalars().all())

--- a/api/src/db/services/users.py
+++ b/api/src/db/services/users.py
@@ -1,5 +1,5 @@
 from sqlalchemy import select
-from src.db.models import User
+from src.db.models import Org, OrgMember, User
 from src.db.session import get_session
 
 
@@ -69,3 +69,15 @@ class UsersService:
             await session.commit()
             await session.refresh(user)
             return user
+
+    async def orgs(self, user_id: int) -> list[Org]:
+        """Retrieve organizations assigned to a user."""
+
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(
+                select(Org)
+                .join(OrgMember, Org.id == OrgMember.id_org)
+                .where(OrgMember.id_user == user_id)
+            )
+            return list(result.scalars().all())

--- a/api/src/routes/user.py
+++ b/api/src/routes/user.py
@@ -12,7 +12,7 @@ async def get_user_details(current_user: db.User = Depends(get_user)):
 
 @router.get('/user/orgs', response_model=list[OrgRead])
 async def get_user_orgs(current_user: db.User = Depends(get_user)):
-    orgs = await db.orgs.list_by_user(current_user.id)
+    orgs = await db.users.orgs(current_user.id)
     return [
         OrgRead(
             id=org.id,


### PR DESCRIPTION
### Motivation
- Centralize user-related membership queries in the user service to keep responsibility boundaries clearer.
- Remove redundant organization-scoped lookup from the orgs service so org-related service only manages org lifecycle and membership records.

### Description
- Removed `OrgsService.list_by_user` from `api/src/db/services/orgs.py` and adjusted imports accordingly.
- Added `UsersService.orgs` to `api/src/db/services/users.py` which returns a list of `Org` instances for a given `user_id` using a join on `OrgMember`.
- Updated the user route `GET /user/orgs` in `api/src/routes/user.py` to call `db.users.orgs(current_user.id)` instead of the removed `db.orgs.list_by_user`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984bb54f81c83239abe18c206bd071a)