### PR TITLE
Add API fetch utility to web lib

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -5,6 +5,11 @@ You are working on a vite tailwind shadcn project.
 - Use shadcn components for reusable UI elements.
 - Ensure consistency across the application.
 
+## API utilities
+
+- Use `src/lib/api.ts` for API calls; it centralizes the base URL, query params, JSON handling, and error handling.
+- Prefer `apiFetch` over direct `fetch` usage unless a specific edge case requires otherwise.
+
 ## Pre commit
 
 If there were any edits run:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,80 @@
+const defaultApiBaseUrl = 'http://localhost:8000';
+
+const apiBaseUrl =
+    import.meta.env.VITE_API_BASE_URL?.toString() ?? defaultApiBaseUrl;
+
+const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/, '');
+
+export const getApiBaseUrl = () => normalizeBaseUrl(apiBaseUrl);
+
+type QueryValue = string | number | boolean | null | undefined;
+export type ApiQueryParams = Record<string, QueryValue>;
+
+export type ApiRequestOptions<TBody = unknown> = Omit<RequestInit, 'body'> & {
+    body?: TBody;
+    query?: ApiQueryParams;
+};
+
+const buildApiUrl = (path: string, query?: ApiQueryParams) => {
+    const url = new URL(path, getApiBaseUrl());
+
+    if (query) {
+        Object.entries(query).forEach(([key, value]) => {
+            if (value === null || value === undefined) return;
+            url.searchParams.set(key, String(value));
+        });
+    }
+
+    return url.toString();
+};
+
+const isJsonBody = (body: unknown): body is Record<string, unknown> => {
+    if (body === null || body === undefined) return false;
+    if (typeof body === 'string') return false;
+    if (body instanceof FormData) return false;
+    if (body instanceof URLSearchParams) return false;
+    if (body instanceof Blob) return false;
+    if (body instanceof ArrayBuffer) return false;
+    return typeof body === 'object';
+};
+
+export async function apiFetch<TResponse>(
+    path: string,
+    options: ApiRequestOptions = {}
+): Promise<TResponse> {
+    const { query, headers, body, ...init } = options;
+    const requestHeaders = new Headers(headers);
+
+    if (!requestHeaders.has('Accept')) {
+        requestHeaders.set('Accept', 'application/json');
+    }
+
+    let requestBody: BodyInit | undefined = body as BodyInit | undefined;
+
+    if (isJsonBody(body)) {
+        requestHeaders.set('Content-Type', 'application/json');
+        requestBody = JSON.stringify(body);
+    }
+
+    const response = await fetch(buildApiUrl(path, query), {
+        ...init,
+        headers: requestHeaders,
+        body: requestBody,
+    });
+
+    if (!response.ok) {
+        const message = `API request failed (${response.status})`;
+        throw new Error(message);
+    }
+
+    if (response.status === 204) {
+        return undefined as TResponse;
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+        return (await response.json()) as TResponse;
+    }
+
+    return (await response.text()) as TResponse;
+}


### PR DESCRIPTION
### Motivation

- Provide a centralized, reusable API helper to simplify base URL normalization, query param encoding, JSON body handling and consistent error/response parsing across the web app. 
- Add a short note in the web agent instructions to encourage using the new helper rather than ad-hoc `fetch` calls.

### Description

- Add `web/src/lib/api.ts` which exports `getApiBaseUrl`, `apiFetch`, and related types (`ApiRequestOptions`, `ApiQueryParams`) and implements URL building, JSON detection, headers management and response parsing. 
- Update `web/AGENTS.md` to document using `src/lib/api.ts` and to prefer `apiFetch` for API calls.

### Testing

- Ran `bun run lint` which completed but reported a warning about React Compiler compatibility in `DataTable.tsx`. 
- Ran `bun run format` which completed successfully. 
- Ran `bun run build` which failed due to unrelated existing TypeScript/module errors (missing modules like `@/components/navigation` and `@/hooks/use-mobile` and other TS issues) rather than the new code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c2528b588323b53917e8d2f92ab0)