### PR TITLE
Add settings profile page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,11 +11,12 @@ import ViaVai from '@/pages/ViaVai';
 import Overview from '@/pages/Overview';
 import Workflows from '@/pages/Workflows';
 import Solutions from '@/pages/Solutions';
-
+import Setting from '@/pages/Setting';
 
 const router = createBrowserRouter([
     { path: '/', element: <Home /> },
     { path: '/login', element: <Login /> },
+    { path: '/setting', element: <Setting /> },
 
     {
         path: '/:org',
@@ -30,10 +31,10 @@ const router = createBrowserRouter([
             // dynamic modules
             {
                 path: 'apps/:app/*',
-                element: <ViaVai />
-            }
-        ]
-    }
+                element: <ViaVai />,
+            },
+        ],
+    },
 ]);
 
 export default function App() {

--- a/web/src/pages/Setting.tsx
+++ b/web/src/pages/Setting.tsx
@@ -1,0 +1,257 @@
+import {
+    Accessibility,
+    Bell,
+    Building2,
+    CreditCard,
+    Gavel,
+    Globe,
+    KeyRound,
+    Mail,
+    Palette,
+    Settings,
+    ShieldCheck,
+    User,
+    Users,
+} from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import { Textarea } from '@/components/ui/textarea';
+
+const mainItems = [
+    { label: 'Public profile', icon: User, active: true },
+    { label: 'Account', icon: Settings },
+    { label: 'Appearance', icon: Palette },
+    { label: 'Accessibility', icon: Accessibility },
+    { label: 'Notifications', icon: Bell },
+];
+
+const accessItems = [
+    { label: 'Billing and licensing', icon: CreditCard },
+    { label: 'Emails', icon: Mail },
+    { label: 'Password and authentication', icon: KeyRound },
+    { label: 'Sessions', icon: ShieldCheck },
+    { label: 'SSH and GPG keys', icon: KeyRound },
+    { label: 'Organizations', icon: Building2 },
+    { label: 'Enterprises', icon: Globe },
+    { label: 'Teams', icon: Users },
+    { label: 'Moderation', icon: Gavel },
+];
+
+export default function Setting() {
+    return (
+        <div className="min-h-screen bg-[#0b0e13] text-white">
+            <div className="mx-auto w-full max-w-6xl px-6 pb-16 pt-10">
+                <header className="flex flex-wrap items-start justify-between gap-6">
+                    <div className="flex items-center gap-4">
+                        <Avatar className="size-14 border border-white/10">
+                            <AvatarImage
+                                src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?auto=format&fit=crop&w=200&q=80"
+                                alt="Leonardo Saurwein profile"
+                            />
+                            <AvatarFallback>LS</AvatarFallback>
+                        </Avatar>
+                        <div>
+                            <div className="flex flex-wrap items-baseline gap-2">
+                                <h1 className="text-xl font-semibold">
+                                    Leonardo Saurwein
+                                </h1>
+                                <span className="text-sm text-white/50">
+                                    (Sau1707)
+                                </span>
+                            </div>
+                            <p className="text-sm text-white/60">
+                                Your personal account
+                            </p>
+                        </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3">
+                        <Button variant="outline" className="gap-2">
+                            Go to settings page
+                        </Button>
+                        <Button variant="secondary">
+                            Go to your personal profile
+                        </Button>
+                    </div>
+                </header>
+
+                <div className="mt-10 grid gap-8 lg:grid-cols-[240px_minmax(0,1fr)]">
+                    <aside className="space-y-6">
+                        <div className="space-y-2">
+                            {mainItems.map((item) => {
+                                const Icon = item.icon;
+                                return (
+                                    <button
+                                        key={item.label}
+                                        type="button"
+                                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${
+                                            item.active
+                                                ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(59,130,246,0.9)]'
+                                                : 'text-white/70 hover:bg-white/5 hover:text-white'
+                                        }`}
+                                    >
+                                        <Icon className="h-4 w-4 text-white/70" />
+                                        {item.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        <Separator className="bg-white/10" />
+                        <div className="space-y-3">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-white/40">
+                                Access
+                            </p>
+                            <div className="space-y-2">
+                                {accessItems.map((item) => {
+                                    const Icon = item.icon;
+                                    return (
+                                        <button
+                                            key={item.label}
+                                            type="button"
+                                            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium text-white/70 transition hover:bg-white/5 hover:text-white"
+                                        >
+                                            <Icon className="h-4 w-4 text-white/50" />
+                                            {item.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </aside>
+
+                    <section className="space-y-6">
+                        <div>
+                            <h2 className="text-2xl font-semibold">
+                                Public profile
+                            </h2>
+                            <p className="mt-1 text-sm text-white/50">
+                                Manage how you appear across the platform.
+                            </p>
+                        </div>
+                        <Separator className="bg-white/10" />
+
+                        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
+                            <div className="space-y-6">
+                                <div className="space-y-2">
+                                    <Label htmlFor="profile-name">Name</Label>
+                                    <Input
+                                        id="profile-name"
+                                        defaultValue="Leonardo Saurwein"
+                                        className="bg-white/5"
+                                    />
+                                    <p className="text-sm text-white/50">
+                                        Your name may appear around LongLink
+                                        where you contribute or are mentioned.
+                                    </p>
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="public-email">
+                                        Public email
+                                    </Label>
+                                    <Select defaultValue="private">
+                                        <SelectTrigger
+                                            id="public-email"
+                                            className="bg-white/5"
+                                        >
+                                            <SelectValue placeholder="Select a verified email to display" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="private">
+                                                Keep my email private
+                                            </SelectItem>
+                                            <SelectItem value="hello">
+                                                hello@longlink.app
+                                            </SelectItem>
+                                            <SelectItem value="work">
+                                                leonardo@longlink.app
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <p className="text-sm text-white/50">
+                                        You can update privacy in email settings
+                                        at any time.
+                                    </p>
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="bio">Bio</Label>
+                                    <Textarea
+                                        id="bio"
+                                        defaultValue="ETHZ - Mechanical engineering"
+                                        className="min-h-[120px] bg-white/5"
+                                    />
+                                    <p className="text-sm text-white/50">
+                                        Mention organizations and teammates with
+                                        @ to link them.
+                                    </p>
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="pronouns">Pronouns</Label>
+                                    <Select defaultValue="unspecified">
+                                        <SelectTrigger
+                                            id="pronouns"
+                                            className="bg-white/5"
+                                        >
+                                            <SelectValue placeholder="Select your pronouns" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="unspecified">
+                                                Don&apos;t specify
+                                            </SelectItem>
+                                            <SelectItem value="she">
+                                                She/Her
+                                            </SelectItem>
+                                            <SelectItem value="he">
+                                                He/Him
+                                            </SelectItem>
+                                            <SelectItem value="they">
+                                                They/Them
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="url">URL</Label>
+                                    <Input
+                                        id="url"
+                                        placeholder="https://your-site.com"
+                                        className="bg-white/5"
+                                    />
+                                </div>
+                            </div>
+
+                            <Card className="flex flex-col items-center gap-4 bg-white/5 p-6 text-center">
+                                <div className="text-sm font-semibold text-white">
+                                    Profile picture
+                                </div>
+                                <Avatar className="size-36 border border-white/10">
+                                    <AvatarImage
+                                        src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?auto=format&fit=crop&w=200&q=80"
+                                        alt="Profile"
+                                    />
+                                    <AvatarFallback>LS</AvatarFallback>
+                                </Avatar>
+                                <Button variant="outline" size="sm">
+                                    Edit
+                                </Button>
+                            </Card>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated `/setting` page that shows the user profile and profile-related controls mirroring the provided design and using the existing shadcn UI primitives. 
- Make the settings accessible via a top-level route so it can be previewed independently of organization-specific pages.

### Description
- Add `web/src/pages/Setting.tsx` which implements the Public profile layout with sidebar navigation, form fields, and profile avatar card using shadcn components (`Avatar`, `Button`, `Card`, `Input`, `Label`, `Select`, `Separator`, `Textarea`, and `lucide-react` icons). 
- Register a new route at `/setting` by importing and adding `Setting` to the router in `web/src/App.tsx`.
- Keep styling consistent with the app theme and existing component primitives so the page integrates with the current UI system.

### Testing
- Ran `bun run format` and formatting completed successfully. 
- Ran `bun run lint` and it completed with a warning about `react-hooks/incompatible-library` in `DataTable` (existing project warning). 
- Ran `bun run build` which failed due to pre-existing TypeScript errors in unrelated files (`DataTable`, `resizable`, `scroll-area`, `sidebar`, and `Test`), so the new page itself was not blocked by compilation errors but the workspace build did not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984dc6dbfa88323bd2aee99050abb0c)