### PR TITLE
Add OrgApp model and deploy/app helpers to OrgsService

### DIFF
--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,4 +1,4 @@
-from .models import App, Org, User
+from .models import App, Org, OrgApp, User
 from .services import AppsService, OrgsService, UsersService
 
 apps = AppsService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -2,5 +2,6 @@
 from .apps import App
 from .orgs import Org
 from .users import User
+from .orgs import OrgApp
 from .orgs import OrgMember
 from .__base__ import Base

--- a/api/src/db/models/orgs.py
+++ b/api/src/db/models/orgs.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from src.db.models.__base__ import Base
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import BigInteger, DateTime, ForeignKey, String, func
+from src.db.models.__base__ import Base
 
 
 class Org(Base):
@@ -27,5 +27,19 @@ class OrgMember(Base):
     role = mapped_column(String(50), nullable=False)
     
     # Date tracking
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+
+
+class OrgApp(Base):
+    """Represent an app deployed for an organization."""
+
+    __tablename__ = 'organizations_apps'
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
+    id_app: Mapped[int] = mapped_column(BigInteger, ForeignKey('apps.id'), nullable=False)
+
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default='true')
+
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
     

--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -1,5 +1,5 @@
 from sqlalchemy import select
-from src.db.models import Org, OrgMember
+from src.db.models import App, Org, OrgApp, OrgMember
 from src.db.session import get_session
 
 
@@ -37,3 +37,48 @@ class OrgsService:
         async with Session() as session:
             result = await session.execute(select(Org).where(Org.id == org_id))
             return result.scalars().first()
+
+    async def app(self, org_id: int, app_id: int) -> App | None:
+        """Retrieve an active app deployed in an organization."""
+
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(
+                select(App)
+                .join(OrgApp, OrgApp.id_app == App.id)
+                .where(
+                    OrgApp.id_org == org_id,
+                    OrgApp.id_app == app_id,
+                    OrgApp.active.is_(True),
+                )
+            )
+            return result.scalars().first()
+
+    async def deploy(self, org_id: int, app_id: int) -> OrgApp:
+        """Deploy an application to an organization."""
+
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(
+                select(OrgApp).where(
+                    OrgApp.id_org == org_id,
+                    OrgApp.id_app == app_id,
+                )
+            )
+            org_app = result.scalars().first()
+            if org_app:
+                if not org_app.active:
+                    org_app.active = True
+                    await session.commit()
+                    await session.refresh(org_app)
+                return org_app
+
+            org_app = OrgApp(
+                id_org=org_id,
+                id_app=app_id,
+                active=True,
+            )
+            session.add(org_app)
+            await session.commit()
+            await session.refresh(org_app)
+            return org_app


### PR DESCRIPTION
### Motivation

- Provide a way to track which applications are deployed to an organization and whether they are active.  
- Expose convenience helpers to fetch an active app and to (re)deploy an app for an organization so higher-level code can manage org-specific deployments.

### Description

- Add `OrgApp` model to `api/src/db/models/orgs.py` to represent rows in `organizations_apps` with fields `id_org`, `id_app`, `active`, and `date_creation`.  
- Register `OrgApp` in `api/src/db/models/__init__.py` and export it via `api/src/db/__init__.py` so it is available through the `src.db` package.  
- Add `OrgsService.app(org_id, app_id)` to return an active `App` deployed to an organization and `OrgsService.deploy(org_id, app_id)` to create or reactivate an `OrgApp` in `api/src/db/services/orgs.py`.

### Testing

- No automated tests were run for these changes.
- Code changes were committed successfully (no runtime tests performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e444448083239a487912fa1482b0)