### PR TITLE
Add router registration and update sample usage

### DIFF
--- a/sdk/viavai/__init__.py
+++ b/sdk/viavai/__init__.py
@@ -1,1 +1,2 @@
 from .app import ViaVai
+from .router import Router

--- a/sdk/viavai/router/__init__.py
+++ b/sdk/viavai/router/__init__.py
@@ -10,6 +10,9 @@ class Router:
     def __init__(self) -> None:
         self._routes: list[Route] = []
 
+    def register(self, router: "Router") -> None:
+        self._routes.extend(router._routes)
+
     def _route(self, method: str, path: str):
         def decorator(func: Handler) -> Handler:
             self._routes.append(Route(method.upper(), path, func))

--- a/sdk/viavai/sample/main.py
+++ b/sdk/viavai/sample/main.py
@@ -3,8 +3,6 @@
 
 
 from src.app import app
+from src.routes.sample import router as sample_router
 
-
-# Import to register the route
-import src.routes.sample  
-
+app.register(sample_router)

--- a/sdk/viavai/sample/src/routes/sample.py
+++ b/sdk/viavai/sample/src/routes/sample.py
@@ -1,8 +1,10 @@
+from viavai import Router
 from src.app import app
 from src.types import UserModel
 
+router = Router()
 
-@app.get("/sample",)
+@router.get("/sample")
 async def sample_get_endpoint():
     app.setting("sample_setting", "sample_value")
 
@@ -12,42 +14,42 @@ async def sample_get_endpoint():
     return "Sample GET endpoint received data"
 
 
-@app.post("/sample")
+@router.post("/sample")
 async def sample_post_endpoint():
     return "Sample POST endpoint response"
 
 
-@app.put("/sample")
+@router.put("/sample")
 async def sample_put_endpoint():
     return f"Sample PUT endpoint updated item"
 
 
-@app.delete("/sample")
+@router.delete("/sample")
 async def sample_delete_endpoint():
     return f"Sample DELETE endpoint deleted item"
 
 
 
-@app.patch("/sample")
+@router.patch("/sample")
 async def sample_patch_endpoint():
     return f"Sample PATCH endpoint patched item"
 
 
 # Example with dynamic URL parameter
-@app.post("/dynamic/{object}")
+@router.post("/dynamic/{object}")
 async def sample_post_endpoint_with_object(object: int):
     return "Sample POST endpoint response"
 
 
 # Example with params
 # Params must have a default value
-@app.post("/params/{object}?{start}&{end}")
+@router.post("/params/{object}?{start}&{end}")
 async def sample_post_endpoint_with_params(object: int, start: int = 0, end: int = 10):
     return "Sample POST endpoint response"
 
 
 # Example that return a Pydantic model
-@app.post("/sample/user")
+@router.post("/sample/user")
 async def sample_post_user_endpoint() -> UserModel:
     return UserModel(
         id=1,
@@ -64,6 +66,6 @@ async def sample_post_user_endpoint() -> UserModel:
 
 # Example with params
 # Params must have a default value
-@app.get("/params/{object}?{start}&{end}")
+@router.get("/params/{object}?{start}&{end}")
 async def sample_get_endpoint_with_params(object: int, start: int = 0, end: int = 10):
     return "Sample GET endpoint response"


### PR DESCRIPTION
### Motivation

- Provide a simple way to compose and reuse route collections by allowing one `Router` to register another router's routes into an app.
- Update the sample scaffold to demonstrate per-module routers and how to register them from the application entrypoint.

### Description

- Add `Router.register(router: "Router")` which extends the target router's `_routes` list with another router's routes in `sdk/viavai/router/__init__.py`.
- Export `Router` from the SDK package by adding it to `sdk/viavai/__init__.py`.
- Change the sample routes module `sdk/viavai/sample/src/routes/sample.py` to create `router = Router()` and use `@router.get/post/...` decorators instead of decorating the global app directly.
- Update the sample entrypoint `sdk/viavai/sample/main.py` to import `sample_router` and call `app.register(sample_router)` to attach the routes.

### Testing

- No automated tests were run for this change.
- Changes were validated via static inspection and local edits to the sample files and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e4c611008323a85bd504c5dcad00)