### PR TITLE
Add OrgRole enum and enforce organization member roles

### DIFF
--- a/api/src/db/README.md
+++ b/api/src/db/README.md
@@ -21,7 +21,7 @@ Import the database layer once and use the service instances:
 import src.db as db
 
 org = await db.orgs.create('Acme')
-await db.orgs.add(org.id, user.id, 'owner')
+await db.orgs.add(org.id, user.id, db.OrgRole.owner)
 app = await db.apps.create(org.id, 'Acme')
 ```
 

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,4 +1,4 @@
-from .models import App, Org, OrgApp, User
+from .models import App, Org, OrgApp, OrgRole, User
 from .services import AppsService, OrgsService, UsersService
 
 apps = AppsService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -3,5 +3,6 @@ from .apps import App
 from .orgs import Org
 from .users import User
 from .orgs import OrgApp
+from .orgs import OrgRole
 from .orgs import OrgMember
 from .__base__ import Base

--- a/api/src/db/models/orgs.py
+++ b/api/src/db/models/orgs.py
@@ -1,7 +1,14 @@
+from enum import Enum
 from datetime import datetime
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, String, func
-from sqlalchemy.orm import Mapped, mapped_column
 from src.db.models.__base__ import Base
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum as SqlEnum, ForeignKey, String, func
+
+
+class OrgRole(str, Enum):
+    owner = 'owner'
+    admin = 'admin'
+    member = 'member'
 
 
 class Org(Base):
@@ -24,7 +31,7 @@ class OrgMember(Base):
     id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
     id_user: Mapped[int] = mapped_column(BigInteger, ForeignKey('users.id'), nullable=False)
     
-    role = mapped_column(String(50), nullable=False)
+    role: Mapped[OrgRole] = mapped_column(SqlEnum(OrgRole, name='org_role'), nullable=False)
     
     # Date tracking
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -1,6 +1,6 @@
 from sqlalchemy import select
-from src.db.models import App, Org, OrgApp, OrgMember
 from src.db.session import get_session
+from src.db.models import App, Org, OrgApp, OrgMember, OrgRole
 
 
 class OrgsService:
@@ -15,7 +15,7 @@ class OrgsService:
             await session.refresh(org)
             return org
 
-    async def add(self, org_id: int, user_id: int, role: str) -> OrgMember:
+    async def add(self, org_id: int, user_id: int, role: OrgRole) -> OrgMember:
         """Add a new member to an organization."""
 
         Session = await get_session()

--- a/api/src/routes/org.py
+++ b/api/src/routes/org.py
@@ -8,7 +8,7 @@ from fastapi import Depends, HTTPException
 @router.post('/org', response_model=OrgRead)
 async def create_org(payload: OrgCreate, current_user: db.User = Depends(get_user)):
     org = await db.orgs.create(payload.name)
-    await db.orgs.add(org.id, current_user.id, 'owner')
+    await db.orgs.add(org.id, current_user.id, db.OrgRole.owner)
     await db.apps.create(org.id, payload.name)
     return OrgRead(
         id=org.id,


### PR DESCRIPTION
### Motivation
- Provide a constrained set of allowed organization membership roles (`owner`, `admin`, `member`) to avoid free-form strings in the database.
- Ensure type-safety across the DB model and service layer when creating or seeding organization members.

### Description
- Introduce `OrgRole` enum in `api/src/db/models/orgs.py` and use a SQLAlchemy `Enum` column for the `role` field on `OrgMember` (type `OrgRole`).
- Update `OrgsService.add` signature to accept `role: OrgRole` and pass the enum value into the `OrgMember` record in `api/src/db/services/orgs.py`.
- Use the enum when seeding the owner in the org creation route by changing the call to `await db.orgs.add(..., db.OrgRole.owner)` in `api/src/routes/org.py`.
- Export `OrgRole` via `api/src/db/models/__init__.py` and `api/src/db/__init__.py`, and document the enum usage in `api/src/db/README.md`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e9aea8248323afdd0e8a9af1d116)