### PR TITLE
Rename Settings page to Profile and update user menu links

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@ import Layout from '@/Layout';
 // Import pages
 import Home from '@/pages/Home';
 import Login from '@/pages/Login';
-import Settings from '@/pages/Settings';
+import Profile from '@/pages/Profile';
 import Developer from '@/pages/Developer';
 import Organizations from '@/pages/Organizations';
 
@@ -17,14 +17,13 @@ import Overview from '@/pages/Overview';
 import Workflows from '@/pages/Workflows';
 import Solutions from '@/pages/Solutions';
 
-
 const router = createBrowserRouter([
     { path: '/', element: <Home /> },
     { path: '/login', element: <Login /> },
     {
-        path: '/settings',
+        path: '/profile',
         element: <Layout />,
-        children: [{ index: true, element: <Settings /> }],
+        children: [{ index: true, element: <Profile /> }],
     },
     {
         path: '/organizations',

--- a/web/src/components/user-profile.tsx
+++ b/web/src/components/user-profile.tsx
@@ -65,17 +65,7 @@ export function UserProfile({
                     className="cursor-pointer transition-colors hover:bg-white/10 p-2"
                     onSelect={(event) => {
                         event.preventDefault();
-                        navigate('/settings/profile');
-                    }}
-                >
-                    <User className="mr-2 h-4 w-4 text-white/70" />
-                    Profile
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                    className="cursor-pointer transition-colors hover:bg-white/10 p-2"
-                    onSelect={(event) => {
-                        event.preventDefault();
-                        navigate('/settings/organizations');
+                        navigate('/organizations');
                     }}
                 >
                     <Building2 className="mr-2 h-4 w-4 text-white/70" />
@@ -85,7 +75,17 @@ export function UserProfile({
                     className="cursor-pointer transition-colors hover:bg-white/10 p-2"
                     onSelect={(event) => {
                         event.preventDefault();
-                        navigate('/settings/developer');
+                        navigate('/profile');
+                    }}
+                >
+                    <User className="mr-2 h-4 w-4 text-white/70" />
+                    Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    className="cursor-pointer transition-colors hover:bg-white/10 p-2"
+                    onSelect={(event) => {
+                        event.preventDefault();
+                        navigate('/developer');
                     }}
                 >
                     <Code2 className="mr-2 h-4 w-4 text-white/70" />

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -48,7 +48,7 @@ const accessItems = [
     { label: 'Moderation', icon: Gavel },
 ];
 
-export default function Settings() {
+export default function Profile() {
     return (
         <div className="grid gap-8 lg:grid-cols-[240px_minmax(0,1fr)]">
             <aside className="space-y-6">
@@ -59,10 +59,11 @@ export default function Settings() {
                             <button
                                 key={item.label}
                                 type="button"
-                                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${item.active
-                                    ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(59,130,246,0.9)]'
-                                    : 'text-white/70 hover:bg-white/5 hover:text-white'
-                                    }`}
+                                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${
+                                    item.active
+                                        ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(59,130,246,0.9)]'
+                                        : 'text-white/70 hover:bg-white/5 hover:text-white'
+                                }`}
                             >
                                 <Icon className="h-4 w-4 text-white/70" />
                                 {item.label}


### PR DESCRIPTION
### Motivation
- Standardize the profile route to `/profile` instead of `/settings` and ensure the user menu links navigate to the intended pages in the requested order (Organizations, Profile, Developer). 
- Update the component name to reflect the new route and improve clarity in the codebase.

### Description
- Renamed `web/src/pages/Settings.tsx` to `web/src/pages/Profile.tsx` and changed the default export from `Settings` to `Profile` so the component matches the new route. 
- Updated the router in `web/src/App.tsx` to import `Profile` and mount it at the `'/profile'` path instead of `'/settings'`. 
- Modified `web/src/components/user-profile.tsx` to reorder the dropdown entries and point them to `/organizations`, `/profile`, and `/developer` respectively, and adjusted the associated icons. 
- Applied formatting tweaks to keep template string formatting consistent after the rename. 

### Testing
- Ran `bun run lint`, which completed with a non-blocking warning about `react-hooks/incompatible-library` in `DataTable.tsx`. 
- Ran `bun run format`, which completed successfully and updated formatted files. 
- Attempted `bun run build`, which failed with TypeScript errors including missing module/type declarations in `Test.tsx`, resizable panels typings issues, an unused `React` import warning, and missing hooks/components references. 
- Started the dev server with `bun run dev` and executed an automated Playwright check that opened `http://127.0.0.1:4173/organizations` and captured a screenshot of the updated user profile dropdown menu.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984edfbcac88323a4c3f8794f72636b)