### PR TITLE
Include country code in organization routes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,7 +37,7 @@ const router = createBrowserRouter([
         children: [{ index: true, element: <Developer /> }],
     },
     {
-        path: '/:org',
+        path: '/:country/:org',
         element: <Layout />,
         children: [
             { index: true, element: <Overview /> },

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -122,7 +122,7 @@ const appTabsByName: Record<string, NavigationTab[]> = {
 };
 
 export default function Layout() {
-    const { app, org } = useParams();
+    const { app, country, org } = useParams();
     const appTabs = app ? (appTabsByName[app] ?? defaultAppTabs) : null;
     const tabs = org ? (appTabs ?? organizationTabs) : accountTabs;
 
@@ -135,7 +135,7 @@ export default function Layout() {
 }
 
 export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
-    const { org = '', app } = useParams();
+    const { country = '', org = '', app } = useParams();
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -144,8 +144,8 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
     const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
     const basePath = org
         ? normalizedSuffix
-            ? `/${org}/${normalizedSuffix}`
-            : `/${org}`
+            ? `/${country}/${org}/${normalizedSuffix}`
+            : `/${country}/${org}`
         : '';
 
     const activeTab = (() => {
@@ -183,7 +183,7 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                             render={(props) => (
                                                 <Link
                                                     {...props}
-                                                    to={org ? `/${org}` : '/'}
+                                                    to={org ? `/${country}/${org}` : '/'}
                                                     className="text-sm font-semibold text-white/70"
                                                 >
                                                     {organizationName}
@@ -199,7 +199,7 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                                     render={(props) => (
                                                         <Link
                                                             {...props}
-                                                            to={`/${org}/apps/${app}`}
+                                                            to={`/${country}/${org}/apps/${app}`}
                                                             className="text-sm font-semibold text-white/70"
                                                         >
                                                             {appName}


### PR DESCRIPTION
### Motivation
- Make organization URLs country-aware to match the platform convention of `/ <iso_country_code> / <org_name>` and allow per-country organization scoping.

### Description
- Change the route in `web/src/App.tsx` from `/:org` to `/:country/:org` so organization pages include the country segment.
- Read `country` from `useParams` in `web/src/Layout.tsx` and propagate it into navigation logic and `basePath` computation.
- Update breadcrumb and app links in `web/src/Layout.tsx` to build targets like `/:country/:org` and `/:country/:org/apps/:app` so tab navigation and app routes resolve correctly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ee92439c8323a4696e7fd1426b03)