### PR TITLE
Add country field to Org model and API types

### DIFF
--- a/api/src/db/models/orgs.py
+++ b/api/src/db/models/orgs.py
@@ -17,6 +17,7 @@ class Org(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    country: Mapped[str | None] = mapped_column(String(2), nullable=True)
     
     # Date tracking
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -4,12 +4,12 @@ from src.db.models import App, Org, OrgApp, OrgMember, OrgRole
 
 
 class OrgsService:
-    async def create(self, name: str) -> Org:
+    async def create(self, name: str, country: str | None = None) -> Org:
         """Add a new organization to the database."""
 
         Session = await get_session()
         async with Session() as session:
-            org = Org(name=name)
+            org = Org(name=name, country=country)
             session.add(org)
             await session.commit()
             await session.refresh(org)

--- a/api/src/routes/org.py
+++ b/api/src/routes/org.py
@@ -7,12 +7,13 @@ from src.types import OrgCreate, OrgRead
 
 @router.post('/org', response_model=OrgRead)
 async def create_org(payload: OrgCreate, current_user: db.User = Depends(get_user)):
-    org = await db.orgs.create(payload.name)
+    org = await db.orgs.create(payload.name, payload.country)
     await db.orgs.add(org.id, current_user.id, db.OrgRole.owner)
     await db.apps.create(org.id, payload.name)
     return OrgRead(
         id=org.id,
         name=org.name,
+        country=org.country,
         date_creation=org.date_creation,
     )
 
@@ -25,5 +26,6 @@ async def get_org(org_id: int, current_user: db.User = Depends(get_user)):
     return OrgRead(
         id=org.id,
         name=org.name,
+        country=org.country,
         date_creation=org.date_creation,
     )

--- a/api/src/routes/user.py
+++ b/api/src/routes/user.py
@@ -14,6 +14,6 @@ async def get_user_details(current_user: db.User = Depends(user)):
 async def get_user_orgs(current_user: db.User = Depends(user)):
     orgs = await db.users.orgs(current_user.id)
     return [ 
-        OrgRead(id=org.id, name=org.name, date_creation=org.date_creation)
+        OrgRead(id=org.id, name=org.name, country=org.country, date_creation=org.date_creation)
         for org in orgs
     ]

--- a/api/src/types/orgs.py
+++ b/api/src/types/orgs.py
@@ -4,9 +4,11 @@ from pydantic import BaseModel
 
 class OrgCreate(BaseModel):
     name: str
+    country: str | None = None
 
 
 class OrgRead(BaseModel):
     id: int
     name: str
+    country: str | None
     date_creation: datetime


### PR DESCRIPTION
### Motivation
- Expose an optional organization country code (ISO 2-letter) in the backend so clients can provide and read an org's country via the API.

### Description
- Add `country: Mapped[str | None]` to the `Org` model in `api/src/db/models/orgs.py`, accept `country` in `OrgsService.create` and persist it, add `country` to the Pydantic types in `api/src/types/orgs.py`, and include `country` in responses produced by `api/src/routes/org.py` and `api/src/routes/user.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f3f5c4888323be034f936cfefd91)