### PR TITLE
Add empty state layout for People page

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -122,7 +122,7 @@ const appTabsByName: Record<string, NavigationTab[]> = {
 };
 
 export default function Layout() {
-    const { app, country, org } = useParams();
+    const { app, org } = useParams();
     const appTabs = app ? (appTabsByName[app] ?? defaultAppTabs) : null;
     const tabs = org ? (appTabs ?? organizationTabs) : accountTabs;
 
@@ -183,7 +183,11 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                             render={(props) => (
                                                 <Link
                                                     {...props}
-                                                    to={org ? `/${country}/${org}` : '/'}
+                                                    to={
+                                                        org
+                                                            ? `/${country}/${org}`
+                                                            : '/'
+                                                    }
                                                     className="text-sm font-semibold text-white/70"
                                                 >
                                                     {organizationName}

--- a/web/src/pages/People.tsx
+++ b/web/src/pages/People.tsx
@@ -1,3 +1,54 @@
+import { Plus, Users } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@/components/ui/empty';
+
 export default function People() {
-    return <h1>People Page</h1>;
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-300 ring-1 ring-emerald-500/30">
+                        <Users className="h-5 w-5" />
+                    </div>
+                    <div>
+                        <h1 className="text-lg font-semibold text-white">
+                            People
+                        </h1>
+                        <p className="text-sm text-white/60">0 people</p>
+                    </div>
+                </div>
+                <Button variant="outline">
+                    <Plus className="h-4 w-4" />
+                    Add Person
+                </Button>
+            </div>
+
+            <Card className="p-10 text-center">
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <Users />
+                        </EmptyMedia>
+                        <EmptyTitle>No People Yet</EmptyTitle>
+                        <EmptyDescription>
+                            Invite teammates and collaborators to start working
+                            together.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                    <EmptyContent className="flex-row justify-center gap-2">
+                        <Button>Invite Person</Button>
+                        <Button variant="outline">Import Directory</Button>
+                    </EmptyContent>
+                </Empty>
+            </Card>
+        </div>
+    );
 }


### PR DESCRIPTION
### Motivation
- Provide a blank/empty-state UI for the People tab matching the existing Workflows style so organizations have a consistent entry point before people are added.
- Fix a lint complaint by removing an unused param in `Layout`.

### Description
- Implemented a full empty-state People page in `web/src/pages/People.tsx` using shared UI components (`Card`, `Button`, `Empty`, and icons) and added header, count, and action buttons.
- Removed the unused `country` variable from the `Layout` component destructuring to address a lint error in `web/src/Layout.tsx`.
- Kept styling and structure consistent with the Workflows page for a unified UX.

### Testing
- Ran `bun run lint` which completes successfully but emits an existing `react-hooks/incompatible-library` warning for `useReactTable()`.
- Ran `bun run format` (Prettier) which completed successfully and reformatted sources as needed.
- Attempted `bun run build` which failed due to unrelated existing type errors and missing module resolutions in other files (these are pre-existing in the repo and not introduced by this change).
- Started the dev server with `bun run dev` and captured a screenshot of the People page to verify the empty-state UI rendered as expected (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c898afe483239f216b9172708acf)