### PR TITLE
Replace tools list with empty-state placeholder

### DIFF
--- a/web/src/pages/Tools.tsx
+++ b/web/src/pages/Tools.tsx
@@ -1,6 +1,14 @@
 import { Plus, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { ModuleCard } from '@/components/module';
+import { Card } from '@/components/ui/card';
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@/components/ui/empty';
 
 export default function Tools() {
     return (
@@ -14,27 +22,33 @@ export default function Tools() {
                         <h1 className="text-lg font-semibold text-white">
                             Tools
                         </h1>
-                        <p className="text-sm text-white/60">2 tools</p>
+                        <p className="text-sm text-white/60">0 tools</p>
                     </div>
                 </div>
                 <Button variant="outline">
                     <Plus className="h-4 w-4" />
-                    New Tools
+                    New Tool
                 </Button>
             </div>
 
-            <div className="grid grid-cols-4 gap-4">
-                <ModuleCard
-                    name="Accounting"
-                    description="Streamline financial operations, manage invoices, and track business expenses in real-time."
-                    href="/tools/accounting"
-                />
-                <ModuleCard
-                    name="Workforce"
-                    description="Optimize team management, monitor productivity, and coordinate resource allocation."
-                    href="/tools/workforce"
-                />
-            </div>
+            <Card className="p-10 text-center">
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <Sparkles />
+                        </EmptyMedia>
+                        <EmptyTitle>No Tools Yet</EmptyTitle>
+                        <EmptyDescription>
+                            You haven&apos;t added any tools yet. Get started by
+                            creating your first tool.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                    <EmptyContent className="flex-row justify-center gap-2">
+                        <Button>Create Tool</Button>
+                        <Button variant="outline">Import Tool</Button>
+                    </EmptyContent>
+                </Empty>
+            </Card>
         </div>
     );
 }


### PR DESCRIPTION
### Motivation
- The Tools page should show the same empty-state placeholder used across the app when there are no tools installed, instead of listing sample modules.

### Description
- Replace the hard-coded `ModuleCard` grid with the shared empty-state `Card` + `Empty` UI to match the Workflows page placeholder in `web/src/pages/Tools.tsx`.
- Update the header count from `2 tools` to `0 tools` and change the action label from `New Tools` to `New Tool`.
- Add imports for `Card` and the `Empty` components and remove the usage of `ModuleCard` on the Tools page.

### Testing
- Ran `bun run lint`, which reported a pre-existing error for an unused variable in `src/Layout.tsx` and a warning in `src/components/DataTable.tsx` so lint did not pass.
- Ran `bun run format`, which completed successfully and formatted files.
- Ran `bun run build`, which failed due to pre-existing TypeScript errors (including the unused variable in `src/Layout.tsx`).
- Started the dev server with `vite` and performed a visual smoke test using Playwright that successfully captured `artifacts/tools-empty.png` showing the new empty state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c87d6b948323842c1fb18a2499ee)