### PR TITLE
Link profile dropdown items to routes

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -183,7 +183,11 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                             render={(props) => (
                                                 <Link
                                                     {...props}
-                                                    to={org ? `/${country}/${org}` : '/'}
+                                                    to={
+                                                        org
+                                                            ? `/${country}/${org}`
+                                                            : '/'
+                                                    }
                                                     className="text-sm font-semibold text-white/70"
                                                 >
                                                     {organizationName}

--- a/web/src/components/user-profile.tsx
+++ b/web/src/components/user-profile.tsx
@@ -1,5 +1,5 @@
 import { Building2, Code2, LogOut, User } from 'lucide-react';
-import { useNavigate } from 'react-router';
+import { Link } from 'react-router';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -28,8 +28,6 @@ export function UserProfile({
     fullName = defaultUser.fullName,
     avatarUrl = defaultUser.avatarUrl,
 }: UserProfileProps) {
-    const navigate = useNavigate();
-
     return (
         <DropdownMenu>
             <DropdownMenuTrigger className="group flex cursor-pointer items-center gap-2 rounded-full border border-white/10 bg-white/5 transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30">
@@ -61,40 +59,33 @@ export function UserProfile({
                     </DropdownMenuLabel>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator className="my-2" />
-                <DropdownMenuItem
-                    className="cursor-pointer transition-colors hover:bg-white/10 p-2"
-                    onSelect={(event) => {
-                        event.preventDefault();
-                        navigate('/organizations');
-                    }}
-                >
-                    <Building2 className="mr-2 h-4 w-4 text-white/70" />
-                    Organizations
+                <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                    <Link
+                        to="/organizations"
+                        className="flex w-full items-center"
+                    >
+                        <Building2 className="mr-2 h-4 w-4 text-white/70" />
+                        Organizations
+                    </Link>
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                    className="cursor-pointer transition-colors hover:bg-white/10 p-2"
-                    onSelect={(event) => {
-                        event.preventDefault();
-                        navigate('/profile');
-                    }}
-                >
-                    <User className="mr-2 h-4 w-4 text-white/70" />
-                    Profile
+                <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                    <Link to="/profile" className="flex w-full items-center">
+                        <User className="mr-2 h-4 w-4 text-white/70" />
+                        Profile
+                    </Link>
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                    className="cursor-pointer transition-colors hover:bg-white/10 p-2"
-                    onSelect={(event) => {
-                        event.preventDefault();
-                        navigate('/developer');
-                    }}
-                >
-                    <Code2 className="mr-2 h-4 w-4 text-white/70" />
-                    Developer
+                <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                    <Link to="/developer" className="flex w-full items-center">
+                        <Code2 className="mr-2 h-4 w-4 text-white/70" />
+                        Developer
+                    </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator className="my-2" />
                 <DropdownMenuItem className="text-red-300 focus:text-red-200 cursor-pointer transition-colors hover:bg-white/10 p-2">
-                    <LogOut className="mr-2 h-4 w-4" />
-                    Sign out
+                    <Link to="/login" className="flex w-full items-center">
+                        <LogOut className="mr-2 h-4 w-4" />
+                        Sign out
+                    </Link>
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
### Motivation

- Make user profile menu entries navigate using standard route links so users can open/copy routes and preserve expected anchor behavior.
- Replace menu-item programmatic navigation with declarative `Link` usage to simplify the menu and avoid custom `onSelect` handlers.
- Small formatting adjustment to the organization breadcrumb `to` expression for readability.

### Description

- Replaced `useNavigate`-based `onSelect` handlers with `Link` children inside `DropdownMenuItem` in `web/src/components/user-profile.tsx`, and removed the unused `navigate` variable. 
- Wired the sign-out entry to `/login` using a `Link` so it behaves like the other menu links. 
- Adjusted the breadcrumb `to` expression wrapping in `web/src/Layout.tsx` to keep the conditional on multiple lines for clarity. 
- Modified files: `web/src/components/user-profile.tsx`, `web/src/Layout.tsx`.

### Testing

- Ran `bun run lint`, which failed due to an existing unused variable in `Layout.tsx` and a `react-hooks/incompatible-library` warning unrelated to the menu changes. 
- Ran `bun run format`, which completed successfully. 
- Ran `bun run build`, which failed due to existing TypeScript errors in other components (`Layout.tsx`, `Test.tsx`, `resizable`, `scroll-area`, `sidebar`, `Organization.tsx`) not introduced by this change. 
- Started the dev server with `bun run dev` and captured a Playwright screenshot of the opened profile dropdown at `artifacts/user-profile-links.png` to verify link rendering in the running app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c844d0888323b238bc5d45ac1a7a)