### PR TITLE
Rename account 'Settings' to 'Profile' and add Organizations empty-state template

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -8,6 +8,7 @@ import {
     LayoutGrid,
     Settings,
     Sparkles,
+    User,
     Users,
     Wrench,
 } from 'lucide-react';
@@ -60,13 +61,13 @@ const defaultAppTabs: NavigationTab[] = [
 ];
 
 const accountTabs: NavigationTab[] = [
-    { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
     {
         value: 'organizations',
         label: 'Organizations',
         path: 'organizations',
         icon: Users,
     },
+    { value: 'profile', label: 'Profile', path: 'profile', icon: User },
     { value: 'developer', label: 'Developer', path: 'developer', icon: Wrench },
 ];
 

--- a/web/src/pages/Organizations.tsx
+++ b/web/src/pages/Organizations.tsx
@@ -1,19 +1,54 @@
+import { Building2, Plus } from 'lucide-react';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@/components/ui/empty';
 
 export default function Organizations() {
     return (
-        <Card className="space-y-3 bg-white/5 p-6">
-            <div>
-                <h2 className="text-xl font-semibold text-white">
-                    Organizations
-                </h2>
-                <p className="text-sm text-white/60">
-                    Manage the organizations connected to your account.
-                </p>
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
+                        <Building2 className="h-5 w-5" />
+                    </div>
+                    <div>
+                        <h2 className="text-lg font-semibold text-white">
+                            Organizations
+                        </h2>
+                        <p className="text-sm text-white/60">0 organizations</p>
+                    </div>
+                </div>
+                <Button variant="outline">
+                    <Plus className="h-4 w-4" />
+                    New Organization
+                </Button>
             </div>
-            <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
-                Organization management tools will appear here.
-            </div>
-        </Card>
+
+            <Card className="p-10 text-center">
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <Building2 />
+                        </EmptyMedia>
+                        <EmptyTitle>No Organizations Yet</EmptyTitle>
+                        <EmptyDescription>
+                            Create or join an organization to start managing
+                            your workspaces and projects.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                    <EmptyContent className="flex-row justify-center gap-2">
+                        <Button>Create Organization</Button>
+                        <Button variant="outline">Join Organization</Button>
+                    </EmptyContent>
+                </Empty>
+            </Card>
+        </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Align account navigation with the intended order and labels by replacing the generic `Settings` tab with `Profile` and ordering account tabs as `Organizations`, `Profile`, `Developer`.
- Provide a clear initial UX for the Organizations page by adding a blank/empty-state template that matches the `Workflows` layout and encourages creating or joining an organization.

### Description
- Updated `web/src/Layout.tsx` to remove the `Settings` account tab, add a `Profile` tab with the `User` icon, and reorder account tabs to `Organizations`, `Profile`, `Developer`.
- Reworked `web/src/pages/Organizations.tsx` to a workflows-style empty state using the `Empty` component with header, description, and action buttons (`Create Organization`, `Join Organization`) and added header stats and a `New Organization` action.
- Added necessary imports for icons and UI components in the modified files and kept app-specific tabs unchanged.

### Testing
- Ran `bun run lint`, which completed but reported a warning about `react-hooks/incompatible-library` in an existing `DataTable` usage.
- Ran `bun run format`, which succeeded and formatted the repository files.
- Attempted `bun run build`, which failed due to unrelated project type/module issues (missing imports/types in other components) and not due to these changes.
- Started the dev server (`bun run dev`) and captured an automated screenshot of the updated Organizations page (dev server responded and screenshot was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f1e78a608323befc9e5a49a978e5)