### PR TITLE
Add Privacy, Terms (Tos) and Impressum pages; update footer links and year

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,9 @@ import Login from '@/pages/Login';
 import Profile from '@/pages/Profile';
 import Developer from '@/pages/Developer';
 import Organizations from '@/pages/Organizations';
+import Privacy from '@/pages/Privacy';
+import Tos from '@/pages/Tos';
+import Impressum from '@/pages/Impressum';
 
 // Organization related pages
 import Tools from '@/pages/Tools';
@@ -20,6 +23,9 @@ import Solutions from '@/pages/Solutions';
 const router = createBrowserRouter([
     { path: '/', element: <Home /> },
     { path: '/login', element: <Login /> },
+    { path: '/privacy', element: <Privacy /> },
+    { path: '/terms', element: <Tos /> },
+    { path: '/impressum', element: <Impressum /> },
     {
         path: '/profile',
         element: <Layout />,

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -10,7 +10,7 @@ import {
     Users,
     Zap,
 } from 'lucide-react';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -284,12 +284,18 @@ export default function Home() {
                 <footer className="border-t border-white/10">
                     <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-6 py-6 text-xs text-white/60 md:flex-row">
                         <div className="flex items-center gap-2">
-                            © 2024 LongLink SAGL. All rights reserved.
+                            © 2026 LongLink SAGL. All rights reserved.
                         </div>
                         <div className="flex gap-6">
-                            <span>Privacy</span>
-                            <span>Terms</span>
-                            <span>Documentation</span>
+                            <Link to="/privacy" className="hover:text-white">
+                                Privacy
+                            </Link>
+                            <Link to="/terms" className="hover:text-white">
+                                Terms
+                            </Link>
+                            <Link to="/impressum" className="hover:text-white">
+                                Impressum
+                            </Link>
                         </div>
                     </div>
                 </footer>

--- a/web/src/pages/Impressum.tsx
+++ b/web/src/pages/Impressum.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router';
+
+import { Card, CardContent } from '@/components/ui/card';
+
+export default function Impressum() {
+    return (
+        <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
+            <Card className="w-full max-w-2xl border-white/10 bg-white/5">
+                <CardContent className="space-y-6 p-8">
+                    <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.2em] text-white/60">
+                            Impressum
+                        </p>
+                        <h1 className="text-3xl font-semibold">
+                            Company information
+                        </h1>
+                        <p className="text-sm text-white/70">
+                            LongLink SAGL is registered in Switzerland and
+                            operates the ViaVai platform. This page provides the
+                            required company details and contact information.
+                        </p>
+                    </div>
+                    <div className="space-y-2 text-sm text-white/70">
+                        <p>LongLink SAGL</p>
+                        <p>Via Industria 21, 6900 Lugano, Switzerland</p>
+                        <p>
+                            Email:{' '}
+                            <span className="text-white">
+                                info@longlink.com
+                            </span>
+                        </p>
+                    </div>
+                    <Link
+                        to="/"
+                        className="text-sm text-blue-300 hover:underline"
+                    >
+                        Back to home
+                    </Link>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/web/src/pages/Privacy.tsx
+++ b/web/src/pages/Privacy.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router';
+
+import { Card, CardContent } from '@/components/ui/card';
+
+export default function Privacy() {
+    return (
+        <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
+            <Card className="w-full max-w-2xl border-white/10 bg-white/5">
+                <CardContent className="space-y-6 p-8">
+                    <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.2em] text-white/60">
+                            Privacy
+                        </p>
+                        <h1 className="text-3xl font-semibold">
+                            Privacy policy
+                        </h1>
+                        <p className="text-sm text-white/70">
+                            LongLink SAGL protects your personal data and keeps
+                            it secure. This page outlines how we handle account
+                            details, usage analytics, and security logs for the
+                            ViaVai platform.
+                        </p>
+                    </div>
+                    <div className="space-y-3 text-sm text-white/70">
+                        <p>
+                            We only collect information needed to operate the
+                            platform, provide support, and improve product
+                            performance. We never sell personal data.
+                        </p>
+                        <p>
+                            For any questions or requests, contact us at{' '}
+                            <span className="text-white">
+                                privacy@longlink.com
+                            </span>
+                            .
+                        </p>
+                    </div>
+                    <Link
+                        to="/"
+                        className="text-sm text-blue-300 hover:underline"
+                    >
+                        Back to home
+                    </Link>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/web/src/pages/Tos.tsx
+++ b/web/src/pages/Tos.tsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router';
+
+import { Card, CardContent } from '@/components/ui/card';
+
+export default function Tos() {
+    return (
+        <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
+            <Card className="w-full max-w-2xl border-white/10 bg-white/5">
+                <CardContent className="space-y-6 p-8">
+                    <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.2em] text-white/60">
+                            Terms &amp; Conditions
+                        </p>
+                        <h1 className="text-3xl font-semibold">
+                            Terms of service
+                        </h1>
+                        <p className="text-sm text-white/70">
+                            These terms govern your use of LongLink and ViaVai.
+                            By accessing the platform, you agree to comply with
+                            organization policies, app licensing, and data
+                            governance requirements.
+                        </p>
+                    </div>
+                    <div className="space-y-3 text-sm text-white/70">
+                        <p>
+                            You are responsible for maintaining the
+                            confidentiality of your account and for all
+                            activities that occur under your credentials.
+                        </p>
+                        <p>
+                            If you need a copy of the full agreement, please
+                            contact{' '}
+                            <span className="text-white">
+                                legal@longlink.com
+                            </span>
+                            .
+                        </p>
+                    </div>
+                    <Link
+                        to="/"
+                        className="text-sm text-blue-300 hover:underline"
+                    >
+                        Back to home
+                    </Link>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide standalone legal pages for Privacy, Terms of Service and Impressum and surface them from the public footer.  
- Remove the previous "Documentation" footer link and update the copyright year to 2026.

### Description
- Added new pages `web/src/pages/Privacy.tsx`, `web/src/pages/Tos.tsx`, and `web/src/pages/Impressum.tsx` with simple legal copy and a "Back to home" link.  
- Wired new routes into the router in `web/src/App.tsx` (`/privacy`, `/terms`, `/impressum`).  
- Updated the landing page footer in `web/src/pages/Home.tsx`: changed year from `© 2024` to `© 2026`, replaced the plain text links with `Link` components and removed the `Documentation` item.  
- Committed changes as "Add legal pages and footer links".

### Testing
- Ran `bun run lint` which completed but produced one advisory warning in `DataTable.tsx`.  
- Ran `bun run format` (Prettier) which succeeded and formatted files.  
- Started the dev server (`bun run dev`) and ran a Playwright script which produced a homepage screenshot (Chromium launch initially failed, Firefox run succeeded).  
- Ran `bun run build` which failed due to unrelated existing TypeScript/module issues in other components (errors reported in `Test.tsx`, `resizable.tsx`, `scroll-area.tsx`, `sidebar.tsx`, `Organization.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f45d13c8832397df7724f3793683)