### PR TITLE
Show "User / <Account Tab>" in account breadcrumb for account pages

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -148,6 +148,7 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
             ? `/${country}/${org}/${normalizedSuffix}`
             : `/${country}/${org}`
         : '';
+    const isAccountView = !org;
 
     const activeTab = (() => {
         const path = location.pathname;
@@ -165,6 +166,15 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
         return matchedTab?.value ?? tabs[0]?.value ?? 'overview';
     })();
 
+    const activeTabConfig =
+        tabs.find((tab) => tab.value === activeTab) ?? tabs[0];
+    const accountRootPath = '/organizations';
+    const accountBreadcrumbLabel = activeTabConfig?.label ?? 'Organizations';
+    const accountBreadcrumbPath = `/${activeTabConfig?.path ?? ''}`.replace(
+        /\/$/,
+        ''
+    );
+
     return (
         <div className="min-h-screen text-white">
             <header className="border-b border-white/10">
@@ -179,41 +189,80 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                             </Link>
                             <Breadcrumb>
                                 <BreadcrumbList>
-                                    <BreadcrumbItem>
-                                        <BreadcrumbLink
-                                            render={(props) => (
-                                                <Link
-                                                    {...props}
-                                                    to={
-                                                        org
-                                                            ? `/${country}/${org}`
-                                                            : '/'
-                                                    }
-                                                    className="text-sm font-semibold text-white/70"
-                                                >
-                                                    {organizationName}
-                                                </Link>
-                                            )}
-                                        />
-                                    </BreadcrumbItem>
-                                    {appName ? (
+                                    {isAccountView ? (
                                         <>
+                                            <BreadcrumbItem>
+                                                <BreadcrumbLink
+                                                    render={(props) => (
+                                                        <Link
+                                                            {...props}
+                                                            to={accountRootPath}
+                                                            className="text-sm font-semibold text-white/70"
+                                                        >
+                                                            User
+                                                        </Link>
+                                                    )}
+                                                />
+                                            </BreadcrumbItem>
                                             <BreadcrumbSeparator />
                                             <BreadcrumbItem>
                                                 <BreadcrumbLink
                                                     render={(props) => (
                                                         <Link
                                                             {...props}
-                                                            to={`/${country}/${org}/apps/${app}`}
+                                                            to={
+                                                                accountBreadcrumbPath ||
+                                                                accountRootPath
+                                                            }
                                                             className="text-sm font-semibold text-white/70"
                                                         >
-                                                            {appName}
+                                                            {
+                                                                accountBreadcrumbLabel
+                                                            }
                                                         </Link>
                                                     )}
                                                 />
                                             </BreadcrumbItem>
                                         </>
-                                    ) : null}
+                                    ) : (
+                                        <>
+                                            <BreadcrumbItem>
+                                                <BreadcrumbLink
+                                                    render={(props) => (
+                                                        <Link
+                                                            {...props}
+                                                            to={
+                                                                org
+                                                                    ? `/${country}/${org}`
+                                                                    : '/'
+                                                            }
+                                                            className="text-sm font-semibold text-white/70"
+                                                        >
+                                                            {organizationName}
+                                                        </Link>
+                                                    )}
+                                                />
+                                            </BreadcrumbItem>
+                                            {appName ? (
+                                                <>
+                                                    <BreadcrumbSeparator />
+                                                    <BreadcrumbItem>
+                                                        <BreadcrumbLink
+                                                            render={(props) => (
+                                                                <Link
+                                                                    {...props}
+                                                                    to={`/${country}/${org}/apps/${app}`}
+                                                                    className="text-sm font-semibold text-white/70"
+                                                                >
+                                                                    {appName}
+                                                                </Link>
+                                                            )}
+                                                        />
+                                                    </BreadcrumbItem>
+                                                </>
+                                            ) : null}
+                                        </>
+                                    )}
                                 </BreadcrumbList>
                             </Breadcrumb>
                         </div>


### PR DESCRIPTION
### Motivation
- Make the header breadcrumb reflect account context (showing `User / Organizations`, `User / Profile`, `User / Developer`) when not viewing a specific organization so users can see which account-area tab they are on.

### Description
- Add `isAccountView` detection and compute `activeTabConfig`, `accountBreadcrumbLabel`, and `accountBreadcrumbPath` to derive the account breadcrumb label and target path.
- Render a two-level breadcrumb `User / <ActiveTabLabel>` when `org` is not present, and preserve the original organization and app breadcrumb rendering when `org` exists.
- Keep existing tab routing behavior intact and reuse the tab configuration to determine the active account breadcrumb label.

### Testing
- Ran the dev server with `bun run dev` and captured a screenshot via Playwright showing the updated account breadcrumb, which loaded successfully. 
- Ran `bun run lint` which completed with a single warning about `react-hooks/incompatible-library` in `DataTable` (no new lint errors introduced). 
- Ran `bun run format` which succeeded. 
- Ran `bun run build` which failed due to existing TypeScript errors unrelated to this change (errors in `Test.tsx`, `resizable.tsx`, `scroll-area.tsx`, and `sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f40fc814832391bc338de0ed3030)