### PR TITLE
Add user context and useUser hook; make login auth-aware

### DIFF
--- a/web/src/components/user-profile.tsx
+++ b/web/src/components/user-profile.tsx
@@ -1,5 +1,5 @@
 import { Building2, Code2, LogOut, User } from 'lucide-react';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -10,24 +10,20 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useUser } from '@/hooks/use-user';
 
-type UserProfileProps = {
-    username?: string;
-    fullName?: string;
-    avatarUrl?: string;
-};
+export function UserProfile() {
+    const navigate = useNavigate();
+    const { user, signOut } = useUser();
+    const username = user?.name ?? 'Guest';
+    const fullName = user?.email ?? 'Not signed in';
+    const avatarUrl = user?.avatar ?? '';
 
-const defaultUser = {
-    username: 'Sau1707',
-    fullName: 'Leonardo Saurwein',
-    avatarUrl: '',
-};
+    const handleSignOut = async () => {
+        await signOut();
+        navigate('/login');
+    };
 
-export function UserProfile({
-    username = defaultUser.username,
-    fullName = defaultUser.fullName,
-    avatarUrl = defaultUser.avatarUrl,
-}: UserProfileProps) {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger className="group flex cursor-pointer items-center gap-2 rounded-full border border-white/10 bg-white/5 transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30">
@@ -82,10 +78,21 @@ export function UserProfile({
                 </DropdownMenuItem>
                 <DropdownMenuSeparator className="my-2" />
                 <DropdownMenuItem className="text-red-300 focus:text-red-200 cursor-pointer transition-colors hover:bg-white/10 p-2">
-                    <Link to="/login" className="flex w-full items-center">
-                        <LogOut className="mr-2 h-4 w-4" />
-                        Sign out
-                    </Link>
+                    {user ? (
+                        <button
+                            type="button"
+                            className="flex w-full items-center"
+                            onClick={handleSignOut}
+                        >
+                            <LogOut className="mr-2 h-4 w-4" />
+                            Sign out
+                        </button>
+                    ) : (
+                        <Link to="/login" className="flex w-full items-center">
+                            <LogOut className="mr-2 h-4 w-4" />
+                            Sign in
+                        </Link>
+                    )}
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>

--- a/web/src/contexts/user-context.tsx
+++ b/web/src/contexts/user-context.tsx
@@ -1,0 +1,87 @@
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import { apiFetch } from '@/lib/api';
+
+export type User = {
+    id: number;
+    name: string;
+    email: string;
+    avatar?: string | null;
+    oauth_github_id?: number | null;
+    date_creation?: string;
+};
+
+type UserContextValue = {
+    user: User | null;
+    isLoading: boolean;
+    refreshUser: () => Promise<void>;
+    signOut: () => Promise<void>;
+};
+
+const UserContext = createContext<UserContextValue | null>(null);
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+    const [user, setUser] = useState<User | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const fetchUser = useCallback(async () => {
+        try {
+            const response = await apiFetch<User>('/user', {
+                credentials: 'include',
+            });
+            setUser(response);
+        } catch {
+            setUser(null);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    const refreshUser = useCallback(async () => {
+        setIsLoading(true);
+        await fetchUser();
+    }, [fetchUser]);
+
+    const signOut = useCallback(async () => {
+        try {
+            await apiFetch('/logout', {
+                method: 'GET',
+                credentials: 'include',
+            });
+        } finally {
+            setUser(null);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchUser();
+    }, [fetchUser]);
+
+    const value = useMemo(
+        () => ({
+            user,
+            isLoading,
+            refreshUser,
+            signOut,
+        }),
+        [isLoading, refreshUser, signOut, user]
+    );
+
+    return (
+        <UserContext.Provider value={value}>{children}</UserContext.Provider>
+    );
+}
+
+export function useUserContext() {
+    const context = useContext(UserContext);
+    if (!context) {
+        throw new Error('useUser must be used within a UserProvider.');
+    }
+    return context;
+}

--- a/web/src/hooks/use-user.ts
+++ b/web/src/hooks/use-user.ts
@@ -1,0 +1,5 @@
+import { useUserContext } from '@/contexts/user-context';
+
+export function useUser() {
+    return useUserContext();
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,9 +3,12 @@ import { createRoot } from 'react-dom/client';
 
 import './index.css';
 import App from './App.tsx';
+import { UserProvider } from '@/contexts/user-context';
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
-        <App />
+        <UserProvider>
+            <App />
+        </UserProvider>
     </StrictMode>
 );

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,13 +1,16 @@
 import { Chrome, Github, Layers } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { useLocation } from 'react-router';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { getApiBaseUrl } from '@/lib/api';
+import { useUser } from '@/hooks/use-user';
 
 export default function Login() {
     const location = useLocation();
-    const apiBaseUrl =
-        import.meta.env.VITE_API_BASE_URL?.toString() ??
-        'http://localhost:8000';
+    const navigate = useNavigate();
+    const { user, isLoading } = useUser();
+    const apiBaseUrl = getApiBaseUrl();
 
     const getDefaultReturnTo = () => {
         const referrer = document.referrer;
@@ -33,10 +36,14 @@ export default function Login() {
             ? queryReturnTo
             : getDefaultReturnTo();
 
+    useEffect(() => {
+        if (!isLoading && user) {
+            navigate(returnTo);
+        }
+    }, [isLoading, navigate, returnTo, user]);
+
     const handleGithubLogin = () => {
-        window.location.href = `${apiBaseUrl}/login/github?return_to=${encodeURIComponent(
-            returnTo
-        )}`;
+        window.location.href = `${apiBaseUrl}/login/github`;
     };
 
     return (


### PR DESCRIPTION
### Motivation
- Provide a central, React context-backed user object loaded from the API session so UI components can react to authentication state.
- Expose a simple `useUser` hook for components to consume user data, refresh the session, and sign out via the API.
- Make the login page respect existing authenticated sessions and use the shared API base URL for OAuth redirects.

### Description
- Added a `UserProvider` and context in `web/src/contexts/user-context.tsx` which calls the API `GET /user` with `credentials: 'include'`, exposes `user`, `isLoading`, `refreshUser`, and `signOut` (uses `apiFetch` and `GET /logout`).
- Added `useUser` hook in `web/src/hooks/use-user.ts` that returns the context value.
- Wrapped the app root with `UserProvider` in `web/src/main.tsx` so the whole app can access auth state.
- Updated `web/src/components/user-profile.tsx` to consume `useUser`, show real user info, and perform sign-out via the context; updated the menu to show Sign in when no user.
- Updated `web/src/pages/Login.tsx` to use `getApiBaseUrl()` for the OAuth flow, remove embedding `return_to` in the client redirect, and automatically navigate back when the session is already authenticated.

### Testing
- Ran `bun run lint` which completed successfully with a warning about `DataTable` React Compiler incompatibility.
- Ran `bun run format` which completed successfully and formatted new files.
- Ran `bun run build` which failed due to pre-existing TypeScript errors unrelated to this PR (missing module/type errors in `Test.tsx`, `resizable.tsx`, `sidebar.tsx`, and other existing components).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f701b46c8323b005755be1306110)