### PR TITLE
Allow Vite dev origin in CORS to fix login session checks

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,15 +11,19 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://localhost:8000"],
+    allow_origins=[
+        'http://localhost:3000',
+        'http://localhost:5173',
+        'http://localhost:8000',
+    ],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=['*'],
+    allow_headers=['*'],
 )
 app.add_middleware(
     SessionMiddleware,
-    secret_key="1234",
-    same_site="lax",
+    secret_key='1234',
+    same_site='lax',
     https_only=False,
 )
 
@@ -31,14 +35,14 @@ import src.routes.user
 app.include_router(router)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     import uvicorn
     from dotenv import load_dotenv
     load_dotenv()
 
     uvicorn.run(
-        "main:app",
-        host="0.0.0.0",
+        'main:app',
+        host='0.0.0.0',
         port=8000,
         reload=True,
         access_log=False,


### PR DESCRIPTION
### Motivation

- The web app running on Vite (http://localhost:5173) was not included in the API CORS allowlist which can prevent session cookies from being sent after OAuth login, causing the frontend to still show as not logged in.
- Align string quoting/style in `api/main.py` with the project's preferred single-quote usage.

### Description

- Add `'http://localhost:5173'` to `CORSMiddleware` `allow_origins` so the Vite dev origin is allowed alongside existing origins. 
- Normalize header/method lists and session options to use consistent single-quote strings in `api/main.py` and tighten formatting for readability. 
- Use `if __name__ == '__main__':` and single-quoted args in the `uvicorn.run` call for consistency.

### Testing

- No automated tests were executed as part of this change.
- Manual verification recommended: run the API and the Vite dev server, perform OAuth login flow, and confirm the frontend `useUser` fetch returns the authenticated user (session cookie is accepted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f94dd3608323be1ce1b37bb6b97e)