### PR TITLE
Derive breadcrumb content from navigation

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,17 +1,3 @@
-import type { LucideIcon } from 'lucide-react';
-import {
-    BarChart3,
-    Boxes,
-    FileText,
-    GitBranch,
-    Layers,
-    LayoutGrid,
-    Settings,
-    Sparkles,
-    User,
-    Users,
-    Wrench,
-} from 'lucide-react';
 import {
     Link,
     Outlet,
@@ -19,161 +5,45 @@ import {
     useNavigate,
     useParams,
 } from 'react-router';
-import {
-    Breadcrumb,
-    BreadcrumbItem,
-    BreadcrumbLink,
-    BreadcrumbList,
-    BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+import { NavigationBreadcrumb } from '@/components/navigation-breadcrumb';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { UserProfile } from '@/components/user-profile';
-
-export type NavigationTab = {
-    value: string;
-    label: string;
-    path?: string;
-    icon: LucideIcon;
-};
+import {
+    getActiveTabConfig,
+    getTabsConfig,
+    NavigationIcon,
+} from '@/lib/navigation';
 
 type NavigationProps = {
-    tabs: NavigationTab[];
+    tabs: ReturnType<typeof getTabsConfig>['tabs'];
     basePathSuffix?: string;
-};
-
-const organizationTabs: NavigationTab[] = [
-    { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
-    { value: 'tools', label: 'Tools', path: 'tools', icon: Wrench },
-    { value: 'solutions', label: 'Solutions', path: 'solutions', icon: Layers },
-    {
-        value: 'workflows',
-        label: 'Workflows',
-        path: 'workflows',
-        icon: GitBranch,
-    },
-    { value: 'people', label: 'People', path: 'people', icon: Users },
-];
-
-const defaultAppTabs: NavigationTab[] = [
-    { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
-    { value: 'data', label: 'Data', path: 'data', icon: FileText },
-    { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
-];
-
-const accountTabs: NavigationTab[] = [
-    {
-        value: 'organizations',
-        label: 'Organizations',
-        path: 'organizations',
-        icon: Users,
-    },
-    { value: 'profile', label: 'Profile', path: 'profile', icon: User },
-    { value: 'developer', label: 'Developer', path: 'developer', icon: Wrench },
-];
-
-const appTabsByName: Record<string, NavigationTab[]> = {
-    viavai: [
-        { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
-        {
-            value: 'automations',
-            label: 'Automations',
-            path: 'automations',
-            icon: Sparkles,
-        },
-        {
-            value: 'integrations',
-            label: 'Integrations',
-            path: 'integrations',
-            icon: Boxes,
-        },
-        {
-            value: 'settings',
-            label: 'Settings',
-            path: 'settings',
-            icon: Settings,
-        },
-    ],
-    atlas: [
-        { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
-        { value: 'models', label: 'Models', path: 'models', icon: Layers },
-        { value: 'reports', label: 'Reports', path: 'reports', icon: FileText },
-        {
-            value: 'settings',
-            label: 'Settings',
-            path: 'settings',
-            icon: Settings,
-        },
-    ],
-    pulse: [
-        { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
-        {
-            value: 'streams',
-            label: 'Streams',
-            path: 'streams',
-            icon: Sparkles,
-        },
-        { value: 'alerts', label: 'Alerts', path: 'alerts', icon: Wrench },
-        {
-            value: 'settings',
-            label: 'Settings',
-            path: 'settings',
-            icon: Settings,
-        },
-    ],
 };
 
 export default function Layout() {
     const { app, org } = useParams();
-    const appTabs = app ? (appTabsByName[app] ?? defaultAppTabs) : null;
-    const tabs = org ? (appTabs ?? organizationTabs) : accountTabs;
+    const { tabs, basePathSuffix } = getTabsConfig({ org, app });
 
-    return (
-        <Navigation
-            tabs={tabs}
-            basePathSuffix={app ? `apps/${app}` : undefined}
-        />
-    );
+    return <Navigation tabs={tabs} basePathSuffix={basePathSuffix} />;
 }
 
 export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
-    const { country = '', org = '', app } = useParams();
+    const { country = '', org = '' } = useParams();
     const navigate = useNavigate();
     const location = useLocation();
 
-    const organizationName = formatOrganizationName(org || 'org');
-    const appName = app ? formatAppName(app) : undefined;
     const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
     const basePath = org
         ? normalizedSuffix
             ? `/${country}/${org}/${normalizedSuffix}`
             : `/${country}/${org}`
         : '';
-    const isAccountView = !org;
 
-    const activeTab = (() => {
-        const path = location.pathname;
-        const matchedTab = tabs.find((tab) => {
-            const tabPath = tab.path ?? '';
-            if (tabPath === '') {
-                return path === (basePath || '/');
-            }
-            const tabFullPath = basePath
-                ? `${basePath}/${tabPath}`
-                : `/${tabPath}`;
-            return path.startsWith(tabFullPath);
-        });
-
-        return matchedTab?.value ?? tabs[0]?.value ?? 'overview';
-    })();
-
-    const activeTabConfig =
-        tabs.find((tab) => tab.value === activeTab) ?? tabs[0];
-    const accountRootPath = '/organizations';
-    const accountBreadcrumbLabel = activeTabConfig?.label ?? 'Organizations';
-    const accountBreadcrumbPath = `/${activeTabConfig?.path ?? ''}`.replace(
-        /\/$/,
-        ''
-    );
+    const activeTabConfig = getActiveTabConfig({
+        tabs,
+        locationPath: location.pathname,
+        basePath,
+    });
+    const activeTab = activeTabConfig?.value ?? tabs[0]?.value ?? 'overview';
 
     return (
         <div className="min-h-screen text-white">
@@ -185,86 +55,9 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                 to="/"
                                 className="flex h-9 w-9 items-center justify-center rounded-full bg-white/5 text-blue-300 transition hover:bg-white/10"
                             >
-                                <BarChart3 className="h-5 w-5" />
+                                <NavigationIcon className="h-5 w-5" />
                             </Link>
-                            <Breadcrumb>
-                                <BreadcrumbList>
-                                    {isAccountView ? (
-                                        <>
-                                            <BreadcrumbItem>
-                                                <BreadcrumbLink
-                                                    render={(props) => (
-                                                        <Link
-                                                            {...props}
-                                                            to={accountRootPath}
-                                                            className="text-sm font-semibold text-white/70"
-                                                        >
-                                                            User
-                                                        </Link>
-                                                    )}
-                                                />
-                                            </BreadcrumbItem>
-                                            <BreadcrumbSeparator />
-                                            <BreadcrumbItem>
-                                                <BreadcrumbLink
-                                                    render={(props) => (
-                                                        <Link
-                                                            {...props}
-                                                            to={
-                                                                accountBreadcrumbPath ||
-                                                                accountRootPath
-                                                            }
-                                                            className="text-sm font-semibold text-white/70"
-                                                        >
-                                                            {
-                                                                accountBreadcrumbLabel
-                                                            }
-                                                        </Link>
-                                                    )}
-                                                />
-                                            </BreadcrumbItem>
-                                        </>
-                                    ) : (
-                                        <>
-                                            <BreadcrumbItem>
-                                                <BreadcrumbLink
-                                                    render={(props) => (
-                                                        <Link
-                                                            {...props}
-                                                            to={
-                                                                org
-                                                                    ? `/${country}/${org}`
-                                                                    : '/'
-                                                            }
-                                                            className="text-sm font-semibold text-white/70"
-                                                        >
-                                                            {organizationName}
-                                                        </Link>
-                                                    )}
-                                                />
-                                            </BreadcrumbItem>
-                                            {appName ? (
-                                                <>
-                                                    <BreadcrumbSeparator />
-                                                    <BreadcrumbItem>
-                                                        <BreadcrumbLink
-                                                            render={(props) => (
-                                                                <Link
-                                                                    {...props}
-                                                                    to={`/${country}/${org}/apps/${app}`}
-                                                                    className="text-sm font-semibold text-white/70"
-                                                                >
-                                                                    {appName}
-                                                                </Link>
-                                                            )}
-                                                        />
-                                                    </BreadcrumbItem>
-                                                </>
-                                            ) : null}
-                                        </>
-                                    )}
-                                </BreadcrumbList>
-                            </Breadcrumb>
+                            <NavigationBreadcrumb />
                         </div>
                         <UserProfile />
                     </div>
@@ -317,24 +110,4 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
             </main>
         </div>
     );
-}
-
-function formatOrganizationName(value: string) {
-    return value
-        .split('-')
-        .map((segment) =>
-            segment.length > 0
-                ? segment[0].toUpperCase() + segment.slice(1)
-                : segment
-        )
-        .join(' ');
-}
-
-function formatAppName(value: string) {
-    const appNames: Record<string, string> = {
-        viavai: 'ViaVai',
-        atlas: 'Atlas',
-        pulse: 'Pulse',
-    };
-    return appNames[value] ?? formatOrganizationName(value);
 }

--- a/web/src/components/navigation-breadcrumb.tsx
+++ b/web/src/components/navigation-breadcrumb.tsx
@@ -1,0 +1,116 @@
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import {
+    formatAppName,
+    formatOrganizationName,
+    getActiveTabConfig,
+    getTabsConfig,
+} from '@/lib/navigation';
+import { Link, useLocation, useParams } from 'react-router';
+
+export function NavigationBreadcrumb() {
+    const { country = '', org = '', app } = useParams();
+    const location = useLocation();
+    const { tabs, basePathSuffix } = getTabsConfig({ org, app });
+
+    const organizationName = formatOrganizationName(org || 'org');
+    const appName = app ? formatAppName(app) : undefined;
+    const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
+    const basePath = org
+        ? normalizedSuffix
+            ? `/${country}/${org}/${normalizedSuffix}`
+            : `/${country}/${org}`
+        : '';
+    const isAccountView = !org;
+    const accountRootPath = '/organizations';
+    const activeTabConfig = getActiveTabConfig({
+        tabs,
+        locationPath: location.pathname,
+        basePath,
+    });
+    const accountBreadcrumbLabel = activeTabConfig?.label ?? 'Organizations';
+    const accountBreadcrumbPath = `/${activeTabConfig?.path ?? ''}`.replace(
+        /\/$/,
+        ''
+    );
+
+    return (
+        <Breadcrumb>
+            <BreadcrumbList>
+                {isAccountView ? (
+                    <>
+                        <BreadcrumbItem>
+                            <BreadcrumbLink
+                                render={(props) => (
+                                    <Link
+                                        {...props}
+                                        to={accountRootPath}
+                                        className="text-sm font-semibold text-white/70"
+                                    >
+                                        User
+                                    </Link>
+                                )}
+                            />
+                        </BreadcrumbItem>
+                        <BreadcrumbSeparator />
+                        <BreadcrumbItem>
+                            <BreadcrumbLink
+                                render={(props) => (
+                                    <Link
+                                        {...props}
+                                        to={
+                                            accountBreadcrumbPath ||
+                                            accountRootPath
+                                        }
+                                        className="text-sm font-semibold text-white/70"
+                                    >
+                                        {accountBreadcrumbLabel}
+                                    </Link>
+                                )}
+                            />
+                        </BreadcrumbItem>
+                    </>
+                ) : (
+                    <>
+                        <BreadcrumbItem>
+                            <BreadcrumbLink
+                                render={(props) => (
+                                    <Link
+                                        {...props}
+                                        to={org ? `/${country}/${org}` : '/'}
+                                        className="text-sm font-semibold text-white/70"
+                                    >
+                                        {organizationName}
+                                    </Link>
+                                )}
+                            />
+                        </BreadcrumbItem>
+                        {appName ? (
+                            <>
+                                <BreadcrumbSeparator />
+                                <BreadcrumbItem>
+                                    <BreadcrumbLink
+                                        render={(props) => (
+                                            <Link
+                                                {...props}
+                                                to={`/${country}/${org}/apps/${app}`}
+                                                className="text-sm font-semibold text-white/70"
+                                            >
+                                                {appName}
+                                            </Link>
+                                        )}
+                                    />
+                                </BreadcrumbItem>
+                            </>
+                        ) : null}
+                    </>
+                )}
+            </BreadcrumbList>
+        </Breadcrumb>
+    );
+}

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -1,0 +1,164 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+    BarChart3,
+    Boxes,
+    FileText,
+    GitBranch,
+    Layers,
+    LayoutGrid,
+    Settings,
+    Sparkles,
+    User,
+    Users,
+    Wrench,
+} from 'lucide-react';
+
+export type NavigationTab = {
+    value: string;
+    label: string;
+    path?: string;
+    icon: LucideIcon;
+};
+
+const organizationTabs: NavigationTab[] = [
+    { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
+    { value: 'tools', label: 'Tools', path: 'tools', icon: Wrench },
+    { value: 'solutions', label: 'Solutions', path: 'solutions', icon: Layers },
+    {
+        value: 'workflows',
+        label: 'Workflows',
+        path: 'workflows',
+        icon: GitBranch,
+    },
+    { value: 'people', label: 'People', path: 'people', icon: Users },
+];
+
+const defaultAppTabs: NavigationTab[] = [
+    { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
+    { value: 'data', label: 'Data', path: 'data', icon: FileText },
+    { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
+];
+
+const accountTabs: NavigationTab[] = [
+    {
+        value: 'organizations',
+        label: 'Organizations',
+        path: 'organizations',
+        icon: Users,
+    },
+    { value: 'profile', label: 'Profile', path: 'profile', icon: User },
+    { value: 'developer', label: 'Developer', path: 'developer', icon: Wrench },
+];
+
+const appTabsByName: Record<string, NavigationTab[]> = {
+    viavai: [
+        { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
+        {
+            value: 'automations',
+            label: 'Automations',
+            path: 'automations',
+            icon: Sparkles,
+        },
+        {
+            value: 'integrations',
+            label: 'Integrations',
+            path: 'integrations',
+            icon: Boxes,
+        },
+        {
+            value: 'settings',
+            label: 'Settings',
+            path: 'settings',
+            icon: Settings,
+        },
+    ],
+    atlas: [
+        { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
+        { value: 'models', label: 'Models', path: 'models', icon: Layers },
+        { value: 'reports', label: 'Reports', path: 'reports', icon: FileText },
+        {
+            value: 'settings',
+            label: 'Settings',
+            path: 'settings',
+            icon: Settings,
+        },
+    ],
+    pulse: [
+        { value: 'overview', label: 'Overview', path: '', icon: LayoutGrid },
+        {
+            value: 'streams',
+            label: 'Streams',
+            path: 'streams',
+            icon: Sparkles,
+        },
+        { value: 'alerts', label: 'Alerts', path: 'alerts', icon: Wrench },
+        {
+            value: 'settings',
+            label: 'Settings',
+            path: 'settings',
+            icon: Settings,
+        },
+    ],
+};
+
+export type TabsConfig = {
+    tabs: NavigationTab[];
+    basePathSuffix?: string;
+};
+
+export function getTabsConfig({
+    org,
+    app,
+}: {
+    org?: string;
+    app?: string;
+}): TabsConfig {
+    const appTabs = app ? (appTabsByName[app] ?? defaultAppTabs) : null;
+    const tabs = org ? (appTabs ?? organizationTabs) : accountTabs;
+    const basePathSuffix = app ? `apps/${app}` : undefined;
+
+    return { tabs, basePathSuffix };
+}
+
+export function getActiveTabConfig({
+    tabs,
+    locationPath,
+    basePath,
+}: {
+    tabs: NavigationTab[];
+    locationPath: string;
+    basePath: string;
+}): NavigationTab | undefined {
+    const matchedTab = tabs.find((tab) => {
+        const tabPath = tab.path ?? '';
+        if (tabPath === '') {
+            return locationPath === (basePath || '/');
+        }
+        const tabFullPath = basePath ? `${basePath}/${tabPath}` : `/${tabPath}`;
+        return locationPath.startsWith(tabFullPath);
+    });
+
+    return matchedTab ?? tabs[0];
+}
+
+export function formatOrganizationName(value: string) {
+    return value
+        .split('-')
+        .map((segment) =>
+            segment.length > 0
+                ? segment[0].toUpperCase() + segment.slice(1)
+                : segment
+        )
+        .join(' ');
+}
+
+export function formatAppName(value: string) {
+    const appNames: Record<string, string> = {
+        viavai: 'ViaVai',
+        atlas: 'Atlas',
+        pulse: 'Pulse',
+    };
+    return appNames[value] ?? formatOrganizationName(value);
+}
+
+export const NavigationIcon = BarChart3;


### PR DESCRIPTION
### Motivation
- Centralize navigation metadata and behavior so breadcrumb and layout can derive display and routing information from a single source of truth.
- Make the breadcrumb component reusable and exportable without requiring many props by computing its content from route context.

### Description
- Added a navigation helper module at `web/src/lib/navigation.ts` that exports tab definitions, `getTabsConfig`, `getActiveTabConfig`, `formatOrganizationName`, `formatAppName`, and `NavigationIcon`.
- Replaced inline breadcrumb logic in `web/src/Layout.tsx` with the new `NavigationBreadcrumb` component and switched the header icon to `NavigationIcon` from the navigation module.
- Implemented `NavigationBreadcrumb` at `web/src/components/navigation-breadcrumb.tsx` to compute breadcrumb content using `useParams` and `useLocation` together with the navigation helpers so it no longer accepts external breadcrumb props.
- Updated `Layout` to call `getTabsConfig` and `getActiveTabConfig` for tab/active-state resolution and to pass only the computed `tabs` and `basePathSuffix` to the navigation renderer.

### Testing
- Ran `bun run lint`, which completed successfully and surfaced an existing TanStack Table compatibility warning (non-blocking).
- Ran `bun run format`, which succeeded and formatted the modified files.
- Ran `bun run build`, which failed due to pre-existing TypeScript errors in unrelated files (the navigation and breadcrumb changes do not introduce these errors).
- Started the dev server and executed an automated Playwright script that loaded the app and captured a screenshot of the updated breadcrumb, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f928e3808323a486301723c17fc1)