### PR TITLE
Add 404 page and improve login redirect

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import Organizations from '@/pages/Organizations';
 import Privacy from '@/pages/Privacy';
 import Tos from '@/pages/Tos';
 import Impressum from '@/pages/Impressum';
+import NotFound from '@/pages/NotFound';
 
 // Organization related pages
 import Tools from '@/pages/Tools';
@@ -58,6 +59,7 @@ const router = createBrowserRouter([
             },
         ],
     },
+    { path: '*', element: <NotFound /> },
 ]);
 
 export default function App() {

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -15,26 +15,33 @@ export default function Login() {
     const getDefaultReturnTo = () => {
         const referrer = document.referrer;
         if (!referrer) {
-            return '/';
+            return '/organizations';
         }
 
         try {
             const referrerUrl = new URL(referrer);
             if (referrerUrl.origin !== window.location.origin) {
-                return '/';
+                return '/organizations';
             }
-            return `${referrerUrl.pathname}${referrerUrl.search}${referrerUrl.hash}`;
+            const referrerPath = `${referrerUrl.pathname}${referrerUrl.search}${referrerUrl.hash}`;
+            return referrerPath.startsWith('/login')
+                ? '/organizations'
+                : referrerPath;
         } catch {
-            return '/';
+            return '/organizations';
         }
     };
 
     const searchParams = new URLSearchParams(location.search);
     const queryReturnTo = searchParams.get('return_to');
-    const returnTo =
-        queryReturnTo && queryReturnTo.startsWith('/')
-            ? queryReturnTo
-            : getDefaultReturnTo();
+    const returnTo = (() => {
+        if (!queryReturnTo || !queryReturnTo.startsWith('/')) {
+            return getDefaultReturnTo();
+        }
+        return queryReturnTo.startsWith('/login')
+            ? getDefaultReturnTo()
+            : queryReturnTo;
+    })();
 
     useEffect(() => {
         if (!isLoading && user) {

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -1,0 +1,50 @@
+import { Link, useLocation } from 'react-router';
+import { Compass } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { buttonVariants } from '@/components/ui/button';
+import { useUser } from '@/hooks/use-user';
+
+export default function NotFound() {
+    const location = useLocation();
+    const { user } = useUser();
+    const primaryLink = user ? '/organizations' : '/';
+    const primaryLabel = user ? 'Back to organizations' : 'Back to home';
+
+    return (
+        <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
+            <Card className="w-full max-w-lg border-white/10 bg-white/5">
+                <CardContent className="space-y-6 p-8 text-center">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-600/20 text-blue-300">
+                        <Compass className="h-6 w-6" />
+                    </div>
+                    <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                            404 error
+                        </p>
+                        <h1 className="text-2xl font-semibold">
+                            We can&apos;t find that page
+                        </h1>
+                        <p className="text-sm text-white/60">
+                            The page{' '}
+                            <span className="font-semibold text-white">
+                                {location.pathname}
+                            </span>{' '}
+                            doesn&apos;t exist or has moved.
+                        </p>
+                    </div>
+                    <div className="flex flex-wrap justify-center gap-3">
+                        <Link to={primaryLink} className={buttonVariants()}>
+                            {primaryLabel}
+                        </Link>
+                        <Link
+                            to="/login"
+                            className={buttonVariants({ variant: 'outline' })}
+                        >
+                            Go to login
+                        </Link>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a user-friendly 404 page for unknown routes and avoid leaving users stranded. 
- Prevent login redirect loops and ensure authenticated users land on their organizations profile by default.

### Description
- Add `NotFound` page component at `web/src/pages/NotFound.tsx` with user-aware CTAs and styling. 
- Register a catch-all route (`{ path: '*', element: <NotFound /> }`) in `web/src/App.tsx`. 
- Update login redirect logic in `web/src/pages/Login.tsx` so the default `returnTo` resolves to `/organizations` and avoids redirecting back to `/login`. 
- Use `buttonVariants` for link-styled buttons in the 404 page to avoid incompatible `asChild` typings.

### Testing
- Ran `bun run lint` which completed (there is an existing warning in `DataTable.tsx`).
- Ran `bun run format` (`prettier`) which completed successfully. 
- Ran `bun run build` which failed due to pre-existing TypeScript errors in unrelated files (errors in `Test.tsx`, `resizable.tsx`, `scroll-area.tsx`, and `sidebar.tsx`).
- Started the dev server (`bun run dev`) and captured a 404 page screenshot via an automated Playwright script which succeeded and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985fc2d9d38832394048ceffed51e01)