### PR TITLE
Enhance organization Overview page with profile and mission content

### DIFF
--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -1,10 +1,10 @@
-import { Plus, Sparkles } from 'lucide-react';
+import { MapPin, Settings, Sparkles, Users } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
 export default function Overview() {
     return (
-        <div className="space-y-6">
+        <div className="space-y-8">
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="flex items-start gap-3">
                     <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
@@ -14,24 +14,85 @@ export default function Overview() {
                         <h1 className="text-lg font-semibold text-white">
                             Overview
                         </h1>
-                        <p className="text-sm text-white/60">0 overview</p>
+                        <p className="text-sm text-white/60">
+                            Your organization workspace
+                        </p>
                     </div>
                 </div>
-                <Button variant="outline">
-                    <Plus className="h-4 w-4" />
-                    New Overview
-                </Button>
             </div>
 
-            <Card className="p-10 text-center">
-                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
-                    <Sparkles className="h-7 w-7" />
-                </div>
-                <h2 className="mt-6 text-lg font-semibold">No overview yet</h2>
-                <p className="mt-2 text-sm text-white/60">
-                    This will be the overview of your organization.
-                </p>
-            </Card>
+            <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+                <Card className="border-white/10 bg-white/5 p-6">
+                    <div className="flex flex-col items-center text-center">
+                        <div className="relative">
+                            <div className="flex h-36 w-36 items-center justify-center rounded-full bg-blue-600 text-5xl font-semibold text-white shadow-lg shadow-blue-600/30">
+                                LO
+                            </div>
+                            <Button
+                                size="icon"
+                                variant="secondary"
+                                className="absolute bottom-1 right-1 h-9 w-9 rounded-full"
+                            >
+                                <Settings className="h-4 w-4" />
+                            </Button>
+                        </div>
+                        <h2 className="mt-6 text-2xl font-semibold text-white">
+                            LongLink
+                        </h2>
+                        <p className="text-sm text-white/60">org-longlink</p>
+                        <p className="mt-2 text-sm text-white/50">
+                            Your organization workspace
+                        </p>
+                        <Button className="mt-6 w-full">Edit profile</Button>
+                        <div className="mt-5 flex items-center gap-2 text-sm text-white/60">
+                            <Users className="h-4 w-4" />
+                            <span>5 followers · 0 following</span>
+                        </div>
+                        <div className="mt-3 flex items-center gap-2 text-sm text-white/60">
+                            <MapPin className="h-4 w-4" />
+                            <span>Switzerland</span>
+                        </div>
+                    </div>
+                </Card>
+
+                <Card className="border-white/10 bg-white/5 p-8">
+                    <h2 className="text-xl font-semibold text-white">
+                        Mission, Vision &amp; Values
+                    </h2>
+                    <div className="mt-6 space-y-6 text-sm leading-relaxed text-white/70">
+                        <p>
+                            <span className="font-semibold text-blue-400">
+                                Our Mission:
+                            </span>{' '}
+                            We empower organizations to build better software,
+                            faster. By streamlining collaboration and providing
+                            cutting-edge tools, we enable teams to focus on what
+                            truly matters—creating exceptional products that
+                            delight users.
+                        </p>
+                        <p>
+                            <span className="font-semibold text-blue-400">
+                                Our Vision:
+                            </span>{' '}
+                            To become the most trusted platform for modern
+                            software development, where innovation meets
+                            simplicity. We envision a future where every team,
+                            regardless of size, has access to world-class
+                            development infrastructure.
+                        </p>
+                        <p>
+                            <span className="font-semibold text-blue-400">
+                                Our Values:
+                            </span>{' '}
+                            We believe in transparency, continuous learning, and
+                            putting our community first. We&apos;re committed to
+                            building sustainable solutions that respect both our
+                            users and the environment, while fostering a culture
+                            of inclusivity and excellence.
+                        </p>
+                    </div>
+                </Card>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Replace the minimal placeholder overview with a richer organization workspace so pages can display profile metadata and narrative content. 

### Description
- Replace the placeholder card in `web/src/pages/Overview.tsx` with a two-column layout containing a profile card and a Mission/Vision/Values content panel. 
- Add icons and metadata (avatar initials, `Edit profile` button, followers, and location) and a settings icon for profile editing. 
- Use a responsive grid (`lg:grid-cols-[320px_1fr]`) and existing `Card`/`Button` UI components for consistent styling. 

### Testing
- Ran a local dev server with `bun run dev` and captured a screenshot of the updated page (artifact produced successfully). 
- Ran `bun run lint` which completed with a single warning in `src/components/DataTable.tsx` (`react-hooks/incompatible-library`). 
- Ran `bun run format` which completed successfully. 
- Ran `bun run build` which failed due to existing TypeScript errors in unrelated files (typecheck errors in other components), not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985fd1339a883239e97bc1e7cf0ca10)