### PR TITLE
Remove extra profile navigation items

### DIFF
--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -1,17 +1,10 @@
 import {
     Accessibility,
     Bell,
-    Building2,
-    CreditCard,
-    Gavel,
-    Globe,
     KeyRound,
     Mail,
     Palette,
-    Settings as SettingsIcon,
-    ShieldCheck,
     User,
-    Users,
 } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -29,23 +22,12 @@ import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 
 const mainItems = [
-    { label: 'General', icon: SettingsIcon, active: true },
-    { label: 'Profile', icon: User },
+    { label: 'Profile', icon: User, active: true },
     { label: 'Appearance', icon: Palette },
     { label: 'Accessibility', icon: Accessibility },
     { label: 'Notifications', icon: Bell },
-];
-
-const accessItems = [
-    { label: 'Billing and licensing', icon: CreditCard },
     { label: 'Emails', icon: Mail },
     { label: 'Password and authentication', icon: KeyRound },
-    { label: 'Sessions', icon: ShieldCheck },
-    { label: 'SSH and GPG keys', icon: KeyRound },
-    { label: 'Organizations', icon: Building2 },
-    { label: 'Enterprises', icon: Globe },
-    { label: 'Teams', icon: Users },
-    { label: 'Moderation', icon: Gavel },
 ];
 
 export default function Profile() {
@@ -70,27 +52,6 @@ export default function Profile() {
                             </button>
                         );
                     })}
-                </div>
-                <Separator className="bg-white/10" />
-                <div className="space-y-3">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-white/40">
-                        Access
-                    </p>
-                    <div className="space-y-2">
-                        {accessItems.map((item) => {
-                            const Icon = item.icon;
-                            return (
-                                <button
-                                    key={item.label}
-                                    type="button"
-                                    className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium text-white/70 transition hover:bg-white/5 hover:text-white"
-                                >
-                                    <Icon className="h-4 w-4 text-white/50" />
-                                    {item.label}
-                                </button>
-                            );
-                        })}
-                    </div>
                 </div>
             </aside>
 


### PR DESCRIPTION
### Motivation
- The profile sidebar included many secondary/access items causing clutter, and the UI should show a trimmed, focused list with `Profile` as the active item.

### Description
- Trimmed the profile sidebar list in `web/src/pages/Profile.tsx` to a single `mainItems` array and removed the separate `accessItems` block and Access panel.
- Set the `Profile` entry as the active selection and removed unused icon imports from `lucide-react`.
- Kept the rest of the page layout and controls intact (profile form, avatar card, and general settings section).

### Testing
- Ran `bun run lint` which completed but produced a non-blocking warning about `DataTable.tsx` (TanStack Table API compatibility). 
- Ran `bun run format` which succeeded and updated formatting with `prettier`.
- Ran `bun run build` which failed due to unrelated TypeScript errors in other files (errors in `Test.tsx`, `resizable.tsx`, `sidebar.tsx`, and `Organization.tsx`).
- Rendered the updated `/profile` page via an automated Playwright script and captured a screenshot successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861134e8288323b0111c1f55389513)