### PR TITLE
Add useOrgs hook for organization listing and creation

### DIFF
--- a/web/src/hooks/use-orgs.ts
+++ b/web/src/hooks/use-orgs.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiFetch } from '@/lib/api';
+
+export type Organization = {
+    id: number;
+    name: string;
+    country: string;
+    date_creation?: string;
+};
+
+export type CreateOrganizationPayload = {
+    name: string;
+    country: string;
+};
+
+type UseOrgsResult = {
+    orgs: Organization[];
+    isLoading: boolean;
+    isCreating: boolean;
+    error: string | null;
+    refreshOrgs: () => Promise<void>;
+    createOrg: (payload: CreateOrganizationPayload) => Promise<Organization>;
+};
+
+export function useOrgs(): UseOrgsResult {
+    const [orgs, setOrgs] = useState<Organization[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isCreating, setIsCreating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const refreshOrgs = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const response = await apiFetch<Organization[]>('/user/orgs', {
+                credentials: 'include',
+            });
+            setOrgs(response);
+        } catch (err) {
+            setError(
+                err instanceof Error
+                    ? err.message
+                    : 'Unable to load organizations.'
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    const createOrg = useCallback(
+        async (payload: CreateOrganizationPayload) => {
+            setIsCreating(true);
+            setError(null);
+            try {
+                const response = await apiFetch<Organization>('/org', {
+                    method: 'POST',
+                    credentials: 'include',
+                    body: payload,
+                });
+                setOrgs((prev) => [...prev, response]);
+                return response;
+            } catch (err) {
+                const message =
+                    err instanceof Error
+                        ? err.message
+                        : 'Unable to create organization.';
+                setError(message);
+                throw new Error(message);
+            } finally {
+                setIsCreating(false);
+            }
+        },
+        []
+    );
+
+    useEffect(() => {
+        void refreshOrgs();
+    }, [refreshOrgs]);
+
+    return useMemo(
+        () => ({
+            orgs,
+            isLoading,
+            isCreating,
+            error,
+            refreshOrgs,
+            createOrg,
+        }),
+        [orgs, isLoading, isCreating, error, refreshOrgs, createOrg]
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable client hook to list the organizations a user belongs to and to create new organizations from the frontend.

### Description
- Add `useOrgs` hook at `web/src/hooks/use-orgs.ts` that exposes `orgs`, `isLoading`, `isCreating`, `error`, `refreshOrgs`, and `createOrg` along with `Organization` and `CreateOrganizationPayload` types.
- `refreshOrgs` calls `GET /user/orgs` and `createOrg` calls `POST /org` using the central `apiFetch` helper and updates local state on success.

### Testing
- Ran `bun run lint` which completed but reported an existing warning in unrelated code.
- Ran `bun run format` which completed successfully.
- Ran `bun run build` which failed due to existing TypeScript errors in unrelated files, not caused by the new hook.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986116e14c48323bb19b4ccb5e42471)