### PR TITLE
Connect organizations page to useOrgs hook and add create-organization dialog

### DIFF
--- a/web/src/pages/Organizations.tsx
+++ b/web/src/pages/Organizations.tsx
@@ -1,6 +1,16 @@
+import { useMemo, useState } from 'react';
 import { Building2, Plus } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
 import {
     Empty,
     EmptyContent,
@@ -9,8 +19,59 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { useOrgs } from '@/hooks/use-orgs';
+
+const emptyFormState = { name: '', country: '' };
 
 export default function Organizations() {
+    const { orgs, isLoading, isCreating, error, createOrg } = useOrgs();
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+    const [formState, setFormState] = useState(emptyFormState);
+    const [formError, setFormError] = useState<string | null>(null);
+
+    const orgCountLabel = useMemo(() => {
+        if (isLoading) {
+            return 'Loading organizations...';
+        }
+        const total = orgs.length;
+        return `${total} organization${total === 1 ? '' : 's'}`;
+    }, [isLoading, orgs.length]);
+
+    const handleOpenChange = (open: boolean) => {
+        setIsDialogOpen(open);
+        if (open) {
+            setFormState(emptyFormState);
+            setFormError(null);
+        }
+    };
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        const trimmedName = formState.name.trim();
+        const trimmedCountry = formState.country.trim();
+        if (!trimmedName) {
+            setFormError('Organization name is required.');
+            return;
+        }
+        setFormError(null);
+        try {
+            await createOrg({
+                name: trimmedName,
+                country: trimmedCountry || 'US',
+            });
+            setIsDialogOpen(false);
+        } catch (err) {
+            setFormError(
+                err instanceof Error
+                    ? err.message
+                    : 'Unable to create organization.'
+            );
+        }
+    };
+
     return (
         <div className="space-y-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -22,33 +83,144 @@ export default function Organizations() {
                         <h2 className="text-lg font-semibold text-white">
                             Organizations
                         </h2>
-                        <p className="text-sm text-white/60">0 organizations</p>
+                        <p className="text-sm text-white/60">{orgCountLabel}</p>
                     </div>
                 </div>
-                <Button variant="outline">
-                    <Plus className="h-4 w-4" />
-                    New Organization
-                </Button>
+                <Dialog open={isDialogOpen} onOpenChange={handleOpenChange}>
+                    <DialogTrigger
+                        render={
+                            <Button variant="outline">
+                                <Plus className="h-4 w-4" />
+                                New Organization
+                            </Button>
+                        }
+                    />
+                    <DialogContent className="bg-slate-950 text-white">
+                        <DialogHeader>
+                            <DialogTitle>Create organization</DialogTitle>
+                            <DialogDescription className="text-white/60">
+                                You&apos;ll be listed as the owner of this
+                                organization.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <form className="space-y-4" onSubmit={handleSubmit}>
+                            <div className="space-y-2">
+                                <Label htmlFor="org-name">
+                                    Organization name
+                                </Label>
+                                <Input
+                                    id="org-name"
+                                    value={formState.name}
+                                    onChange={(event) =>
+                                        setFormState((prev) => ({
+                                            ...prev,
+                                            name: event.target.value,
+                                        }))
+                                    }
+                                    placeholder="Acme Studio"
+                                    className="bg-white/5"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="org-country">
+                                    Country (ISO)
+                                </Label>
+                                <Input
+                                    id="org-country"
+                                    value={formState.country}
+                                    onChange={(event) =>
+                                        setFormState((prev) => ({
+                                            ...prev,
+                                            country: event.target.value,
+                                        }))
+                                    }
+                                    placeholder="US"
+                                    className="bg-white/5 uppercase"
+                                    maxLength={2}
+                                />
+                            </div>
+                            {(formError || error) && (
+                                <p className="text-sm text-red-400">
+                                    {formError || error}
+                                </p>
+                            )}
+                            <DialogFooter>
+                                <Button type="submit" disabled={isCreating}>
+                                    {isCreating ? (
+                                        <>
+                                            <Spinner className="mr-2" />
+                                            Creating...
+                                        </>
+                                    ) : (
+                                        'Create organization'
+                                    )}
+                                </Button>
+                            </DialogFooter>
+                        </form>
+                    </DialogContent>
+                </Dialog>
             </div>
 
-            <Card className="p-10 text-center">
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <Building2 />
-                        </EmptyMedia>
-                        <EmptyTitle>No Organizations Yet</EmptyTitle>
-                        <EmptyDescription>
-                            Create or join an organization to start managing
-                            your workspaces and projects.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                    <EmptyContent className="flex-row justify-center gap-2">
-                        <Button>Create Organization</Button>
-                        <Button variant="outline">Join Organization</Button>
-                    </EmptyContent>
-                </Empty>
-            </Card>
+            {isLoading ? (
+                <Card className="p-10 text-center">
+                    <div className="flex flex-col items-center gap-3 text-sm text-white/60">
+                        <Spinner className="h-5 w-5" />
+                        Loading organizations...
+                    </div>
+                </Card>
+            ) : orgs.length === 0 ? (
+                <Card className="p-10 text-center">
+                    <Empty>
+                        <EmptyHeader>
+                            <EmptyMedia variant="icon">
+                                <Building2 />
+                            </EmptyMedia>
+                            <EmptyTitle>No Organizations Yet</EmptyTitle>
+                            <EmptyDescription>
+                                Create or join an organization to start managing
+                                your workspaces and projects.
+                            </EmptyDescription>
+                        </EmptyHeader>
+                        <EmptyContent className="flex-row justify-center gap-2">
+                            <Button onClick={() => setIsDialogOpen(true)}>
+                                Create Organization
+                            </Button>
+                            <Button variant="outline">Join Organization</Button>
+                        </EmptyContent>
+                    </Empty>
+                </Card>
+            ) : (
+                <div className="grid gap-4 md:grid-cols-2">
+                    {orgs.map((org) => {
+                        const createdAt = org.date_creation
+                            ? new Date(org.date_creation).toLocaleDateString()
+                            : 'Unknown date';
+                        return (
+                            <Card
+                                key={org.id}
+                                className="flex flex-col gap-3 p-5"
+                            >
+                                <div className="flex items-start justify-between gap-3">
+                                    <div className="space-y-1">
+                                        <p className="text-lg font-semibold text-white">
+                                            {org.name}
+                                        </p>
+                                        <p className="text-sm text-white/50">
+                                            {org.country || 'No country set'}
+                                        </p>
+                                    </div>
+                                    <Button variant="outline" size="sm">
+                                        Open
+                                    </Button>
+                                </div>
+                                <div className="text-xs text-white/50">
+                                    Created {createdAt}
+                                </div>
+                            </Card>
+                        );
+                    })}
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Wire the Organizations UI to the existing `useOrgs` hook so the page loads the current user organizations and can create new ones from the frontend.
- Provide a first-class create-organization flow with form validation and loading/error states so users can create orgs from `/organizations`.
- Ensure the frontend submission uses the platform API that assigns the creating user as the organization owner (the API already handles owner membership).

### Description
- Updated `web/src/pages/Organizations.tsx` to import and use `useOrgs`, `Dialog` UI primitives, `Input`, `Label`, and `Spinner` and added local state for the create-org dialog and form.
- Implemented a create-organization dialog with client-side validation, default country fallback (`'US'`) and loading / error handling that calls `createOrg` from the hook.
- Replaced the static empty state with dynamic rendering for loading, empty, and populated organization lists, rendering organization cards with name, country and creation date.
- Kept owner assignment responsibility on the backend by invoking the existing `/org` endpoint which already adds the creator as `OrgRole.owner`.

### Testing
- Ran `bun run lint` which completed but reported one existing warning (`react-hooks/incompatible-library` in `DataTable`).
- Ran `bun run format` which completed successfully and formatted the changed files.
- Attempted `bun run build` which failed due to pre-existing TypeScript issues elsewhere (unrelated errors in `components/Test.tsx`, `ui/resizable.tsx`, `ui/scroll-area.tsx`, `ui/sidebar.tsx`, and `pages/Organization.tsx`).
- Launched the dev server (`bun run dev`) and captured a screenshot of the `/organizations` page to verify the UI changes locally (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698613e07d8883238068192ce610e3d3)