### PR TITLE
Home: show "Access" for signed-in users and rename site title to LongLink

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/vite.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>vite-app</title>
+        <title>LongLink</title>
     </head>
     <body>
         <div id="root"></div>

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -14,9 +14,14 @@ import { Link, useNavigate } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { useUser } from '@/hooks/use-user';
 
 export default function Home() {
     const navigate = useNavigate();
+    const { user } = useUser();
+
+    const loginLabel = user ? 'Access' : 'Login';
+    const loginTarget = user ? '/organizations' : '/login';
 
     return (
         <div className="min-h-screen text-white">
@@ -34,9 +39,9 @@ export default function Home() {
                             </div>
                             <Button
                                 className="flex items-center gap-2 bg-blue-600 px-4 py-2 font-semibold text-white shadow-lg shadow-blue-600/40 transition hover:bg-blue-500"
-                                onClick={() => navigate('/login')}
+                                onClick={() => navigate(loginTarget)}
                             >
-                                Login
+                                {loginLabel}
                                 <ArrowRight className="h-4 w-4" />
                             </Button>
                         </div>


### PR DESCRIPTION
### Motivation
- Ensure the landing page CTA routes signed-in users directly to the organizations dashboard by showing "Access" and to update the site branding by renaming the document title to LongLink.

### Description
- Import `useUser` in `web/src/pages/Home.tsx`, compute `loginLabel` and `loginTarget` based on the current user, and change the header CTA to `navigate(loginTarget)` and display the conditional label; and update the HTML document title in `web/index.html` to `LongLink`.

### Testing
- Ran `bun run lint` (completed with an existing React Compiler warning), `bun run format` (success), and `bun run build` (failed due to unrelated TypeScript/missing module errors in other web components).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861509f0488323ac0dcd293696706b)