### PR TITLE
Update profile picture presentation

### DIFF
--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -4,11 +4,11 @@ import {
     KeyRound,
     Mail,
     Palette,
+    Pencil,
     User,
 } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -81,21 +81,28 @@ export default function Profile() {
                         </div>
                     </div>
 
-                    <Card className="flex flex-col items-center gap-4 bg-white/5 p-6 text-center">
+                    <div className="flex flex-col items-center gap-4 text-center">
                         <div className="text-sm font-semibold text-white">
                             Profile picture
                         </div>
-                        <Avatar className="size-36 border border-white/10">
-                            <AvatarImage
-                                src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?auto=format&fit=crop&w=200&q=80"
-                                alt="Profile"
-                            />
-                            <AvatarFallback>LS</AvatarFallback>
-                        </Avatar>
-                        <Button variant="outline" size="sm">
-                            Edit
-                        </Button>
-                    </Card>
+                        <div className="relative">
+                            <Avatar className="size-44 border border-white/10">
+                                <AvatarImage
+                                    src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?auto=format&fit=crop&w=200&q=80"
+                                    alt="Profile"
+                                />
+                                <AvatarFallback>LS</AvatarFallback>
+                            </Avatar>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="absolute -bottom-3 left-2 gap-2 bg-slate-950/70 text-white hover:bg-slate-900/80"
+                            >
+                                <Pencil className="h-4 w-4" />
+                                Edit
+                            </Button>
+                        </div>
+                    </div>
                 </div>
             </section>
         </div>


### PR DESCRIPTION
### Motivation
- Align the profile picture UI with the provided reference by removing the boxed card and making the avatar more prominent with an inline edit affordance.

### Description
- Removed the surrounding `Card` wrapper and replaced it with a compact `div` container for the profile picture block.
- Increased the avatar scale (`size-36` -> `size-44`) and kept the avatar image/fallback using `Avatar`, `AvatarImage`, and `AvatarFallback`.
- Added `Pencil` icon import from `lucide-react` and overlaid an `Edit` `Button` positioned absolutely on the avatar with updated classes for visual styling.
- Adjusted layout classes to maintain center alignment and spacing without the card background.

### Testing
- Ran `npm install` in `web/` which completed with no errors.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported the site as ready and serving locally.
- Attempted an automated Playwright screenshot to verify the UI, but the headless Chromium process crashed in this environment so the visual check could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986174d3cdc83238d900e1c03c3d151)