### PR TITLE
Use Integer primary keys for organizations/apps to fix SQLite autoincrement

### DIFF
--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from src.db.models.__base__ import Base
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import String, DateTime, BigInteger, ForeignKey, func
+from src.db.models.__base__ import Base
 
 
 class App(Base):
@@ -9,8 +9,8 @@ class App(Base):
 
     __tablename__ = 'apps'
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id_org: Mapped[int] = mapped_column(Integer, ForeignKey('organizations.id'), nullable=False)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
 
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/models/orgs.py
+++ b/api/src/db/models/orgs.py
@@ -1,8 +1,8 @@
 from enum import Enum
 from datetime import datetime
-from src.db.models.__base__ import Base
+from sqlalchemy import Boolean, DateTime, Enum as SqlEnum, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import BigInteger, Boolean, DateTime, Enum as SqlEnum, ForeignKey, String, func
+from src.db.models.__base__ import Base
 
 
 class OrgRole(str, Enum):
@@ -15,7 +15,7 @@ class Org(Base):
     """Represent an organization account in the platform"""
     __tablename__ = 'organizations'
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     country: Mapped[str | None] = mapped_column(String(2), nullable=True)
     
@@ -27,10 +27,10 @@ class OrgMember(Base):
     """Represent a member of an organization"""
     __tablename__ = 'organizations_members'
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
-    id_user: Mapped[int] = mapped_column(BigInteger, ForeignKey('users.id'), nullable=False)
+    id_org: Mapped[int] = mapped_column(Integer, ForeignKey('organizations.id'), nullable=False)
+    id_user: Mapped[int] = mapped_column(Integer, ForeignKey('users.id'), nullable=False)
     
     role: Mapped[OrgRole] = mapped_column(SqlEnum(OrgRole, name='org_role'), nullable=False)
     
@@ -43,9 +43,9 @@ class OrgApp(Base):
 
     __tablename__ = 'organizations_apps'
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    id_org: Mapped[int] = mapped_column(BigInteger, ForeignKey('organizations.id'), nullable=False)
-    id_app: Mapped[int] = mapped_column(BigInteger, ForeignKey('apps.id'), nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id_org: Mapped[int] = mapped_column(Integer, ForeignKey('organizations.id'), nullable=False)
+    id_app: Mapped[int] = mapped_column(Integer, ForeignKey('apps.id'), nullable=False)
 
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default='true')
 


### PR DESCRIPTION
### Motivation
- Prevent SQLite `NOT NULL` insert failures for organizations/apps by ensuring the ORM uses a type that supports SQLite autoincrement behavior.
- Keep primary and foreign key column types consistent across organization-related models to avoid type mismatches between tables.

### Description
- Replaced `BigInteger` with `Integer` for primary keys and related foreign keys in `api/src/db/models/orgs.py` and `api/src/db/models/apps.py` to ensure SQLite treats them as autoincrementing `INTEGER PRIMARY KEY` columns.
- Adjusted imports to include `Integer` where needed and reordered imports for clarity in the modified files.
- Files changed: `api/src/db/models/orgs.py` and `api/src/db/models/apps.py`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861805c9ec8323ab3ccc9bb5bd4bc3)