### PR TITLE
Remove bio and helper text from profile settings

### DIFF
--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -21,7 +21,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
 
 const sectionTitle = {
     profile: 'General settings',
@@ -117,23 +116,6 @@ export default function Profile() {
                                     defaultValue="Leonardo Saurwein"
                                     className="bg-white/5"
                                 />
-                                <p className="text-sm text-white/50">
-                                    Your name may appear around LongLink where
-                                    you contribute or are mentioned.
-                                </p>
-                            </div>
-
-                            <div className="space-y-2">
-                                <Label htmlFor="bio">Bio</Label>
-                                <Textarea
-                                    id="bio"
-                                    defaultValue="ETHZ - Mechanical engineering"
-                                    className="min-h-[120px] bg-white/5"
-                                />
-                                <p className="text-sm text-white/50">
-                                    Mention organizations and teammates with @
-                                    to link them.
-                                </p>
                             </div>
                         </div>
 


### PR DESCRIPTION
### Motivation
- Simplify the profile settings UI by removing the Bio field and the helper text under the name field, and drop an unused import.

### Description
- Deleted the Bio textarea and the helper paragraphs from `web/src/pages/Profile.tsx` and removed the now-unused `Textarea` import.

### Testing
- Ran `bun run lint` (completed with a non-blocking warning about an incompatible library), ran `bun run format` (Prettier ran, no substantive changes), attempted `bun run build` (failed due to unrelated missing modules/types elsewhere), and started the dev server and captured a Playwright screenshot (`artifacts/profile-settings.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863417d7ac8323b21d7ca1f6c34475)