### PR TITLE
Make organization name clickable and add kebab actions menu

### DIFF
--- a/web/src/pages/Organizations.tsx
+++ b/web/src/pages/Organizations.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { Building2, Plus } from 'lucide-react';
+import { Building2, MoreVertical, Plus } from 'lucide-react';
+import { Link } from 'react-router';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -30,6 +31,12 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useOrgs } from '@/hooks/use-orgs';
 
 const emptyFormState = { name: '', country: '' };
@@ -217,10 +224,19 @@ export default function Organizations() {
                                           org.date_creation
                                       ).toLocaleDateString()
                                     : 'Unknown date';
+                                const orgCountry =
+                                    org.country?.toLowerCase() || 'us';
+                                const orgSlug = encodeURIComponent(org.name);
+                                const orgBasePath = `/${orgCountry}/${orgSlug}`;
                                 return (
                                     <TableRow key={org.id}>
                                         <TableCell className="font-semibold text-white">
-                                            {org.name}
+                                            <Link
+                                                to={orgBasePath}
+                                                className="transition-colors hover:underline underline-offset-4"
+                                            >
+                                                {org.name}
+                                            </Link>
                                         </TableCell>
                                         <TableCell className="text-white/60">
                                             {org.country || 'No country set'}
@@ -229,9 +245,40 @@ export default function Organizations() {
                                             {createdAt}
                                         </TableCell>
                                         <TableCell className="text-right">
-                                            <Button variant="outline" size="sm">
-                                                Open
-                                            </Button>
+                                            <DropdownMenu>
+                                                <DropdownMenuTrigger className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-white/10 bg-white/5 text-white transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30">
+                                                    <MoreVertical className="h-4 w-4" />
+                                                </DropdownMenuTrigger>
+                                                <DropdownMenuContent
+                                                    align="end"
+                                                    className="w-64 p-2"
+                                                >
+                                                    <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                                                        <Link
+                                                            to={orgBasePath}
+                                                            className="flex w-full items-center"
+                                                        >
+                                                            Overview
+                                                        </Link>
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                                                        <Link
+                                                            to={`${orgBasePath}/people`}
+                                                            className="flex w-full items-center"
+                                                        >
+                                                            Members
+                                                        </Link>
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                                                        <Link
+                                                            to={`${orgBasePath}/settings`}
+                                                            className="flex w-full items-center"
+                                                        >
+                                                            Settings
+                                                        </Link>
+                                                    </DropdownMenuItem>
+                                                </DropdownMenuContent>
+                                            </DropdownMenu>
                                         </TableCell>
                                     </TableRow>
                                 );


### PR DESCRIPTION
### Motivation
- Make organization entries easier to navigate by turning the organization name into a direct link to its overview page and provide a compact actions menu for common organization actions.

### Description
- Added imports for `MoreVertical`, `Link` and `DropdownMenu` components and computed `orgBasePath` from the organization country and name.
- Rendered the organization name as a clickable `Link` with hover underline styling that points to `/:country/:org`.
- Replaced the previous `Open` button with a kebab (`MoreVertical`) `DropdownMenu` styled like the user profile menu containing `Overview`, `Members`, and `Settings` links to the organization routes.
- Increased dropdown width to `w-64` and committed the changes to `web/src/pages/Organizations.tsx`.

### Testing
- Ran `bun run lint` which completed successfully but surfaced an existing warning in `DataTable.tsx`.
- Ran `bun run format` (Prettier) which completed successfully.
- Ran `bun run build` which failed due to unrelated missing modules/types in other files (existing type/module issues in the codebase).
- Launched the dev server and executed a Playwright script to capture a screenshot of the organizations page and actions menu, which produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863654d1948323b15c98d12fb00cfd)