### PR TITLE
Add org URL and name-based lookup with optional country filter

### DIFF
--- a/api/src/db/services/orgs.py
+++ b/api/src/db/services/orgs.py
@@ -38,6 +38,17 @@ class OrgsService:
             result = await session.execute(select(Org).where(Org.id == org_id))
             return result.scalars().first()
 
+    async def get_by_name(self, name: str, country: str | None = None) -> Org | None:
+        """Retrieve an organization by its name and optional country."""
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Org).where(Org.name == name)
+            if country is not None:
+                statement = statement.where(Org.country == country)
+            result = await session.execute(statement)
+            return result.scalars().first()
+
     async def app(self, org_id: int, app_id: int) -> App | None:
         """Retrieve an active app deployed in an organization."""
 

--- a/api/src/routes/org.py
+++ b/api/src/routes/org.py
@@ -1,5 +1,5 @@
 import src.db as db
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Query
 from src.auth import user as get_user
 from src.router import router
 from src.types import OrgCreate, OrgRead
@@ -13,20 +13,26 @@ async def create_org(payload: OrgCreate, current_user: db.User = Depends(get_use
     return OrgRead(
         id=org.id,
         name=org.name,
+        url=f'/{org.name}',
         country=org.country,
         date_creation=org.date_creation,
     )
 
 
-@router.get('/org/{org_id}', response_model=OrgRead)
-async def get_org(org_id: int, current_user: db.User = Depends(get_user)):
-    """Get an organization by its ID."""
-    org = await db.orgs.get(org_id)
+@router.get('/org/{org_name}', response_model=OrgRead)
+async def get_org(
+    org_name: str,
+    current_user: db.User = Depends(get_user),
+    country: str | None = Query(default=None),
+):
+    """Get an organization by its name, optionally scoped by country."""
+    org = await db.orgs.get_by_name(org_name, country=country)
     if org is None:
         raise HTTPException(404, 'Organization not found')
     return OrgRead(
         id=org.id,
         name=org.name,
+        url=f'/{org.name}',
         country=org.country,
         date_creation=org.date_creation,
     )

--- a/api/src/types/orgs.py
+++ b/api/src/types/orgs.py
@@ -10,5 +10,6 @@ class OrgCreate(BaseModel):
 class OrgRead(BaseModel):
     id: int
     name: str
+    url: str
     country: str | None
     date_creation: datetime


### PR DESCRIPTION
### Motivation
- Expose a global organization path (`/<org>`) in API responses so clients can compose non-country-scoped links.  
- Allow retrieving organizations by their name with an optional `country` filter to support both global and country-scoped lookups.

### Description
- Add a `url` field to the `OrgRead` model so responses include the organization's global path (`api/src/types/orgs.py`).
- Implement `OrgsService.get_by_name(name, country=None)` to fetch organizations by name and optionally restrict by country (`api/src/db/services/orgs.py`).
- Change the GET route to `@router.get('/org/{org_name}')` and update the handler signature to accept `org_name` and `country: str | None = Query(None)`, using `db.orgs.get_by_name` for lookup (`api/src/routes/org.py`).
- Populate the returned `OrgRead.url` as `f'/{org.name}'` in both create and get responses (`api/src/routes/org.py`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986372920408323926b01a2080732dd)