### PR TITLE
Add organization Settings tab and page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import ViaVai from '@/pages/ViaVai';
 import Overview from '@/pages/Overview';
 import Workflows from '@/pages/Workflows';
 import Solutions from '@/pages/Solutions';
+import SettingsPage from '@/pages/Settings';
 
 const router = createBrowserRouter([
     { path: '/', element: <Home /> },
@@ -51,6 +52,7 @@ const router = createBrowserRouter([
             { path: 'people', element: <People /> },
             { path: 'solutions', element: <Solutions /> },
             { path: 'workflows', element: <Workflows /> },
+            { path: 'settings', element: <SettingsPage /> },
 
             // dynamic modules
             {

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -31,6 +31,7 @@ const organizationTabs: NavigationTab[] = [
         icon: GitBranch,
     },
     { value: 'people', label: 'People', path: 'people', icon: Users },
+    { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
 ];
 
 const defaultAppTabs: NavigationTab[] = [

--- a/web/src/pages/Organization.tsx
+++ b/web/src/pages/Organization.tsx
@@ -5,6 +5,7 @@ import {
     GitBranch,
     LayoutGrid,
     Layers,
+    Settings,
     Users,
     Wrench,
 } from 'lucide-react';
@@ -27,6 +28,12 @@ export function Organization() {
             icon: GitBranch,
         },
         { value: 'people', label: 'People', path: 'people', icon: Users },
+        {
+            value: 'settings',
+            label: 'Settings',
+            path: 'settings',
+            icon: Settings,
+        },
     ];
 
     return (

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,0 +1,56 @@
+import { Plus, Settings } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@/components/ui/empty';
+
+export default function SettingsPage() {
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-500/10 text-slate-200 ring-1 ring-slate-500/30">
+                        <Settings className="h-5 w-5" />
+                    </div>
+                    <div>
+                        <h1 className="text-lg font-semibold text-white">
+                            Settings
+                        </h1>
+                        <p className="text-sm text-white/60">
+                            Organization settings
+                        </p>
+                    </div>
+                </div>
+                <Button variant="outline">
+                    <Plus className="h-4 w-4" />
+                    New Setting
+                </Button>
+            </div>
+
+            <Card className="p-10 text-center">
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <Settings />
+                        </EmptyMedia>
+                        <EmptyTitle>No Settings Yet</EmptyTitle>
+                        <EmptyDescription>
+                            Configure organization preferences, access, and
+                            policies from here.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                    <EmptyContent className="flex-row justify-center gap-2">
+                        <Button>Manage Settings</Button>
+                        <Button variant="outline">Review Permissions</Button>
+                    </EmptyContent>
+                </Empty>
+            </Card>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide an Organization-level Settings view and add a dedicated Settings tab so organizations can access configuration and policies from the main org navigation.

### Description
- Add `settings` entry to organization navigation in `web/src/lib/navigation.ts` so the Settings tab appears in org tab lists.
- Keep the legacy org tab definition in `web/src/pages/Organization.tsx` in sync by adding the `settings` tab there as well.
- Add a new `Settings` page component at `web/src/pages/Settings.tsx` that shows an empty-state UI with actions.
- Wire the Settings route into the organization routes in `web/src/App.tsx` under `/:country/:org/settings`.

### Testing
- Ran `bun run lint`, which completed but reported a warning related to `useReactTable()` memoization in `DataTable.tsx`.
- Ran `bun run format`, which succeeded and formatted the codebase.
- Launched the dev server (`bun run dev`) and executed a Playwright screenshot navigation to `/us/longlink/settings`, which succeeded and produced a screenshot artifact.
- Ran `bun run build`, which failed due to pre-existing TypeScript errors unrelated to this change (errors in `Test.tsx`, resizable panel typings, and a missing hook module).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698637766028832389c29fd4a2dee7c9)