### PR TITLE
Add organization `url` to user orgs response

### DIFF
--- a/api/src/routes/user.py
+++ b/api/src/routes/user.py
@@ -13,7 +13,13 @@ async def get_user_details(current_user: db.User = Depends(user)):
 @router.get('/user/orgs', response_model=list[OrgRead])
 async def get_user_orgs(current_user: db.User = Depends(user)):
     orgs = await db.users.orgs(current_user.id)
-    return [ 
-        OrgRead(id=org.id, name=org.name, country=org.country, date_creation=org.date_creation)
+    return [
+        OrgRead(
+            id=org.id,
+            name=org.name,
+            url=f'/{org.name}',
+            country=org.country,
+            date_creation=org.date_creation,
+        )
         for org in orgs
     ]


### PR DESCRIPTION
### Motivation
- The `OrgRead` pydantic model requires a `url` field and omitting it caused a validation error when returning the list of organizations for a user.

### Description
- Populate `url` when constructing `OrgRead` in `api/src/routes/user.py` by returning `OrgRead(..., url=f'/{org.name}', ...)` for each organization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986397d04288323a5986129eff520d2)