### PR TITLE
Remove empty-state action buttons

### DIFF
--- a/web/src/pages/Organizations.tsx
+++ b/web/src/pages/Organizations.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/components/ui/dialog';
 import {
     Empty,
-    EmptyContent,
     EmptyDescription,
     EmptyHeader,
     EmptyMedia,
@@ -196,12 +195,6 @@ export default function Organizations() {
                                 your workspaces and projects.
                             </EmptyDescription>
                         </EmptyHeader>
-                        <EmptyContent className="flex-row justify-center gap-2">
-                            <Button onClick={() => setIsDialogOpen(true)}>
-                                Create Organization
-                            </Button>
-                            <Button variant="outline">Join Organization</Button>
-                        </EmptyContent>
                     </Empty>
                 </Card>
             ) : (

--- a/web/src/pages/People.tsx
+++ b/web/src/pages/People.tsx
@@ -3,7 +3,6 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
     Empty,
-    EmptyContent,
     EmptyDescription,
     EmptyHeader,
     EmptyMedia,
@@ -43,10 +42,6 @@ export default function People() {
                             together.
                         </EmptyDescription>
                     </EmptyHeader>
-                    <EmptyContent className="flex-row justify-center gap-2">
-                        <Button>Invite Person</Button>
-                        <Button variant="outline">Import Directory</Button>
-                    </EmptyContent>
                 </Empty>
             </Card>
         </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -3,7 +3,6 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
     Empty,
-    EmptyContent,
     EmptyDescription,
     EmptyHeader,
     EmptyMedia,
@@ -45,10 +44,6 @@ export default function SettingsPage() {
                             policies from here.
                         </EmptyDescription>
                     </EmptyHeader>
-                    <EmptyContent className="flex-row justify-center gap-2">
-                        <Button>Manage Settings</Button>
-                        <Button variant="outline">Review Permissions</Button>
-                    </EmptyContent>
                 </Empty>
             </Card>
         </div>

--- a/web/src/pages/Solutions.tsx
+++ b/web/src/pages/Solutions.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
     Empty,
-    EmptyContent,
     EmptyDescription,
     EmptyHeader,
     EmptyMedia,
@@ -43,10 +42,6 @@ export default function Solutions() {
                             started by building your first solution.
                         </EmptyDescription>
                     </EmptyHeader>
-                    <EmptyContent className="flex-row justify-center gap-2">
-                        <Button>Create Solution</Button>
-                        <Button variant="outline">Import Solution</Button>
-                    </EmptyContent>
                 </Empty>
             </Card>
         </div>

--- a/web/src/pages/Tools.tsx
+++ b/web/src/pages/Tools.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
     Empty,
-    EmptyContent,
     EmptyDescription,
     EmptyHeader,
     EmptyMedia,
@@ -43,10 +42,6 @@ export default function Tools() {
                             creating your first tool.
                         </EmptyDescription>
                     </EmptyHeader>
-                    <EmptyContent className="flex-row justify-center gap-2">
-                        <Button>Create Tool</Button>
-                        <Button variant="outline">Import Tool</Button>
-                    </EmptyContent>
                 </Empty>
             </Card>
         </div>

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -3,7 +3,6 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
     Empty,
-    EmptyContent,
     EmptyDescription,
     EmptyHeader,
     EmptyMedia,
@@ -43,10 +42,6 @@ export default function Workflows() {
                             started by creating your first workflow.
                         </EmptyDescription>
                     </EmptyHeader>
-                    <EmptyContent className="flex-row justify-center gap-2">
-                        <Button>Create Workflow</Button>
-                        <Button variant="outline">Import Workflow</Button>
-                    </EmptyContent>
                 </Empty>
             </Card>
         </div>


### PR DESCRIPTION
### Motivation
- The empty/blank pages showed action CTA buttons that clutter the informational empty states, so the buttons were removed to present a simpler, read-only empty view.

### Description
- Removed the `EmptyContent` action blocks (and corresponding import) from the empty-state components on `Organizations`, `Tools`, `Solutions`, `Workflows`, `People`, and `Settings` pages.
- Kept the icon, title, and description in each empty state so the informational header remains.
- Applied project formatting to affected files.

### Testing
- Ran `bun install` in `web` which completed successfully.
- Ran `bun run format` in `web` which completed successfully and reported files unchanged/updated as needed.
- Started the dev server (`bun run dev`) and verified the UI loaded (Vite reported ready) and captured a headless screenshot of the empty states to confirm buttons are gone.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863a3ac7dc83238f16b08801fcf405)