### PR TITLE
Add PATCH /user endpoint to update current user details

### DIFF
--- a/api/src/routes/user.py
+++ b/api/src/routes/user.py
@@ -2,12 +2,26 @@ import src.db as db
 from fastapi import Depends
 from src.auth import user
 from src.types import OrgRead
+from src.types import UserUpdate
 from src.router import router
 
 
 @router.get('/user')
 async def get_user_details(current_user: db.User = Depends(user)):
     return current_user
+
+
+@router.patch('/user')
+async def patch_user_details(
+    payload: UserUpdate,
+    current_user: db.User = Depends(user),
+):
+    params = payload.model_dump(exclude_unset=True)
+    if not params:
+        return current_user
+
+    updated_user = await db.users.update(current_user.id, **params)
+    return updated_user
 
 
 @router.get('/user/orgs', response_model=list[OrgRead])

--- a/api/src/types/__init__.py
+++ b/api/src/types/__init__.py
@@ -2,3 +2,4 @@ from .countries import CountryCode
 from .address import AddressType
 from .orgs import OrgCreate
 from .orgs import OrgRead
+from .users import UserUpdate

--- a/api/src/types/users.py
+++ b/api/src/types/users.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, EmailStr
+
+
+class UserUpdate(BaseModel):
+    name: str | None = None
+    email: EmailStr | None = None
+    avatar: str | None = None


### PR DESCRIPTION
### Motivation
- Provide an authenticated HTTP endpoint to allow users to update their profile fields (name, email, avatar) via partial updates.

### Description
- Added `PATCH /user` in `api/src/routes/user.py` which accepts a `UserUpdate` payload and updates only fields provided in the request using `exclude_unset=True` before calling `db.users.update`.
- Introduced `api/src/types/users.py` containing the `UserUpdate` Pydantic model with optional `name`, `email` (`EmailStr`), and `avatar` fields.
- Exported `UserUpdate` from `api/src/types/__init__.py` so routes can import it from `src.types`.

### Testing
- Ran `python -m compileall src` in `api/` and the code compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dce4ff61c8323b5d9964a0ff13992)