### PR TITLE
Align developer sidebar with profile (white highlight + pointer) and simplify Developer page

### DIFF
--- a/web/src/pages/Developer.tsx
+++ b/web/src/pages/Developer.tsx
@@ -1,14 +1,12 @@
 import { Code2 } from 'lucide-react';
 import { useState } from 'react';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const sectionTitle = {
     general: 'General developer settings',
 } as const;
 
 const sectionSubtitle = {
-    general: 'Manage API access, webhooks, and tooling defaults.',
+    general: 'Manage API access, webhooks, and tooling defaults',
 } as const;
 
 type SectionId = keyof typeof sectionTitle;
@@ -32,9 +30,9 @@ export default function Developer() {
                                 key={item.label}
                                 type="button"
                                 onClick={() => setActiveSection(item.id)}
-                                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${
+                                className={`flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${
                                     isActive
-                                        ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(59,130,246,0.9)]'
+                                        ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(255,255,255,0.75)]'
                                         : 'text-white/70 hover:bg-white/5 hover:text-white'
                                 }`}
                             >
@@ -55,43 +53,6 @@ export default function Developer() {
                         {sectionSubtitle[activeSection]}
                     </p>
                 </div>
-
-                {activeSection === 'general' && (
-                    <div className="grid gap-4">
-                        <Card>
-                            <CardHeader className="flex-row items-start justify-between gap-4">
-                                <div>
-                                    <CardTitle>API access</CardTitle>
-                                    <p className="text-sm text-white/60">
-                                        Use personal tokens to authenticate your
-                                        tools and integrations.
-                                    </p>
-                                </div>
-                                <Badge className="bg-white/10 text-white">
-                                    Enabled
-                                </Badge>
-                            </CardHeader>
-                            <CardContent className="text-sm text-white/70">
-                                Tokens you create can be scoped to specific orgs
-                                and revoked at any time.
-                            </CardContent>
-                        </Card>
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>Webhook defaults</CardTitle>
-                                <p className="text-sm text-white/60">
-                                    Set the baseline event delivery behavior for
-                                    new apps.
-                                </p>
-                            </CardHeader>
-                            <CardContent className="text-sm text-white/70">
-                                LongLink will retry failed deliveries for 24
-                                hours and sign each payload with your org
-                                secret.
-                            </CardContent>
-                        </Card>
-                    </div>
-                )}
             </section>
         </div>
     );

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -63,7 +63,7 @@ export default function Profile() {
                                 key={item.label}
                                 type="button"
                                 onClick={() => setActiveSection(item.id)}
-                                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${
+                                className={`flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition ${
                                     isActive
                                         ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(255,255,255,0.75)]'
                                         : 'text-white/70 hover:bg-white/5 hover:text-white'


### PR DESCRIPTION
### Motivation
- Make the Developer sidebar visually consistent with the Profile sidebar by using the same white active highlight instead of the blue one.
- Ensure section menu items show the pointer cursor to indicate interactivity in both Profile and Developer pages.
- Simplify the Developer > General section to only show the heading and subtitle as requested.

### Description
- Updated `web/src/pages/Developer.tsx` to remove the detailed content cards and related imports, leaving only the `General developer settings` title and `Manage API access, webhooks, and tooling defaults` subtitle.
- Changed the Developer sidebar active indicator shadow color from blue to white and added `cursor-pointer` to the sidebar buttons in `web/src/pages/Developer.tsx`.
- Added `cursor-pointer` to the sidebar buttons in `web/src/pages/Profile.tsx` to match Developer behavior.
- Minor subtitle punctuation alignment: kept the subtitle text exactly as `Manage API access, webhooks, and tooling defaults`.

### Testing
- Ran formatter with `bun run format` in `web/` and it completed successfully.
- Ran targeted Prettier with `bunx prettier src/pages/Developer.tsx src/pages/Profile.tsx --write` and it completed successfully.
- Attempted a full build with `bun run build` which failed due to pre-existing TypeScript errors in unrelated files and thus is not caused by these changes.
- Captured an automated UI screenshot of the updated `/developer` page to validate the visual update and pointer behavior (screenshot generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcea6f89c8323936f32a5759e9f23)