### PR TITLE
Add `/lists/countries` endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,7 @@ app.add_middleware(
 import src.routes.auth
 import src.routes.org
 import src.routes.user
+import src.routes.lists
 app.include_router(router)
 
 

--- a/api/src/routes/lists.py
+++ b/api/src/routes/lists.py
@@ -1,0 +1,11 @@
+from src.router import router
+from src.types.countries import CountryCode
+from src.types.countries import CountryNames
+
+
+@router.get('/lists/countries', response_model=dict[str, str])
+async def list_countries():
+    return {
+        country_code.value: CountryNames[country_code.name].value
+        for country_code in CountryCode
+    }


### PR DESCRIPTION
### Motivation
- Expose a simple centralized list of countries to the frontend by providing an API route that maps ISO 3166-1 alpha-2 codes to human-readable country names.

### Description
- Add `api/src/routes/lists.py` implementing `GET /lists/countries` which returns a `dict[str, str]` built from the `CountryCode` and `CountryNames` enums, and register the new route in `api/main.py` so it is included in the application router.

### Testing
- Ran `python -m compileall src main.py` in `api/`, which succeeded and compiled the new module.
- Attempted a direct invocation of the route function, but the runtime import failed because `fastapi` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd3baa8288323ae7f7f65b8a58329)