### PR TITLE
Add reusable CountryPicker combobox component

### DIFF
--- a/web/src/components/viavai/country-picker.tsx
+++ b/web/src/components/viavai/country-picker.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { apiFetch } from '@/lib/api';
+import {
+    Combobox,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxInput,
+    ComboboxItem,
+    ComboboxList,
+} from '@/components/ui/combobox';
+
+type CountryMap = Record<string, string>;
+
+type CountryOption = {
+    code: string;
+    name: string;
+};
+
+type CountryPickerProps = {
+    value?: string | null;
+    defaultValue?: string | null;
+    onValueChange?: (value: string | null) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    className?: string;
+};
+
+export function CountryPicker({
+    value,
+    defaultValue,
+    onValueChange,
+    placeholder = 'Select a country',
+    disabled = false,
+    className,
+}: CountryPickerProps) {
+    const [countries, setCountries] = useState<CountryOption[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadCountries = async () => {
+            try {
+                setIsLoading(true);
+                const response = await apiFetch<CountryMap>('/lists/countries');
+
+                if (!isMounted) return;
+
+                const countryOptions = Object.entries(response)
+                    .map(([code, name]) => ({ code, name }))
+                    .sort((a, b) => a.name.localeCompare(b.name));
+
+                setCountries(countryOptions);
+                setError(null);
+            } catch {
+                if (!isMounted) return;
+                setError('Unable to load countries.');
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        loadCountries();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    const emptyMessage = useMemo(() => {
+        if (isLoading) return 'Loading countries...';
+        if (error) return error;
+        return 'No countries found.';
+    }, [error, isLoading]);
+
+    return (
+        <Combobox
+            items={countries}
+            value={value}
+            defaultValue={defaultValue}
+            onValueChange={onValueChange}
+            itemToString={(item: CountryOption | null) =>
+                item ? `${item.name} (${item.code})` : ''
+            }
+            autoHighlight
+            disabled={disabled || isLoading}
+        >
+            <ComboboxInput
+                className={className}
+                placeholder={placeholder}
+                showClear
+                disabled={disabled || isLoading}
+            />
+            <ComboboxContent>
+                <ComboboxEmpty>{emptyMessage}</ComboboxEmpty>
+                <ComboboxList>
+                    {(item: CountryOption) => (
+                        <ComboboxItem key={item.code} value={item.code}>
+                            {item.name} ({item.code})
+                        </ComboboxItem>
+                    )}
+                </ComboboxList>
+            </ComboboxContent>
+        </Combobox>
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable country selector component for forms and app screens that pulls canonical country names and codes from the platform API at `/lists/countries`.
- Reuse the existing shadcn-style combobox primitives so the picker integrates visually and behaviorally with other UI components.
- Surface common states (loading, error, empty) and support both controlled and uncontrolled usage patterns for flexible integration.

### Description
- Added a new `CountryPicker` React component at `web/src/components/viavai/country-picker.tsx` that fetches country data via the shared `apiFetch` helper and normalizes it into an alphabetically sorted list of `{ code, name }` items.
- Renders the picker using the existing combobox primitives: `Combobox`, `ComboboxInput`, `ComboboxContent`, `ComboboxEmpty`, `ComboboxList`, and `ComboboxItem`, and enables `autoHighlight` so the first filtered item is highlighted automatically.
- Exposes `value`, `defaultValue`, `onValueChange`, `placeholder`, `disabled`, and `className` props and provides typed handling for `null` selection and item rendering.
- Shows appropriate messages for loading, error, and empty states inside the combobox dropdown.

### Testing
- Ran formatter with `bun run format` (Prettier) on the repo and formatted the new file successfully.
- Linted the new file with `bunx eslint src/components/viavai/country-picker.tsx` which completed without errors for the new component.
- Attempted a full build with `bun run build`, which failed due to existing unrelated TypeScript errors elsewhere in the repo and not due to this component.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd549605c83238956dd82df34a8e1)