### PR TITLE
web: use CountryPicker in create organization dialog

### DIFF
--- a/web/src/components/dialogs/create-organization-dialog.tsx
+++ b/web/src/components/dialogs/create-organization-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
+import { CountryPicker } from '@/components/viavai/country-picker';
 import type { CreateOrganizationPayload } from '@/hooks/use-orgs';
 
 const emptyFormState = { name: '', country: '', crn: '', vat: '' };
@@ -103,19 +104,17 @@ export function CreateOrganizationDialog({
                         />
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="org-country">Country (ISO)</Label>
-                        <Input
-                            id="org-country"
+                        <Label>Country</Label>
+                        <CountryPicker
                             value={formState.country}
-                            onChange={(event) =>
+                            onValueChange={(country) =>
                                 setFormState((prev) => ({
                                     ...prev,
-                                    country: event.target.value,
+                                    country: country ?? '',
                                 }))
                             }
-                            placeholder="US"
-                            maxLength={2}
-                            className="bg-white/5 uppercase"
+                            placeholder="Select country"
+                            className="w-full bg-white/5"
                         />
                     </div>
                     <div className="space-y-2">


### PR DESCRIPTION
### Motivation
- Replace the free-text ISO country input with the reusable `CountryPicker` to provide a consistent, discoverable country selection UX in the create organization dialog.

### Description
- Import and render `CountryPicker` in `web/src/components/dialogs/create-organization-dialog.tsx`, replacing the previous `Input` used for the country field and updating the label and placeholder.
- Wire `CountryPicker`'s `onValueChange` to update `formState.country` (`country ?? ''`) while preserving the submit behavior which falls back to `'US'` when no country is provided.

### Testing
- Ran `bun run format` in `web` and it completed successfully.
- Started the dev server with `bun run dev --host 0.0.0.0 --port 4173` and visually validated the dialog (screenshot captured of the updated dialog).
- Ran `bun run build` in `web`, which failed due to pre-existing TypeScript issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ddce158dc8323812abebc53ad123a)