### PR TITLE
Fix ViaVai form types and text/email/textarea field components

### DIFF
--- a/web/src/components/fields/Email.tsx
+++ b/web/src/components/fields/Email.tsx
@@ -1,9 +1,19 @@
+import { Controller } from 'react-hook-form';
 
-const emailField: FieldDefinition = {
+import { type FieldDefinition } from '@/components/viavai/form.types';
+import {
+    Field,
+    FieldDescription,
+    FieldError,
+    FieldLabel,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+
+import { buildStringValidation } from './validation';
+
+export const emailField: FieldDefinition = {
     buildValidation: (config) =>
-        baseStringValidation(config).email(
-            config.error || "Invalid email"
-        ),
+        buildStringValidation(config).email(config.error || 'Invalid email'),
 
     render: ({ config, control }) => (
         <Controller
@@ -36,4 +46,4 @@ const emailField: FieldDefinition = {
             )}
         />
     ),
-}
+};

--- a/web/src/components/fields/Text.tsx
+++ b/web/src/components/fields/Text.tsx
@@ -1,30 +1,18 @@
+import { Controller } from 'react-hook-form';
 
-const textField: FieldDefinition = {
-    buildValidation: (config) => {
-        let validator = z.string()
+import { type FieldDefinition } from '@/components/viavai/form.types';
+import {
+    Field,
+    FieldDescription,
+    FieldError,
+    FieldLabel,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
 
-        if (config.required) {
-            validator = validator.min(1, config.error || "Required")
-        }
+import { buildStringValidation } from './validation';
 
-        if (config.validate?.minLength !== undefined) {
-            validator = validator.min(config.validate.minLength, config.error)
-        }
-
-        if (config.validate?.maxLength !== undefined) {
-            validator = validator.max(config.validate.maxLength, config.error)
-        }
-
-        if (config.validate?.pattern) {
-            validator = validator.regex(
-                new RegExp(config.validate.pattern),
-                config.error
-            )
-        }
-
-        return validator
-
-    },
+export const textField: FieldDefinition = {
+    buildValidation: buildStringValidation,
 
     render: ({ config, control }) => (
         <Controller
@@ -58,4 +46,4 @@ const textField: FieldDefinition = {
             )}
         />
     ),
-}
+};

--- a/web/src/components/fields/TextArea.tsx
+++ b/web/src/components/fields/TextArea.tsx
@@ -1,29 +1,23 @@
+import { Controller } from 'react-hook-form';
 
-const textareaField: FieldDefinition = {
-    buildValidation: (config) => {
-        let validator = z.string()
+import { type FieldDefinition } from '@/components/viavai/form.types';
+import {
+    Field,
+    FieldDescription,
+    FieldError,
+    FieldLabel,
+} from '@/components/ui/field';
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupText,
+    InputGroupTextarea,
+} from '@/components/ui/input-group';
 
-        if (config.required) {
-            validator = validator.min(1, config.error || "Required")
-        }
+import { buildStringValidation } from './validation';
 
-        if (config.validate?.minLength !== undefined) {
-            validator = validator.min(config.validate.minLength, config.error)
-        }
-
-        if (config.validate?.maxLength !== undefined) {
-            validator = validator.max(config.validate.maxLength, config.error)
-        }
-
-        if (config.validate?.pattern) {
-            validator = validator.regex(
-                new RegExp(config.validate.pattern),
-                config.error
-            )
-        }
-
-        return validator
-    },
+export const textareaField: FieldDefinition = {
+    buildValidation: buildStringValidation,
 
     render: ({ config, control }) => (
         <Controller
@@ -47,7 +41,7 @@ const textareaField: FieldDefinition = {
                         {config.validate?.maxLength && (
                             <InputGroupAddon align="block-end">
                                 <InputGroupText className="tabular-nums">
-                                    {field.value.length}/
+                                    {String(field.value ?? '').length}/
                                     {config.validate.maxLength}
                                 </InputGroupText>
                             </InputGroupAddon>
@@ -67,4 +61,4 @@ const textareaField: FieldDefinition = {
             )}
         />
     ),
-}
+};

--- a/web/src/components/fields/validation.ts
+++ b/web/src/components/fields/validation.ts
@@ -1,0 +1,28 @@
+import * as z from 'zod';
+
+import { type Component } from '@/components/viavai/form.types';
+
+export function buildStringValidation(config: Component) {
+    let validator = z.string();
+
+    if (config.required) {
+        validator = validator.min(1, config.error || 'Required');
+    }
+
+    if (config.validate?.minLength !== undefined) {
+        validator = validator.min(config.validate.minLength, config.error);
+    }
+
+    if (config.validate?.maxLength !== undefined) {
+        validator = validator.max(config.validate.maxLength, config.error);
+    }
+
+    if (config.validate?.pattern) {
+        validator = validator.regex(
+            new RegExp(config.validate.pattern),
+            config.error
+        );
+    }
+
+    return validator;
+}

--- a/web/src/components/viavai/form.tsx
+++ b/web/src/components/viavai/form.tsx
@@ -1,9 +1,9 @@
-import { zodResolver } from "@hookform/resolvers/zod"
-import { useForm } from "react-hook-form"
-import { toast } from "sonner"
-import * as z from "zod"
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import * as z from 'zod';
 
-import { Button } from "@/components/ui/button"
+import { Button } from '@/components/ui/button';
 import {
     Card,
     CardContent,
@@ -11,42 +11,17 @@ import {
     CardFooter,
     CardHeader,
     CardTitle,
-} from "@/components/ui/card"
-import {
-    Field,
-    FieldGroup,
-} from "@/components/ui/field"
+} from '@/components/ui/card';
+import { Field, FieldGroup } from '@/components/ui/field';
 
 /* ============================================================
    Types
 ============================================================ */
 
-type Component = {
-    type: "text" | "email" | "textarea"
-    name: string
-    label: string
-    description?: string
-    placeholder?: string
-    required?: boolean
-    default?: string
-    validate?: {
-        pattern?: string
-        minLength?: number
-        maxLength?: number
-    }
-    error?: string
-    depends?: any[]
-}
-
-type FieldComponentProps = {
-    config: Component
-    control: any
-}
-
-type FieldDefinition = {
-    render: (props: FieldComponentProps) => JSX.Element
-    buildValidation: (config: Component) => z.ZodTypeAny
-}
+import {
+    type Component,
+    type FieldDefinition,
+} from '@/components/viavai/form.types';
 
 /* ============================================================
    JSON Form Configuration
@@ -54,90 +29,88 @@ type FieldDefinition = {
 
 const sample: Component[] = [
     {
-        type: "text",
-        name: "title",
-        label: "Bug Title",
-        description: "Short summary of the issue.",
-        placeholder: "Login button not working",
+        type: 'text',
+        name: 'title',
+        label: 'Bug Title',
+        description: 'Short summary of the issue.',
+        placeholder: 'Login button not working',
         required: true,
-        default: "",
+        default: '',
         validate: {
             minLength: 5,
             maxLength: 32,
         },
-        error: "Title must be between 5 and 32 characters.",
+        error: 'Title must be between 5 and 32 characters.',
     },
     {
-        type: "textarea",
-        name: "description",
-        label: "Description",
-        description: "Steps to reproduce and expected result.",
-        placeholder: "Explain what happened...",
+        type: 'textarea',
+        name: 'description',
+        label: 'Description',
+        description: 'Steps to reproduce and expected result.',
+        placeholder: 'Explain what happened...',
         required: true,
-        default: "",
+        default: '',
         validate: {
             minLength: 20,
             maxLength: 100,
         },
-        error: "Description must be between 20 and 100 characters.",
+        error: 'Description must be between 20 and 100 characters.',
     },
-]
-
+];
 
 /* ============================================================
    Registry
 ============================================================ */
 
-import { textField } from "@/components/fields/Text"
-import { emailField } from "@/components/fields/Email"
-import { textareaField } from "@/components/fields/TextArea"
-
+import { textField } from '@/components/fields/Text';
+import { emailField } from '@/components/fields/Email';
+import { textareaField } from '@/components/fields/TextArea';
 
 const fieldRegistry: Record<string, FieldDefinition> = {
     text: textField,
     email: emailField,
     textarea: textareaField,
-}
+};
 
 /* ============================================================
    Schema Builder
 ============================================================ */
 
 function buildSchema(components: Component[]) {
-    const shape: Record<string, z.ZodTypeAny> = {}
+    const shape: Record<string, z.ZodTypeAny> = {};
 
     components.forEach((config) => {
-        const definition = fieldRegistry[config.type]
-        if (!definition) return
+        const definition = fieldRegistry[config.type];
+        if (!definition) return;
 
-        shape[config.name] = definition.buildValidation(config)
-    })
+        shape[config.name] = definition.buildValidation(config);
+    });
 
-    return z.object(shape)
+    return z.object(shape);
 }
 
 /* ============================================================
    Component
 ============================================================ */
 
-export default function Form() {
-    const schema = buildSchema(sample)
+export function Form() {
+    const schema = buildSchema(sample);
 
     const form = useForm({
         resolver: zodResolver(schema),
         defaultValues: Object.fromEntries(
-            sample.map((f) => [f.name, f.default ?? ""])
+            sample.map((f) => [f.name, f.default ?? ''])
         ),
-    })
+    });
 
     function onSubmit(data: any) {
-        toast("Submitted values:", {
+        toast('Submitted values:', {
             description: (
                 <pre className="bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4">
                     <code>{JSON.stringify(data, null, 2)}</code>
                 </pre>
             ),
-        })
+        });
     }
 
     return (
@@ -153,8 +126,8 @@ export default function Form() {
                 <form id="dynamic-form" onSubmit={form.handleSubmit(onSubmit)}>
                     <FieldGroup>
                         {sample.map((config) => {
-                            const definition = fieldRegistry[config.type]
-                            if (!definition) return null
+                            const definition = fieldRegistry[config.type];
+                            if (!definition) return null;
 
                             return (
                                 <div key={config.name}>
@@ -163,7 +136,7 @@ export default function Form() {
                                         control: form.control,
                                     })}
                                 </div>
-                            )
+                            );
                         })}
                     </FieldGroup>
                 </form>
@@ -184,5 +157,7 @@ export default function Form() {
                 </Field>
             </CardFooter>
         </Card>
-    )
+    );
 }
+
+export default Form;

--- a/web/src/components/viavai/form.types.ts
+++ b/web/src/components/viavai/form.types.ts
@@ -1,0 +1,30 @@
+import { type ReactElement } from 'react';
+import { type Control, type FieldValues } from 'react-hook-form';
+import * as z from 'zod';
+
+export type Component = {
+    type: 'text' | 'email' | 'textarea';
+    name: string;
+    label: string;
+    description?: string;
+    placeholder?: string;
+    required?: boolean;
+    default?: string;
+    validate?: {
+        pattern?: string;
+        minLength?: number;
+        maxLength?: number;
+    };
+    error?: string;
+    depends?: unknown[];
+};
+
+export type FieldComponentProps = {
+    config: Component;
+    control: Control<FieldValues>;
+};
+
+export type FieldDefinition = {
+    render: (props: FieldComponentProps) => ReactElement;
+    buildValidation: (config: Component) => z.ZodTypeAny;
+};


### PR DESCRIPTION
### Motivation
- Centralize the dynamic form field contracts and remove duplicated validation logic so the form and individual field components share a single type/validation source of truth. 
- Repair the `Email`, `Text` and `TextArea` field modules so they export usable field definitions and handle nullish values in the textarea counter.

### Description
- Added `web/src/components/viavai/form.types.ts` exporting `Component`, `FieldComponentProps`, and `FieldDefinition` used across the form and fields. 
- Introduced `web/src/components/fields/validation.ts` with `buildStringValidation` to consolidate the common zod string validation used by text-like fields. 
- Updated `Email.tsx`, `Text.tsx`, and `TextArea.tsx` to import shared types and validation, add missing UI imports, export the field definitions (`emailField`, `textField`, `textareaField`), and harden the textarea character counter with `String(field.value ?? '')`. 
- Updated `web/src/components/viavai/form.tsx` to consume the shared types, use the field registry, and export `Form` as both a named and default export; also applied consistent formatting/quoting.

### Testing
- Ran `bun run format` in the `web` package and formatting completed successfully. 
- Attempted `bun run build` in the `web` package which failed due to unrelated, pre-existing TypeScript issues elsewhere in the repo (missing module/type declarations and other unrelated type errors); the changes in this PR are formatted and committed despite the unrelated build failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dffcefc908323b46048526faa386c)