### PR TITLE
Refactor form fields to export components and validation functions

### DIFF
--- a/web/src/components/fields/Email.tsx
+++ b/web/src/components/fields/Email.tsx
@@ -4,6 +4,7 @@ import * as z from 'zod';
 import {
     type Component,
     type FieldDefinition,
+    type FieldComponentProps,
 } from '@/components/viavai/form.types';
 import {
     Field,
@@ -13,7 +14,7 @@ import {
 } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 
-function buildEmailValidation(config: Component) {
+export function emailValidation(config: Component) {
     let validator = z.string();
 
     if (config.required) {
@@ -38,10 +39,8 @@ function buildEmailValidation(config: Component) {
     return validator.email(config.error || 'Invalid email');
 }
 
-export const emailField: FieldDefinition = {
-    buildValidation: buildEmailValidation,
-
-    render: ({ config, control }) => (
+export function Email({ config, control }: FieldComponentProps) {
+    return (
         <Controller
             name={config.name}
             control={control}
@@ -71,5 +70,10 @@ export const emailField: FieldDefinition = {
                 </Field>
             )}
         />
-    ),
+    );
+}
+
+export const emailField: FieldDefinition = {
+    component: Email,
+    validation: emailValidation,
 };

--- a/web/src/components/fields/Text.tsx
+++ b/web/src/components/fields/Text.tsx
@@ -4,6 +4,7 @@ import * as z from 'zod';
 import {
     type Component,
     type FieldDefinition,
+    type FieldComponentProps,
 } from '@/components/viavai/form.types';
 import {
     Field,
@@ -13,7 +14,7 @@ import {
 } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 
-function buildTextValidation(config: Component) {
+export function textValidation(config: Component) {
     let validator = z.string();
 
     if (config.required) {
@@ -38,10 +39,8 @@ function buildTextValidation(config: Component) {
     return validator;
 }
 
-export const textField: FieldDefinition = {
-    buildValidation: buildTextValidation,
-
-    render: ({ config, control }) => (
+export function Text({ config, control }: FieldComponentProps) {
+    return (
         <Controller
             name={config.name}
             control={control}
@@ -72,5 +71,10 @@ export const textField: FieldDefinition = {
                 </Field>
             )}
         />
-    ),
+    );
+}
+
+export const textField: FieldDefinition = {
+    component: Text,
+    validation: textValidation,
 };

--- a/web/src/components/fields/TextArea.tsx
+++ b/web/src/components/fields/TextArea.tsx
@@ -4,6 +4,7 @@ import * as z from 'zod';
 import {
     type Component,
     type FieldDefinition,
+    type FieldComponentProps,
 } from '@/components/viavai/form.types';
 import {
     Field,
@@ -18,7 +19,7 @@ import {
     InputGroupTextarea,
 } from '@/components/ui/input-group';
 
-function buildTextAreaValidation(config: Component) {
+export function textAreaValidation(config: Component) {
     let validator = z.string();
 
     if (config.required) {
@@ -43,10 +44,8 @@ function buildTextAreaValidation(config: Component) {
     return validator;
 }
 
-export const textareaField: FieldDefinition = {
-    buildValidation: buildTextAreaValidation,
-
-    render: ({ config, control }) => (
+export function TextArea({ config, control }: FieldComponentProps) {
+    return (
         <Controller
             name={config.name}
             control={control}
@@ -87,5 +86,10 @@ export const textareaField: FieldDefinition = {
                 </Field>
             )}
         />
-    ),
+    );
+}
+
+export const textareaField: FieldDefinition = {
+    component: TextArea,
+    validation: textAreaValidation,
 };

--- a/web/src/components/viavai/form.tsx
+++ b/web/src/components/viavai/form.tsx
@@ -83,7 +83,7 @@ function buildSchema(components: Component[]) {
         const definition = fieldRegistry[config.type];
         if (!definition) return;
 
-        shape[config.name] = definition.buildValidation(config);
+        shape[config.name] = definition.validation(config);
     });
 
     return z.object(shape);
@@ -131,7 +131,7 @@ export function Form() {
 
                             return (
                                 <div key={config.name}>
-                                    {definition.render({
+                                    {definition.component({
                                         config,
                                         control: form.control,
                                     })}

--- a/web/src/components/viavai/form.types.ts
+++ b/web/src/components/viavai/form.types.ts
@@ -25,6 +25,6 @@ export type FieldComponentProps = {
 };
 
 export type FieldDefinition = {
-    render: (props: FieldComponentProps) => ReactElement;
-    buildValidation: (config: Component) => z.ZodTypeAny;
+    component: (props: FieldComponentProps) => ReactElement;
+    validation: (config: Component) => z.ZodTypeAny;
 };


### PR DESCRIPTION
### Motivation

- Separate rendering from validation so field modules expose a renderable TSX component and a standalone validation builder for clearer reuse and testing.
- Update the form registry contract to make component usage explicit and simplify schema construction.

### Description

- Replaced `FieldDefinition` keys `render` and `buildValidation` with `component` and `validation` in `web/src/components/viavai/form.types.ts`.
- Updated `Text`, `Email`, and `TextArea` modules to export a render component (`Text`, `Email`, `TextArea`) and a validation function (`textValidation`, `emailValidation`, `textAreaValidation`), and adapted each module to provide a `FieldDefinition` using `component` and `validation` (files: `web/src/components/fields/Text.tsx`, `web/src/components/fields/Email.tsx`, `web/src/components/fields/TextArea.tsx`).
- Updated dynamic form usage to call `definition.validation(config)` when building the Zod schema and to render via `definition.component(...)` (file: `web/src/components/viavai/form.tsx`).

### Testing

- Ran formatter in the `web` package with `bun run format`, which completed successfully.
- Attempted to build the `web` package with `bun run build`, which failed due to pre-existing unrelated TypeScript errors in other files (so the failure is not attributable to these field refactors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e3d8928488323b660ab020456ad98)