### PR TITLE
Implement and fix viavai JSON-configurable Table component

### DIFF
--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -5,266 +5,259 @@ import {
     useReactTable,
 } from '@tanstack/react-table';
 import {
-    Table,
+    Table as UITable,
     TableBody,
     TableCell,
     TableHead,
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    type TableAlign,
+    type TableColumn,
+    type TableConfig,
+} from '@/types/viavai/table.types';
 
-/* =========================
-   SCHEMA
-========================= */
-
-export type ColumnSchema = {
-    key: string;
-    align?: 'left' | 'center' | 'right';
-    cell: string[];
+const textAlignClasses: Record<TableAlign, string> = {
+    left: 'text-left',
+    center: 'text-center',
+    right: 'text-right',
 };
 
-/* =========================
-   TEMPLATE HELPERS
-========================= */
+const sample: TableConfig<{
+    id: string;
+    client: {
+        name: string;
+        email: string;
+    };
+    invoiceNumber: string;
+    issueDate: string;
+    dueDate: string;
+    status: string;
+    subtotal: number;
+    vat: number;
+}> = {
+    title: 'Dynamic Table',
+    description: 'Schema-driven table rendered from JSON data + JSON schema.',
+    data: [
+        {
+            id: '1',
+            client: {
+                name: 'Adriano Saurwein',
+                email: 'adriano@email.com',
+            },
+            invoiceNumber: 'INV-001',
+            issueDate: '2024-01-10',
+            dueDate: '2024-01-20',
+            status: 'Paid',
+            subtotal: 1000,
+            vat: 200,
+        },
+        {
+            id: '2',
+            client: {
+                name: 'Leonardo Saurwein',
+                email: 'leo@email.com',
+            },
+            invoiceNumber: 'INV-002',
+            issueDate: '2024-01-15',
+            dueDate: '2024-01-30',
+            status: 'Pending',
+            subtotal: 450,
+            vat: 90,
+        },
+    ],
+    schema: {
+        columns: [
+            {
+                key: 'invoice',
+                label: 'Invoice',
+                align: 'left',
+                cell: [
+                    '{invoiceNumber}',
+                    'Issued {issueDate}',
+                    'Status: {status}',
+                ],
+            },
+            {
+                key: 'client',
+                label: 'Client',
+                cell: ['{client.name}', '{client.email}'],
+            },
+            {
+                key: 'dueDate',
+                label: 'Due Date',
+                align: 'left',
+                cell: ['{dueDate}'],
+            },
+            {
+                key: 'amount',
+                label: 'Amount',
+                align: 'right',
+                cell: ['€{subtotal}', 'VAT €{vat}'],
+            },
+        ],
+    },
+};
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function resolvePath(obj: any, path: string): any {
-    return path.split('.').reduce((acc, key) => acc?.[key], obj);
+function resolvePath(data: unknown, path: string): unknown {
+    return path
+        .split('.')
+        .reduce<unknown>(
+            (acc, key) => (acc as Record<string, unknown>)?.[key],
+            data
+        );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function renderTemplate(template: string, data: any): string {
-    return template.replace(/\{([^}]+)\}/g, (_, path) =>
-        String(resolvePath(data, path) ?? '')
-    );
+function renderTemplate(template: string, data: unknown): string {
+    return template.replace(/\{([^}]+)\}/g, (_, path) => {
+        const value = resolvePath(data, path.trim());
+        return value == null ? '' : String(value);
+    });
 }
-
-/* =========================
-   COLUMN BUILDER
-========================= */
 
 function buildColumns<T extends object>(
-    schema: ColumnSchema[]
+    columns: TableColumn[]
 ): ColumnDef<T>[] {
-    return schema.map((col) => ({
-        header: col.key,
-        meta: {
-            align: col.align ?? 'left',
-        },
-        cell: ({ row }) => (
-            <div className={`leading-tight text-${col.align ?? 'left'}`}>
-                {col.cell.map((line, i) => (
-                    <div
-                        key={i}
-                        className={
-                            i === 0
-                                ? 'text-sm font-medium'
-                                : 'text-xs text-muted-foreground'
-                        }
-                    >
-                        {renderTemplate(line, row.original)}
-                    </div>
-                ))}
-            </div>
-        ),
-    }));
+    return columns.map((column) => {
+        const align = column.align ?? 'left';
+
+        return {
+            id: column.key,
+            header: column.label ?? column.key,
+            meta: { align },
+            cell: ({ row }) => (
+                <div className={`leading-tight ${textAlignClasses[align]}`}>
+                    {column.cell.map((line, index) => (
+                        <div
+                            key={`${column.key}-${index}`}
+                            className={
+                                index === 0
+                                    ? 'text-sm font-medium'
+                                    : 'text-xs text-muted-foreground'
+                            }
+                        >
+                            {renderTemplate(line, row.original)}
+                        </div>
+                    ))}
+                </div>
+            ),
+        };
+    });
 }
 
-/* =========================
-   TABLE
-========================= */
-
-type DataTableProps<T> = {
-    data: T[];
-    schema: ColumnSchema[];
+type JsonTableProps<T extends object> = {
+    config: TableConfig<T>;
 };
 
-export function DataTable<T extends object>({
-    data,
-    schema,
-}: DataTableProps<T>) {
+export function JsonTable<T extends object>({ config }: JsonTableProps<T>) {
     const table = useReactTable({
-        data,
-        columns: buildColumns<T>(schema),
+        data: config.data,
+        columns: buildColumns<T>(config.schema.columns),
         getCoreRowModel: getCoreRowModel(),
     });
 
     return (
-        <div className="border overflow-hidden">
-            <Table>
-                <TableHeader>
-                    {table.getHeaderGroups().map((hg) => (
-                        <TableRow key={hg.id}>
-                            {hg.headers.map((header) => {
-                                const align =
-                                    header.column.columnDef.meta?.align ??
-                                    'left';
-
-                                return (
-                                    <TableHead
-                                        key={header.id}
-                                        className={`text-${align}`}
-                                    >
-                                        {header.isPlaceholder
-                                            ? null
-                                            : flexRender(
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>{config.title}</CardTitle>
+                {config.description ? (
+                    <CardDescription>{config.description}</CardDescription>
+                ) : null}
+            </CardHeader>
+            <CardContent>
+                <div className="overflow-hidden rounded-md border">
+                    <UITable>
+                        <TableHeader>
+                            {table.getHeaderGroups().map((headerGroup) => (
+                                <TableRow key={headerGroup.id}>
+                                    {headerGroup.headers.map((header) => {
+                                        const align =
+                                            (
                                                 header.column.columnDef
-                                                    .header,
-                                                header.getContext()
-                                            )}
-                                    </TableHead>
-                                );
-                            })}
-                        </TableRow>
-                    ))}
-                </TableHeader>
+                                                    .meta as {
+                                                    align?: TableAlign;
+                                                }
+                                            )?.align ?? 'left';
 
-                <TableBody>
-                    {table.getRowModel().rows.map((row) => (
-                        <TableRow key={row.id}>
-                            {row.getVisibleCells().map((cell) => {
-                                const align =
-                                    cell.column.columnDef.meta?.align ?? 'left';
+                                        return (
+                                            <TableHead
+                                                key={header.id}
+                                                className={
+                                                    textAlignClasses[align]
+                                                }
+                                            >
+                                                {header.isPlaceholder
+                                                    ? null
+                                                    : flexRender(
+                                                          header.column
+                                                              .columnDef.header,
+                                                          header.getContext()
+                                                      )}
+                                            </TableHead>
+                                        );
+                                    })}
+                                </TableRow>
+                            ))}
+                        </TableHeader>
 
-                                return (
+                        <TableBody>
+                            {table.getRowModel().rows.length > 0 ? (
+                                table.getRowModel().rows.map((row) => (
+                                    <TableRow key={row.id}>
+                                        {row.getVisibleCells().map((cell) => {
+                                            const align =
+                                                (
+                                                    cell.column.columnDef
+                                                        .meta as {
+                                                        align?: TableAlign;
+                                                    }
+                                                )?.align ?? 'left';
+
+                                            return (
+                                                <TableCell
+                                                    key={cell.id}
+                                                    className={
+                                                        textAlignClasses[align]
+                                                    }
+                                                >
+                                                    {flexRender(
+                                                        cell.column.columnDef
+                                                            .cell,
+                                                        cell.getContext()
+                                                    )}
+                                                </TableCell>
+                                            );
+                                        })}
+                                    </TableRow>
+                                ))
+                            ) : (
+                                <TableRow>
                                     <TableCell
-                                        key={cell.id}
-                                        className={`text-${align}`}
+                                        colSpan={config.schema.columns.length}
+                                        className="h-24 text-center text-muted-foreground"
                                     >
-                                        {flexRender(
-                                            cell.column.columnDef.cell,
-                                            cell.getContext()
-                                        )}
+                                        No data available.
                                     </TableCell>
-                                );
-                            })}
-                        </TableRow>
-                    ))}
-                </TableBody>
-            </Table>
-        </div>
+                                </TableRow>
+                            )}
+                        </TableBody>
+                    </UITable>
+                </div>
+            </CardContent>
+        </Card>
     );
 }
 
-
-import { Card } from "@/components/ui/card"
-import { DataTable } from "@/components/DataTable"
-
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const data: any[] = [
-    {
-        id: "1",
-        client: {
-            name: "Adriano Saurwein",
-            email: "adriano@email.com"
-        },
-        invoiceNumber: "INV-001",
-        issueDate: "2024-01-10",
-        dueDate: "2024-01-20",
-        status: "Paid",
-        subtotal: 1000,
-        vat: 200,
-        method: "Card",
-    },
-    {
-        id: "2",
-        client: {
-            name: "Leonardo Saurwein",
-            email: "leo@email.com"
-        },
-        invoiceNumber: "INV-002",
-        issueDate: "2024-01-15",
-        dueDate: "2024-01-30",
-        status: "Pending",
-        subtotal: 450,
-        vat: 90,
-        method: "Bank Transfer",
-    },
-    {
-        id: "3",
-        client: {
-            name: "Bongo",
-            email: "bongo@email.com"
-        },
-        invoiceNumber: "INV-003",
-        issueDate: "2024-01-05",
-        dueDate: "2024-01-12",
-        status: "Overdue",
-        subtotal: 300,
-        vat: 60,
-        method: "Card",
-    },
-]
-
-export type ColumnSchema = {
-    key: string                // column header
-    align?: "left" | "center" | "right"
-    cell: string[]             // template lines
+export function Table() {
+    return <JsonTable config={sample} />;
 }
 
-const schema: ColumnSchema[] = [
-    {
-        key: "Invoice",
-        align: "left",
-        cell: [
-            "{invoiceNumber}",
-            "Issued {issueDate}",
-            "Status: {status}",
-        ],
-    },
-    {
-        key: "Client",
-        cell: [
-            "{client.name}",
-            "{client.email}",
-        ],
-    },
-    {
-        key: "Due Date",
-        align: "left",
-        cell: [
-            "{dueDate}",
-        ],
-    },
-    {
-        key: "Amount",
-        align: "right",
-        cell: [
-            "€{subtotal}",
-            "VAT €{vat}",
-        ],
-    },
-    // TODO: Functions
-    // bold() -> makes text bold
-    // icon() -> adds an icon before the text
-    // i18n() -> translates text key to current locale
-    // badge() -> wraps text in a badge
-    // link() -> makes text a clickable link
-    // {
-    //     key: "Invoice",
-    //     align: "left",
-    //     cell: [
-    //         "{bold(invoiceNumber)}",
-    //         "i18n(Issued) {issueDate}",
-    //         "Status: {status}",
-    //     ],
-    // },
-
-]
-
-// TODO: Table actions
-// TODO: Filtering
-// TODO: Endpoint calling, ecc
-export function Test() {
-    return (
-        <>
-            <div className="flex justify-center p-6">
-                <Card className="w-full max-w-6xl p-0">
-                    <DataTable data={data} schema={schema} />
-                </Card>
-            </div>
-        </>
-
-    )
-}
+export default Table;

--- a/web/src/types/viavai/table.types.ts
+++ b/web/src/types/viavai/table.types.ts
@@ -1,0 +1,19 @@
+export type TableAlign = 'left' | 'center' | 'right';
+
+export type TableColumn = {
+    key: string;
+    label?: string;
+    align?: TableAlign;
+    cell: string[];
+};
+
+export type TableSchema = {
+    columns: TableColumn[];
+};
+
+export type TableConfig<T extends object> = {
+    title: string;
+    description?: string;
+    data: T[];
+    schema: TableSchema;
+};


### PR DESCRIPTION
### Motivation

- The existing `viavai/Table.tsx` was incomplete and not usable as a schema-driven component similar to the `Form` component, so it needed to be implemented to support rendering tables from JSON data + a JSON schema.
- Provide a typed, reusable table renderer so apps can declare UI via JSON (data + schema) matching the pattern used by the form system.

### Description

- Rewrote `web/src/components/viavai/Table.tsx` to export a `JsonTable` component that accepts a typed `config` object (`data` + `schema`) and a default `Table` that renders a sample config, and wrapped the table in a `Card` for consistency with other components.
- Implemented template helpers `resolvePath` and `renderTemplate` to support nested path interpolation in cell templates (e.g. `{client.email}`), and a `buildColumns` function that converts the JSON schema to `@tanstack/react-table` columns.
- Added typed schema definitions in `web/src/types/viavai/table.types.ts` (`TableAlign`, `TableColumn`, `TableSchema`, `TableConfig`) to mirror the form typology and make JSON configuration strongly typed.
- Replaced dynamic Tailwind class interpolation with a stable class map `textAlignClasses` to avoid unsafe `text-${align}` usage and added an explicit empty-state row when `data` is empty.

### Testing

- Ran formatter: `bun run format` in `web/` and applied formatting to the changed files successfully.
- Ran lint on modified files: `bunx eslint src/components/viavai/Table.tsx src/types/viavai/table.types.ts` which completed; it reported a non-blocking `react-hooks/incompatible-library` warning for `useReactTable` but no errors.
- Attempted full build with `bun run build` in `web/` which failed due to pre-existing unrelated TypeScript errors in other parts of the project that were not introduced by these changes (errors shown originate from unrelated files such as `src/components/Test.tsx`, `src/pages/Example.tsx`, and certain UI helpers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e414195948323876e0fb7966d47d1)