### PR TITLE
Refactor Form to accept external schema prop

### DIFF
--- a/web/src/components/viavai/Form.tsx
+++ b/web/src/components/viavai/Form.tsx
@@ -9,41 +9,6 @@ import {
     type FieldDefinition,
 } from '@/types/viavai/form.types';
 
-/* ============================================================
-   JSON Form Configuration
-============================================================ */
-
-const sample: Component[] = [
-    {
-        type: 'text',
-        name: 'title',
-        label: 'Bug Title',
-        description: 'Short summary of the issue.',
-        placeholder: 'Login button not working',
-        required: true,
-        default: '',
-        validate: {
-            minLength: 5,
-            maxLength: 32,
-        },
-        error: 'Title must be between 5 and 32 characters.',
-    },
-    {
-        type: 'textarea',
-        name: 'description',
-        label: 'Description',
-        description: 'Steps to reproduce and expected result.',
-        placeholder: 'Explain what happened...',
-        required: true,
-        default: '',
-        validate: {
-            minLength: 20,
-            maxLength: 100,
-        },
-        error: 'Description must be between 20 and 100 characters.',
-    },
-];
-
 // Registry
 import { textField } from '@/components/fields/Text';
 import { emailField } from '@/components/fields/Email';
@@ -70,13 +35,17 @@ function buildSchema(components: Component[]) {
 }
 
 // Component
-export function Form() {
-    const schema = buildSchema(sample);
+type FormProps = {
+    schema: Component[];
+};
+
+export function Form({ schema: components }: FormProps) {
+    const schema = buildSchema(components);
 
     const form = useForm({
         resolver: zodResolver(schema),
         defaultValues: Object.fromEntries(
-            sample.map((f) => [f.name, f.default ?? ''])
+            components.map((f) => [f.name, f.default ?? ''])
         ),
     });
 
@@ -96,7 +65,7 @@ export function Form() {
             onSubmit={form.handleSubmit(onSubmit)}
         >
             <FieldGroup>
-                {sample.map((config) => {
+                {components.map((config) => {
                     const definition = fieldRegistry[config.type];
                     if (!definition) return null;
 

--- a/web/src/pages/Example.tsx
+++ b/web/src/pages/Example.tsx
@@ -1,5 +1,37 @@
-import { Form } from "@/components/viavai/Form"
+import { Form } from '@/components/viavai/Form';
+import { type Component } from '@/types/viavai/form.types';
+
+const sample: Component[] = [
+    {
+        type: 'text',
+        name: 'title',
+        label: 'Bug Title',
+        description: 'Short summary of the issue.',
+        placeholder: 'Login button not working',
+        required: true,
+        default: '',
+        validate: {
+            minLength: 5,
+            maxLength: 32,
+        },
+        error: 'Title must be between 5 and 32 characters.',
+    },
+    {
+        type: 'textarea',
+        name: 'description',
+        label: 'Description',
+        description: 'Steps to reproduce and expected result.',
+        placeholder: 'Explain what happened...',
+        required: true,
+        default: '',
+        validate: {
+            minLength: 20,
+            maxLength: 100,
+        },
+        error: 'Description must be between 20 and 100 characters.',
+    },
+];
 
 export default function Example() {
-    return <Form />
+    return <Form schema={sample} />;
 }


### PR DESCRIPTION
### Motivation

- Make the JSON-driven Form component reusable by accepting its field schema from the parent instead of using an internal sample constant.
- Keep example/test data out of the component so consumers can provide their own schemas and the component remains generic.

### Description

- Added a `FormProps` type and changed `Form` to accept `schema: Component[]` as a prop and renamed it to `components` internally.
- Replaced the internal `sample` constant usages with `components` for schema building, default values, and rendering.
- Moved the former `sample` configuration into `web/src/pages/Example.tsx` and wired the page to render `<Form schema={sample} />`.
- Updated imports/exports accordingly and left the component API intact aside from the new required prop.

### Testing

- Ran `bun run format` which completed successfully.
- Ran `bunx prettier --check src/components/viavai/Form.tsx src/pages/Example.tsx` which passed.
- Ran `bun run build` which failed due to pre-existing TypeScript errors in unrelated files (missing modules and type mismatches), not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4bdea9b0832398f3bec9ee3505df)