### PR TITLE
Add viavai JsonTable example to Example page with schema and sample data

### DIFF
--- a/web/src/pages/Example.tsx
+++ b/web/src/pages/Example.tsx
@@ -1,5 +1,7 @@
 import { Form } from '@/components/viavai/Form';
+import { JsonTable } from '@/components/viavai/Table';
 import { type Component } from '@/types/viavai/form.types';
+import { type TableConfig } from '@/types/viavai/table.types';
 
 const sample: Component[] = [
     {
@@ -32,6 +34,89 @@ const sample: Component[] = [
     },
 ];
 
+type ExampleInvoice = {
+    id: string;
+    client: {
+        name: string;
+        email: string;
+    };
+    invoiceNumber: string;
+    issueDate: string;
+    dueDate: string;
+    status: string;
+    subtotal: number;
+    vat: number;
+};
+
+const sampleTable: TableConfig<ExampleInvoice> = {
+    title: 'Invoices',
+    description: 'Example viavai table rendered with schema and sample data.',
+    data: [
+        {
+            id: '1',
+            client: {
+                name: 'Adriano Saurwein',
+                email: 'adriano@email.com',
+            },
+            invoiceNumber: 'INV-001',
+            issueDate: '2024-01-10',
+            dueDate: '2024-01-20',
+            status: 'Paid',
+            subtotal: 1000,
+            vat: 200,
+        },
+        {
+            id: '2',
+            client: {
+                name: 'Leonardo Saurwein',
+                email: 'leo@email.com',
+            },
+            invoiceNumber: 'INV-002',
+            issueDate: '2024-01-15',
+            dueDate: '2024-01-30',
+            status: 'Pending',
+            subtotal: 450,
+            vat: 90,
+        },
+    ],
+    schema: {
+        columns: [
+            {
+                key: 'invoice',
+                label: 'Invoice',
+                align: 'left',
+                cell: [
+                    '{invoiceNumber}',
+                    'Issued {issueDate}',
+                    'Status: {status}',
+                ],
+            },
+            {
+                key: 'client',
+                label: 'Client',
+                cell: ['{client.name}', '{client.email}'],
+            },
+            {
+                key: 'dueDate',
+                label: 'Due Date',
+                align: 'left',
+                cell: ['{dueDate}'],
+            },
+            {
+                key: 'amount',
+                label: 'Amount',
+                align: 'right',
+                cell: ['€{subtotal}', 'VAT €{vat}'],
+            },
+        ],
+    },
+};
+
 export default function Example() {
-    return <Form schema={sample} />;
+    return (
+        <div className="space-y-6">
+            <Form schema={sample} />
+            <JsonTable config={sampleTable} />
+        </div>
+    );
 }


### PR DESCRIPTION
### Motivation
- Provide a concrete example of the viavai table component on the Example page so consumers can see schema-driven table usage alongside the existing form example.

### Description
- Imported `JsonTable` from `@/components/viavai/Table` and `TableConfig` from `@/types/viavai/table.types` in `web/src/pages/Example.tsx`.
- Added a typed `ExampleInvoice` model and a `sampleTable: TableConfig<ExampleInvoice>` containing sample rows and a column schema with templated cell lines.
- Updated the `Example` component to render the existing `Form` and the new `JsonTable` stacked in a vertical layout.

### Testing
- Ran `bun run format` in `web/` (passed).
- Attempted `bun run build` in `web/` (failed due to pre-existing TypeScript issues in unrelated files, not caused by this change).
- Started the dev server with `bun run dev` and verified the Example page loaded successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/example` showing the form and the rendered table (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4d6a54948323b2d129188f0e1b88)