### PR TITLE
Refactor viavai Table to accept `schema` and `data` props (rename JsonTable → Table)

### DIFF
--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -22,89 +22,13 @@ import {
 import {
     type TableAlign,
     type TableColumn,
-    type TableConfig,
+    type TableSchemaConfig,
 } from '@/types/viavai/table.types';
 
 const textAlignClasses: Record<TableAlign, string> = {
     left: 'text-left',
     center: 'text-center',
     right: 'text-right',
-};
-
-const sample: TableConfig<{
-    id: string;
-    client: {
-        name: string;
-        email: string;
-    };
-    invoiceNumber: string;
-    issueDate: string;
-    dueDate: string;
-    status: string;
-    subtotal: number;
-    vat: number;
-}> = {
-    title: 'Dynamic Table',
-    description: 'Schema-driven table rendered from JSON data + JSON schema.',
-    data: [
-        {
-            id: '1',
-            client: {
-                name: 'Adriano Saurwein',
-                email: 'adriano@email.com',
-            },
-            invoiceNumber: 'INV-001',
-            issueDate: '2024-01-10',
-            dueDate: '2024-01-20',
-            status: 'Paid',
-            subtotal: 1000,
-            vat: 200,
-        },
-        {
-            id: '2',
-            client: {
-                name: 'Leonardo Saurwein',
-                email: 'leo@email.com',
-            },
-            invoiceNumber: 'INV-002',
-            issueDate: '2024-01-15',
-            dueDate: '2024-01-30',
-            status: 'Pending',
-            subtotal: 450,
-            vat: 90,
-        },
-    ],
-    schema: {
-        columns: [
-            {
-                key: 'invoice',
-                label: 'Invoice',
-                align: 'left',
-                cell: [
-                    '{invoiceNumber}',
-                    'Issued {issueDate}',
-                    'Status: {status}',
-                ],
-            },
-            {
-                key: 'client',
-                label: 'Client',
-                cell: ['{client.name}', '{client.email}'],
-            },
-            {
-                key: 'dueDate',
-                label: 'Due Date',
-                align: 'left',
-                cell: ['{dueDate}'],
-            },
-            {
-                key: 'amount',
-                label: 'Amount',
-                align: 'right',
-                cell: ['€{subtotal}', 'VAT €{vat}'],
-            },
-        ],
-    },
 };
 
 function resolvePath(data: unknown, path: string): unknown {
@@ -153,23 +77,24 @@ function buildColumns<T extends object>(
     });
 }
 
-type JsonTableProps<T extends object> = {
-    config: TableConfig<T>;
+type TableProps<T extends object> = {
+    schema: TableSchemaConfig;
+    data: T[];
 };
 
-export function JsonTable<T extends object>({ config }: JsonTableProps<T>) {
+export function Table<T extends object>({ schema, data }: TableProps<T>) {
     const table = useReactTable({
-        data: config.data,
-        columns: buildColumns<T>(config.schema.columns),
+        data,
+        columns: buildColumns<T>(schema.schema.columns),
         getCoreRowModel: getCoreRowModel(),
     });
 
     return (
         <Card className="w-full">
             <CardHeader>
-                <CardTitle>{config.title}</CardTitle>
-                {config.description ? (
-                    <CardDescription>{config.description}</CardDescription>
+                <CardTitle>{schema.title}</CardTitle>
+                {schema.description ? (
+                    <CardDescription>{schema.description}</CardDescription>
                 ) : null}
             </CardHeader>
             <CardContent>
@@ -241,7 +166,7 @@ export function JsonTable<T extends object>({ config }: JsonTableProps<T>) {
                             ) : (
                                 <TableRow>
                                     <TableCell
-                                        colSpan={config.schema.columns.length}
+                                        colSpan={schema.schema.columns.length}
                                         className="h-24 text-center text-muted-foreground"
                                     >
                                         No data available.
@@ -254,10 +179,6 @@ export function JsonTable<T extends object>({ config }: JsonTableProps<T>) {
             </CardContent>
         </Card>
     );
-}
-
-export function Table() {
-    return <JsonTable config={sample} />;
 }
 
 export default Table;

--- a/web/src/pages/Example.tsx
+++ b/web/src/pages/Example.tsx
@@ -1,7 +1,7 @@
 import { Form } from '@/components/viavai/Form';
-import { JsonTable } from '@/components/viavai/Table';
+import { Table } from '@/components/viavai/Table';
 import { type Component } from '@/types/viavai/form.types';
-import { type TableConfig } from '@/types/viavai/table.types';
+import { type TableSchemaConfig } from '@/types/viavai/table.types';
 
 const sample: Component[] = [
     {
@@ -48,37 +48,9 @@ type ExampleInvoice = {
     vat: number;
 };
 
-const sampleTable: TableConfig<ExampleInvoice> = {
+const sampleTableSchema: TableSchemaConfig = {
     title: 'Invoices',
     description: 'Example viavai table rendered with schema and sample data.',
-    data: [
-        {
-            id: '1',
-            client: {
-                name: 'Adriano Saurwein',
-                email: 'adriano@email.com',
-            },
-            invoiceNumber: 'INV-001',
-            issueDate: '2024-01-10',
-            dueDate: '2024-01-20',
-            status: 'Paid',
-            subtotal: 1000,
-            vat: 200,
-        },
-        {
-            id: '2',
-            client: {
-                name: 'Leonardo Saurwein',
-                email: 'leo@email.com',
-            },
-            invoiceNumber: 'INV-002',
-            issueDate: '2024-01-15',
-            dueDate: '2024-01-30',
-            status: 'Pending',
-            subtotal: 450,
-            vat: 90,
-        },
-    ],
     schema: {
         columns: [
             {
@@ -112,11 +84,40 @@ const sampleTable: TableConfig<ExampleInvoice> = {
     },
 };
 
+const sampleTableData: ExampleInvoice[] = [
+    {
+        id: '1',
+        client: {
+            name: 'Adriano Saurwein',
+            email: 'adriano@email.com',
+        },
+        invoiceNumber: 'INV-001',
+        issueDate: '2024-01-10',
+        dueDate: '2024-01-20',
+        status: 'Paid',
+        subtotal: 1000,
+        vat: 200,
+    },
+    {
+        id: '2',
+        client: {
+            name: 'Leonardo Saurwein',
+            email: 'leo@email.com',
+        },
+        invoiceNumber: 'INV-002',
+        issueDate: '2024-01-15',
+        dueDate: '2024-01-30',
+        status: 'Pending',
+        subtotal: 450,
+        vat: 90,
+    },
+];
+
 export default function Example() {
     return (
         <div className="space-y-6">
             <Form schema={sample} />
-            <JsonTable config={sampleTable} />
+            <Table schema={sampleTableSchema} data={sampleTableData} />
         </div>
     );
 }

--- a/web/src/types/viavai/table.types.ts
+++ b/web/src/types/viavai/table.types.ts
@@ -11,9 +11,8 @@ export type TableSchema = {
     columns: TableColumn[];
 };
 
-export type TableConfig<T extends object> = {
+export type TableSchemaConfig = {
     title: string;
     description?: string;
-    data: T[];
     schema: TableSchema;
 };


### PR DESCRIPTION
### Motivation
- Simplify the table API by separating presentation schema from row data so the schema can be reused independently from data.
- Standardize the component name to `Table` (previously `JsonTable`) for consistency with other UI components.
- Move sample rows out of the component to allow passing different datasets via props and make examples clearer.

### Description
- Replaced `TableConfig<T>` with `TableSchemaConfig` in `web/src/types/viavai/table.types.ts` so schema metadata is typed separately from row data.
- Updated `web/src/components/viavai/Table.tsx` to export `Table` (generic) that accepts `schema: TableSchemaConfig` and `data: T[]` instead of a single `config` prop, and removed the embedded sample data from the component.
- Adjusted column building and rendering to read columns from `schema.schema.columns` and row values from the `data` prop.
- Updated `web/src/pages/Example.tsx` to provide `sampleTableSchema` and `sampleTableData` separately and to import and use the new `Table` API (`<Table schema={...} data={...} />`).

### Testing
- Ran `bun run format` in `web/` which completed successfully.
- Ran `bun run build` in `web/` which failed due to unrelated pre-existing TypeScript errors in other files and not due to the table refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5b85547883239c8d3796004b5a43)