### PR TITLE
Add Table and Form pages to user menu and account tabs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from "@/components/ui/sonner"
+import { Toaster } from '@/components/ui/sonner';
 import { ThemeProvider } from '@/components/theme';
 import { RouterProvider, createBrowserRouter } from 'react-router';
 import Layout from '@/Layout';
@@ -13,7 +13,6 @@ import Privacy from '@/pages/Privacy';
 import Tos from '@/pages/Tos';
 import Impressum from '@/pages/Impressum';
 import NotFound from '@/pages/NotFound';
-import Example from '@/pages/Example';
 
 // Organization related pages
 import Tools from '@/pages/Tools';
@@ -23,6 +22,8 @@ import Overview from '@/pages/Overview';
 import Workflows from '@/pages/Workflows';
 import Solutions from '@/pages/Solutions';
 import SettingsPage from '@/pages/Settings';
+import TablePage from '@/pages/Table';
+import FormPage from '@/pages/Form';
 
 const router = createBrowserRouter([
     { path: '/', element: <Home /> },
@@ -46,6 +47,16 @@ const router = createBrowserRouter([
         children: [{ index: true, element: <Developer /> }],
     },
     {
+        path: '/table',
+        element: <Layout />,
+        children: [{ index: true, element: <TablePage /> }],
+    },
+    {
+        path: '/form',
+        element: <Layout />,
+        children: [{ index: true, element: <FormPage /> }],
+    },
+    {
         path: '/:country/:org',
         element: <Layout />,
         children: [
@@ -63,7 +74,6 @@ const router = createBrowserRouter([
             },
         ],
     },
-    { path: '/example', element: <Example /> },
     { path: '*', element: <NotFound /> },
 ]);
 

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -79,8 +79,8 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                 nextPath === ''
                                     ? basePath || '/'
                                     : basePath
-                                        ? `${basePath}/${nextPath}`
-                                        : `/${nextPath}`;
+                                      ? `${basePath}/${nextPath}`
+                                      : `/${nextPath}`;
                             navigate(targetPath);
                         }}
                     >

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -108,10 +108,10 @@ export function DataTable<T extends object>({
                                         {header.isPlaceholder
                                             ? null
                                             : flexRender(
-                                                header.column.columnDef
-                                                    .header,
-                                                header.getContext()
-                                            )}
+                                                  header.column.columnDef
+                                                      .header,
+                                                  header.getContext()
+                                              )}
                                     </TableHead>
                                 );
                             })}

--- a/web/src/components/user-profile.tsx
+++ b/web/src/components/user-profile.tsx
@@ -1,4 +1,11 @@
-import { Building2, Code2, LogOut, User } from 'lucide-react';
+import {
+    Building2,
+    Code2,
+    FilePenLine,
+    LogOut,
+    TableProperties,
+    User,
+} from 'lucide-react';
 import { Link, useNavigate } from 'react-router';
 import {
     DropdownMenu,
@@ -74,6 +81,19 @@ export function UserProfile() {
                     <Link to="/developer" className="flex w-full items-center">
                         <Code2 className="mr-2 h-4 w-4 text-white/70" />
                         Developer
+                    </Link>
+                </DropdownMenuItem>
+
+                <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                    <Link to="/table" className="flex w-full items-center">
+                        <TableProperties className="mr-2 h-4 w-4 text-white/70" />
+                        Table
+                    </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
+                    <Link to="/form" className="flex w-full items-center">
+                        <FilePenLine className="mr-2 h-4 w-4 text-white/70" />
+                        Form
                     </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator className="my-2" />

--- a/web/src/components/viavai/Form.tsx
+++ b/web/src/components/viavai/Form.tsx
@@ -60,7 +60,10 @@ export function Form({ schema: components }: FormProps) {
     }
 
     return (
-        <form className="w-full space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+        <form
+            className="w-full space-y-4"
+            onSubmit={form.handleSubmit(onSubmit)}
+        >
             <FieldGroup>
                 {components.map((config) => {
                     const definition = fieldRegistry[config.type];

--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -91,26 +91,23 @@ export function Table<T extends object>({ schema, data }: TableProps<T>) {
                             {headerGroup.headers.map((header) => {
                                 const align =
                                     (
-                                        header.column.columnDef
-                                            .meta as {
-                                                align?: TableAlign;
-                                            }
+                                        header.column.columnDef.meta as {
+                                            align?: TableAlign;
+                                        }
                                     )?.align ?? 'left';
 
                                 return (
                                     <TableHead
                                         key={header.id}
-                                        className={
-                                            textAlignClasses[align]
-                                        }
+                                        className={textAlignClasses[align]}
                                     >
                                         {header.isPlaceholder
                                             ? null
                                             : flexRender(
-                                                header.column
-                                                    .columnDef.header,
-                                                header.getContext()
-                                            )}
+                                                  header.column.columnDef
+                                                      .header,
+                                                  header.getContext()
+                                              )}
                                     </TableHead>
                                 );
                             })}
@@ -125,22 +122,18 @@ export function Table<T extends object>({ schema, data }: TableProps<T>) {
                                 {row.getVisibleCells().map((cell) => {
                                     const align =
                                         (
-                                            cell.column.columnDef
-                                                .meta as {
-                                                    align?: TableAlign;
-                                                }
+                                            cell.column.columnDef.meta as {
+                                                align?: TableAlign;
+                                            }
                                         )?.align ?? 'left';
 
                                     return (
                                         <TableCell
                                             key={cell.id}
-                                            className={
-                                                textAlignClasses[align]
-                                            }
+                                            className={textAlignClasses[align]}
                                         >
                                             {flexRender(
-                                                cell.column.columnDef
-                                                    .cell,
+                                                cell.column.columnDef.cell,
                                                 cell.getContext()
                                             )}
                                         </TableCell>

--- a/web/src/lib/example-data.ts
+++ b/web/src/lib/example-data.ts
@@ -1,0 +1,112 @@
+import { type Component } from '@/types/viavai/form.types';
+import { type TableSchemaConfig } from '@/types/viavai/table.types';
+
+export const sampleFormSchema: Component[] = [
+    {
+        type: 'text',
+        name: 'title',
+        label: 'Bug Title',
+        description: 'Short summary of the issue.',
+        placeholder: 'Login button not working',
+        required: true,
+        default: '',
+        validate: {
+            minLength: 5,
+            maxLength: 32,
+        },
+        error: 'Title must be between 5 and 32 characters.',
+    },
+    {
+        type: 'textarea',
+        name: 'description',
+        label: 'Description',
+        description: 'Steps to reproduce and expected result.',
+        placeholder: 'Explain what happened...',
+        required: true,
+        default: '',
+        validate: {
+            minLength: 20,
+            maxLength: 100,
+        },
+        error: 'Description must be between 20 and 100 characters.',
+    },
+];
+
+type ExampleInvoice = {
+    id: string;
+    client: {
+        name: string;
+        email: string;
+    };
+    invoiceNumber: string;
+    issueDate: string;
+    dueDate: string;
+    status: string;
+    subtotal: number;
+    vat: number;
+};
+
+export const sampleTableSchema: TableSchemaConfig = {
+    title: 'Invoices',
+    description: 'Example viavai table rendered with schema and sample data.',
+    schema: {
+        columns: [
+            {
+                key: 'invoice',
+                label: 'Invoice',
+                align: 'left',
+                cell: [
+                    '{invoiceNumber}',
+                    'Issued {issueDate}',
+                    'Status: {status}',
+                ],
+            },
+            {
+                key: 'client',
+                label: 'Client',
+                cell: ['{client.name}', '{client.email}'],
+            },
+            {
+                key: 'dueDate',
+                label: 'Due Date',
+                align: 'left',
+                cell: ['{dueDate}'],
+            },
+            {
+                key: 'amount',
+                label: 'Amount',
+                align: 'right',
+                cell: ['€{subtotal}', 'VAT €{vat}'],
+            },
+        ],
+    },
+};
+
+export const sampleTableData: ExampleInvoice[] = [
+    {
+        id: '1',
+        client: {
+            name: 'Adriano Saurwein',
+            email: 'adriano@email.com',
+        },
+        invoiceNumber: 'INV-001',
+        issueDate: '2024-01-10',
+        dueDate: '2024-01-20',
+        status: 'Paid',
+        subtotal: 1000,
+        vat: 200,
+    },
+    {
+        id: '2',
+        client: {
+            name: 'Leonardo Saurwein',
+            email: 'leo@email.com',
+        },
+        invoiceNumber: 'INV-002',
+        issueDate: '2024-01-15',
+        dueDate: '2024-01-30',
+        status: 'Pending',
+        subtotal: 450,
+        vat: 90,
+    },
+];

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -10,6 +10,8 @@ import {
     Sparkles,
     User,
     Users,
+    TableProperties,
+    FilePenLine,
     Wrench,
 } from 'lucide-react';
 
@@ -49,6 +51,8 @@ const accountTabs: NavigationTab[] = [
     },
     { value: 'profile', label: 'Profile', path: 'profile', icon: User },
     { value: 'developer', label: 'Developer', path: 'developer', icon: Wrench },
+    { value: 'table', label: 'Table', path: 'table', icon: TableProperties },
+    { value: 'form', label: 'Form', path: 'form', icon: FilePenLine },
 ];
 
 const appTabsByName: Record<string, NavigationTab[]> = {

--- a/web/src/pages/Form.tsx
+++ b/web/src/pages/Form.tsx
@@ -1,0 +1,6 @@
+import { Form } from '@/components/viavai/Form';
+import { sampleFormSchema } from '@/lib/example-data';
+
+export default function FormPage() {
+    return <Form schema={sampleFormSchema} />;
+}

--- a/web/src/pages/Table.tsx
+++ b/web/src/pages/Table.tsx
@@ -1,0 +1,6 @@
+import { Table } from '@/components/viavai/Table';
+import { sampleTableData, sampleTableSchema } from '@/lib/example-data';
+
+export default function TablePage() {
+    return <Table schema={sampleTableSchema} data={sampleTableData} />;
+}


### PR DESCRIPTION
### Motivation
- Provide direct access to the sample Table and Form views from the account UI so the example content is accessible as first-class pages.

### Description
- Added two new account routes (`/table` and `/form`) rendered inside the shared `Layout` and removed the previous `/example` route by replacing it with dedicated pages using the same sample payload.
- Extracted the sample form/table schema and data into `web/src/lib/example-data.ts` and created `web/src/pages/Table.tsx` and `web/src/pages/Form.tsx` that reuse that data.
- Added `Table` and `Form` entries to the account tabs via `getTabsConfig` in `web/src/lib/navigation.ts` so they appear in the user/account tab bar, and added corresponding links to the avatar dropdown in `web/src/components/user-profile.tsx` for quick access.
- Performed formatting and small component cleanups (`Form`, `Table`, and table rendering/formatting tweaks) to keep code style consistent.

### Testing
- Ran the project formatter with `bun run format` which completed successfully.
- Attempted a full build with `bun run build` which failed due to pre-existing TypeScript issues unrelated to this change (missing imports / existing type errors in other files), so the build failure is not caused by these edits.
- Started the dev server and validated the new pages by loading `http://localhost:4173/table` and capturing a screenshot with an automated Playwright script which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f125fe5c88323a2a3b0e43ad3e4a9)