### PR TITLE
Improve invoice table readability with updated Dates column and header contrast

### DIFF
--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -85,7 +85,7 @@ export function Table<T extends object>({ schema, data }: TableProps<T>) {
     return (
         <div className="overflow-hidden rounded-md border">
             <UITable>
-                <TableHeader>
+                <TableHeader className="bg-muted/50">
                     {table.getHeaderGroups().map((headerGroup) => (
                         <TableRow key={headerGroup.id}>
                             {headerGroup.headers.map((header) => {

--- a/web/src/lib/example-data.ts
+++ b/web/src/lib/example-data.ts
@@ -68,9 +68,9 @@ export const sampleTableSchema: TableSchemaConfig = {
             },
             {
                 key: 'dueDate',
-                label: 'Due Date',
+                label: 'Dates',
                 align: 'left',
-                cell: ['{dueDate}'],
+                cell: ['{issueDate}', 'Due date: {dueDate}'],
             },
             {
                 key: 'amount',

--- a/web/src/pages/Example.tsx
+++ b/web/src/pages/Example.tsx
@@ -70,9 +70,9 @@ const sampleTableSchema: TableSchemaConfig = {
             },
             {
                 key: 'dueDate',
-                label: 'Due Date',
+                label: 'Dates',
                 align: 'left',
-                cell: ['{dueDate}'],
+                cell: ['{issueDate}', 'Due date: {dueDate}'],
             },
             {
                 key: 'amount',


### PR DESCRIPTION
### Motivation
- Improve visual separation between table header and body so column headings are more visible.
- Rename the `Due Date` column to `Dates` to surface both issue and due dates together.
- Show the invoice `issueDate` first and display the `dueDate` as a second line labeled `Due date:` for clarity.

### Description
- Add `className="bg-muted/50"` to `TableHeader` in `web/src/components/viavai/Table.tsx` to give the header a muted background. 
- Update the table schema in `web/src/lib/example-data.ts` to rename the `dueDate` column label to `Dates` and change the `cell` to `['{issueDate}', 'Due date: {dueDate}']`.
- Apply the same schema change in `web/src/pages/Example.tsx` so the example page matches the shared sample data definition.

### Testing
- Ran formatter with `bun run format` (in `web/`) which completed successfully.
- Attempted production build with `bun run build` (in `web/`) which failed due to pre-existing TypeScript issues unrelated to these changes.
- Started the dev server and captured a screenshot of the updated `/example` view to validate the visual changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f169d9a048323a25dbecb4e50ca2c)