### PR TITLE
Add reusable viavai Hero component and use it on Table page

### DIFF
--- a/web/src/components/viavai/Hero.tsx
+++ b/web/src/components/viavai/Hero.tsx
@@ -1,0 +1,34 @@
+import { type LucideIcon } from 'lucide-react';
+import { type ReactNode } from 'react';
+
+type HeroProps = {
+    title: string;
+    subtitle?: string;
+    icon?: LucideIcon;
+    element?: ReactNode;
+};
+
+export function Hero({ title, subtitle, icon: Icon, element }: HeroProps) {
+    return (
+        <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex items-start gap-3">
+                {Icon ? (
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
+                        <Icon className="h-5 w-5" />
+                    </div>
+                ) : null}
+                <div>
+                    <h2 className="text-lg font-semibold text-white">
+                        {title}
+                    </h2>
+                    {subtitle ? (
+                        <p className="text-sm text-white/60">{subtitle}</p>
+                    ) : null}
+                </div>
+            </div>
+            {element ? <div>{element}</div> : null}
+        </div>
+    );
+}
+
+export default Hero;

--- a/web/src/pages/Table.tsx
+++ b/web/src/pages/Table.tsx
@@ -1,6 +1,24 @@
+import { Plus, TableProperties } from 'lucide-react';
+import { Hero } from '@/components/viavai/Hero';
 import { Table } from '@/components/viavai/Table';
+import { Button } from '@/components/ui/button';
 import { sampleTableData, sampleTableSchema } from '@/lib/example-data';
 
 export default function TablePage() {
-    return <Table schema={sampleTableSchema} data={sampleTableData} />;
+    return (
+        <div className="space-y-6">
+            <Hero
+                title={sampleTableSchema.title}
+                subtitle={sampleTableSchema.description}
+                icon={TableProperties}
+                element={
+                    <Button type="button" variant="outline">
+                        <Plus className="h-4 w-4" />
+                        New Invoice
+                    </Button>
+                }
+            />
+            <Table schema={sampleTableSchema} data={sampleTableData} />
+        </div>
+    );
 }


### PR DESCRIPTION
### Motivation
- Provide a reusable header/hero block for viavai pages that mirrors the Organizations header layout and supports a right-side action slot. 
- Make it easy to surface a `title`, optional `subtitle` and `icon`, and inject any JSX action (`element`) on the right. 

### Description
- Added a new `Hero` component at `web/src/components/viavai/Hero.tsx` that accepts `title`, optional `subtitle`, optional `icon` (a `LucideIcon`) and optional `element` (`ReactNode`) and renders the Organizations-style header layout. 
- Updated the example Table page at `web/src/pages/Table.tsx` to render `Hero` above the example `Table` using `sampleTableSchema.title` and `sampleTableSchema.description`, and added a sample right-side `New Invoice` `Button` to demonstrate the `element` slot. 
- Styling uses the existing Tailwind/shadcn utility classes to match the app look-and-feel.

### Testing
- Ran formatting in `web` with `bun run format`, which completed successfully. 
- Started the dev server (`vite`) and loaded `/table`, then captured a UI screenshot of the new Hero + Table layout (visual verification succeeded). 
- Ran a build check `bun run build` which failed due to pre-existing TypeScript issues in unrelated files (these errors are not caused by the `Hero` addition).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1a9859c48323b4932fdf7ff771e4)