### PR TITLE
Add schema-driven ViaVai Sidebar and integrate into /form example

### DIFF
--- a/web/src/components/viavai/Sidebar.tsx
+++ b/web/src/components/viavai/Sidebar.tsx
@@ -1,0 +1,87 @@
+import { useMemo, useState } from 'react';
+import { type LucideIcon, Bell, Palette, UserRound } from 'lucide-react';
+import {
+    type SidebarSchemaConfig,
+    type SidebarItem,
+} from '@/types/viavai/sidebar.types';
+
+const iconRegistry: Record<string, LucideIcon> = {
+    profile: UserRound,
+    appearance: Palette,
+    notifications: Bell,
+};
+
+type SidebarProps = {
+    schema: SidebarSchemaConfig;
+    activeItem?: string;
+};
+
+function SidebarRow({
+    item,
+    active,
+    onClick,
+}: {
+    item: SidebarItem;
+    active: boolean;
+    onClick: () => void;
+}) {
+    const Icon = iconRegistry[item.icon.toLowerCase()] ?? Bell;
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm font-medium transition-colors ${
+                active
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+            }`}
+        >
+            <Icon className="h-4 w-4" />
+            <span>{item.name}</span>
+        </button>
+    );
+}
+
+export function Sidebar({ schema, activeItem }: SidebarProps) {
+    const fallbackActive = schema.items.at(0)?.name ?? '';
+    const [selectedName, setSelectedName] = useState(
+        activeItem ?? fallbackActive
+    );
+
+    const selectedItem = useMemo(() => {
+        return (
+            schema.items.find((item) => item.name === selectedName) ??
+            schema.items.at(0)
+        );
+    }, [schema.items, selectedName]);
+
+    return (
+        <div className="grid gap-6 md:grid-cols-[240px_1fr]">
+            <aside className="w-full space-y-5 rounded-lg border bg-card p-3">
+                {schema.title ? (
+                    <h2 className="px-2 text-sm font-semibold tracking-tight">
+                        {schema.title}
+                    </h2>
+                ) : null}
+
+                <div className="space-y-1">
+                    {schema.items.map((item) => (
+                        <SidebarRow
+                            key={item.name}
+                            item={item}
+                            active={item.name === selectedName}
+                            onClick={() => setSelectedName(item.name)}
+                        />
+                    ))}
+                </div>
+            </aside>
+
+            <section className="space-y-4 rounded-lg border bg-card p-4 sm:p-6">
+                {selectedItem?.element}
+            </section>
+        </div>
+    );
+}
+
+export default Sidebar;

--- a/web/src/lib/example-data.ts
+++ b/web/src/lib/example-data.ts
@@ -1,4 +1,5 @@
 import { type Component } from '@/types/viavai/form.types';
+import { type SidebarSchemaConfig } from '@/types/viavai/sidebar.types';
 import { type TableSchemaConfig } from '@/types/viavai/table.types';
 
 export const sampleFormSchema: Component[] = [
@@ -110,3 +111,24 @@ export const sampleTableData: ExampleInvoice[] = [
         vat: 90,
     },
 ];
+
+export const sampleSidebarSchema: SidebarSchemaConfig = {
+    title: 'Settings',
+    items: [
+        {
+            name: 'Profile',
+            icon: 'profile',
+            element: null,
+        },
+        {
+            name: 'Appearance',
+            icon: 'appearance',
+            element: null,
+        },
+        {
+            name: 'Notifications',
+            icon: 'notifications',
+            element: null,
+        },
+    ],
+};

--- a/web/src/pages/Form.tsx
+++ b/web/src/pages/Form.tsx
@@ -1,6 +1,89 @@
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { Form } from '@/components/viavai/Form';
-import { sampleFormSchema } from '@/lib/example-data';
+import { Sidebar } from '@/components/viavai/Sidebar';
+import {
+    sampleFormSchema,
+    sampleSidebarSchema,
+    sampleTableData,
+    sampleTableSchema,
+} from '@/lib/example-data';
+import { Table } from '@/components/viavai/Table';
 
 export default function FormPage() {
-    return <Form schema={sampleFormSchema} />;
+    const schema = {
+        ...sampleSidebarSchema,
+        items: sampleSidebarSchema.items.map((item) => {
+            if (item.name === 'Notifications') {
+                return {
+                    ...item,
+                    element: (
+                        <div className="space-y-6">
+                            <div>
+                                <h2 className="text-2xl font-semibold">
+                                    Notification preferences
+                                </h2>
+                                <p className="text-muted-foreground mt-1 text-sm">
+                                    Choose how you want to stay informed.
+                                </p>
+                            </div>
+
+                            <div className="space-y-4 rounded-lg border p-4">
+                                <h3 className="text-xl font-semibold">
+                                    In-app alerts
+                                </h3>
+
+                                <div className="flex items-center justify-between gap-4">
+                                    <div>
+                                        <p className="font-medium">
+                                            Mentions & assignments
+                                        </p>
+                                        <p className="text-muted-foreground text-sm">
+                                            Get notified when you are tagged.
+                                        </p>
+                                    </div>
+                                    <Switch defaultChecked />
+                                </div>
+
+                                <div className="flex items-center justify-between gap-4">
+                                    <div>
+                                        <p className="font-medium">
+                                            Workflow updates
+                                        </p>
+                                        <p className="text-muted-foreground text-sm">
+                                            Alerts for automation status.
+                                        </p>
+                                    </div>
+                                    <Switch />
+                                </div>
+                            </div>
+
+                            <div className="space-y-4 rounded-lg border p-4">
+                                <h3 className="text-xl font-semibold">
+                                    Notification schedule
+                                </h3>
+                                <p className="text-muted-foreground text-sm">
+                                    Set quiet hours for alerts.
+                                </p>
+                                <Input defaultValue="22:00 - 07:00" />
+                            </div>
+                        </div>
+                    ),
+                };
+            }
+
+            if (item.name === 'Profile') {
+                return { ...item, element: <Form schema={sampleFormSchema} /> };
+            }
+
+            return {
+                ...item,
+                element: (
+                    <Table schema={sampleTableSchema} data={sampleTableData} />
+                ),
+            };
+        }),
+    };
+
+    return <Sidebar schema={schema} activeItem="Notifications" />;
 }

--- a/web/src/types/viavai/sidebar.types.ts
+++ b/web/src/types/viavai/sidebar.types.ts
@@ -1,0 +1,12 @@
+import { type ReactNode } from 'react';
+
+export type SidebarItem = {
+    name: string;
+    icon: string;
+    element: ReactNode;
+};
+
+export type SidebarSchemaConfig = {
+    title?: string;
+    items: SidebarItem[];
+};


### PR DESCRIPTION
### Motivation
- Provide a reusable, schema-driven sidebar component for ViaVai apps that can render a list of items (`name`, `icon`, `element`) and display the selected item's content panel. 
- Demonstrate the sidebar usage in the existing `/form` example so the component is available as a reference for app UI patterns.

### Description
- Added a new `Sidebar` component at `web/src/components/viavai/Sidebar.tsx` that renders items, supports click selection, highlights the active item, and shows the selected `element` in a content panel. 
- Introduced types `SidebarItem` and `SidebarSchemaConfig` in `web/src/types/viavai/sidebar.types.ts` to match the schema-first pattern used by other Viavai components. 
- Added `sampleSidebarSchema` to `web/src/lib/example-data.ts` and wired the schema into `web/src/pages/Form.tsx`, where the Notifications tab renders a small notification-preferences layout and other tabs reuse the existing `Form` and `Table` examples. 
- Used `lucide-react` icons via a small `iconRegistry` and preserved styling consistent with existing shadcn UI classes.

### Testing
- Ran formatter with `bun run format`, which completed successfully. 
- Ran targeted lint checks with `bunx eslint` on the changed files, which passed. 
- Attempted a full build with `bun run build`, which failed due to unrelated pre-existing TypeScript issues in other files (not caused by these changes). 
- Started the dev server and captured an automated screenshot of `http://localhost:4173/form` to validate the sidebar rendering (Playwright script executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f39ba72f083238e19dcc52aed19a4)