### PR TITLE
style(web): align ViaVai sidebar with profile navigation

### DIFF
--- a/web/src/components/viavai/Sidebar.tsx
+++ b/web/src/components/viavai/Sidebar.tsx
@@ -33,11 +33,13 @@ function SidebarRow({
             onClick={onClick}
             className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm font-medium transition-colors ${
                 active
-                    ? 'bg-muted text-foreground'
-                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+                    ? 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(255,255,255,0.75)]'
+                    : 'text-white/70 hover:bg-white/5 hover:text-white'
             }`}
         >
-            <Icon className="h-4 w-4" />
+            <Icon
+                className={`h-4 w-4 ${active ? 'text-white' : 'text-white/70'}`}
+            />
             <span>{item.name}</span>
         </button>
     );
@@ -58,9 +60,9 @@ export function Sidebar({ schema, activeItem }: SidebarProps) {
 
     return (
         <div className="grid gap-6 md:grid-cols-[240px_1fr]">
-            <aside className="w-full space-y-5 rounded-lg border bg-card p-3">
+            <aside className="w-full space-y-5 rounded-lg border border-white/10 bg-zinc-950/60 p-4">
                 {schema.title ? (
-                    <h2 className="px-2 text-sm font-semibold tracking-tight">
+                    <h2 className="px-2 text-sm font-semibold tracking-tight text-white">
                         {schema.title}
                     </h2>
                 ) : null}


### PR DESCRIPTION
### Motivation
- Make the ViaVai module sidebar visually consistent with the `/profile` settings panel so the app feels cohesive across the product.

### Description
- Updated `web/src/components/viavai/Sidebar.tsx` to use the same active/inactive button styles and icon color behavior as the `/profile` sidebar, and adjusted the sidebar container classes (border, background, padding, and title text color) to match the profile panel look.

### Testing
- Ran `bun run format` in `web` which completed successfully.
- Ran `bun run build` which failed due to pre-existing TypeScript errors in unrelated files and not because of these styling changes.
- Launched the dev server and captured an automated Playwright screenshot of `/form` showing the updated sidebar styling which validated the visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69906a32f848832398fffe6acfd879fb)