### PR TITLE
style(web): remove card wrappers from ViaVai settings sidebar layout

### DIFF
--- a/web/src/components/viavai/Sidebar.tsx
+++ b/web/src/components/viavai/Sidebar.tsx
@@ -60,13 +60,7 @@ export function Sidebar({ schema, activeItem }: SidebarProps) {
 
     return (
         <div className="grid gap-6 md:grid-cols-[240px_1fr]">
-            <aside className="w-full space-y-5 rounded-lg border border-white/10 bg-zinc-950/60 p-4">
-                {schema.title ? (
-                    <h2 className="px-2 text-sm font-semibold tracking-tight text-white">
-                        {schema.title}
-                    </h2>
-                ) : null}
-
+            <aside className="w-full">
                 <div className="space-y-1">
                     {schema.items.map((item) => (
                         <SidebarRow
@@ -79,7 +73,7 @@ export function Sidebar({ schema, activeItem }: SidebarProps) {
                 </div>
             </aside>
 
-            <section className="space-y-4 rounded-lg border bg-card p-4 sm:p-6">
+            <section className="space-y-4 p-4 sm:p-6">
                 {selectedItem?.element}
             </section>
         </div>


### PR DESCRIPTION
### Motivation
- Simplify the ViaVai settings layout by removing the card/bordered chrome so the sidebar and content panel sit flush with the page background, matching the requested visual change.

### Description
- Updated `web/src/components/viavai/Sidebar.tsx` to remove the bordered/card wrapper around the left sidebar by deleting the rounded/border/background/padding container classes and the title block inside it.
- Updated the right content pane in the same file to remove `rounded-lg border bg-card` leaving only spacing and padding classes (`space-y-4 p-4 sm:p-6`).
- Preserved the sidebar item rendering and click interactions, and kept the selected content injection (`selectedItem?.element`) unchanged.

### Testing
- Ran `bun run format` in `web/` which completed successfully.
- Attempted `bun run build`; build failed due to pre-existing TypeScript errors in unrelated files, so no production build was produced (errors are outside the touched file).
- Started the dev server (`bun run dev --host 0.0.0.0 --port 4173`) and captured a screenshot of `/form` to validate the visual change showing the sidebar without card wrappers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699078af3c688323bafe0612f176c5fb)