### PR TITLE
Refactor sample page response to use BaseModel components

### DIFF
--- a/api/src/routes/sample.py
+++ b/api/src/routes/sample.py
@@ -1,21 +1,21 @@
 from src.router import router
-from src.types.sample import PageSampleResponse
+from src.types.sample import Hero, Page
 
 
 # A LongLink page takes a URL, with filders and stuff. If is not possible to show in a single page then the content is too complex
 # Each POST request from the page shall automatically re-render the page. Given that we assume new data has come
-@router.get('/sample/form', response_model=PageSampleResponse)
+@router.get('/sample/form', response_model=Page)
 async def form():
     """Return an example page schema payload with a hero component."""
 
-    return PageSampleResponse(
+    return Page(
         title='Sample page',
         description='Sample page schema with a hero section.',
         components=[
-            {
-                'title': 'Welcome to VaiVai',
-                'description': 'Build modular apps for your organization with one click.',
-                'icon': 'rocket',
-            }
+            Hero(
+                title='Welcome to VaiVai',
+                description='Build modular apps for your organization with one click.',
+                icon='rocket',
+            )
         ],
     )

--- a/api/src/types/sample.py
+++ b/api/src/types/sample.py
@@ -1,14 +1,23 @@
-from pydantic import BaseModel
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
 
 
-class HeroComponent(BaseModel):
-    type: str = 'hero'
+class Component(BaseModel):
+    type: str
+
+
+class Hero(Component):
+    type: Literal['hero'] = 'hero'
     title: str
     description: str
     icon: str | None = None
 
 
-class PageSampleResponse(BaseModel):
+PageComponent = Annotated[Hero, Field(discriminator='type')]
+
+
+class Page(BaseModel):
     title: str
     description: str
-    components: list[HeroComponent]
+    components: list[PageComponent]


### PR DESCRIPTION
### Motivation
- Convert page UI primitives into proper Pydantic models so page responses are typed as lists of components for easier validation and extension. 
- Replace the one-off `HeroComponent` mapping with a component model hierarchy to support multiple component types in the future.
- Make the sample `/sample/form` endpoint return a `Page` model composed of component instances rather than raw dicts.

### Description
- Replaced `HeroComponent` with a component model hierarchy in `api/src/types/sample.py` by adding `Component` (base), `Hero` (concrete component), `PageComponent = Annotated[Hero, Field(discriminator='type')]`, and `Page` `BaseModel` with `components: list[PageComponent]`.
- Updated `api/src/routes/sample.py` to use `response_model=Page` and to construct and return a `Hero` instance inside the `Page.components` list instead of a raw dict.
- Used a discriminated annotated type (`Field(discriminator='type')`) so parsing of heterogeneous component lists will resolve concrete component models.

### Testing
- Ran `python -m compileall api/src/types/sample.py api/src/routes/sample.py` which completed successfully.
- Executed a manual validation script that calls `Page.model_validate(payload)` with a payload containing a hero component and confirmed the parsed component is a `Hero` and the dumped model matches the expected schema.
- No automated unit tests were modified; the above validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990885c70bc832395a8487d27fe33f3)