### PR TITLE
web: fetch /sample/page on ViaVai page and render JSON

### DIFF
--- a/web/src/pages/ViaVai.tsx
+++ b/web/src/pages/ViaVai.tsx
@@ -1,4 +1,32 @@
-// Dynamic page, handle the generation of the application layout
+import { useEffect, useState } from 'react';
+
+import { apiFetch } from '@/lib/api';
+
 export default function ViaVai() {
-    return <h1>ViaVai Module Home</h1>;
+    const [samplePageData, setSamplePageData] = useState<unknown>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadSamplePage = async () => {
+            try {
+                const data = await apiFetch<unknown>('/sample/page');
+                if (!isMounted) return;
+                setSamplePageData(data);
+            } catch (requestError) {
+                if (!isMounted) return;
+                setError('Failed to load /sample/page');
+                console.error(requestError);
+            }
+        };
+
+        loadSamplePage();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    return <div>{error ? error : JSON.stringify(samplePageData)}</div>;
 }


### PR DESCRIPTION
### Motivation
- Enable the ViaVai module page to retrieve sample content from the backend and show it to the user for quick verification of app data. 
- Reuse the shared API helper to keep network requests consistent with the rest of the frontend.

### Description
- Updated `web/src/pages/ViaVai.tsx` to import `apiFetch` and React hooks (`useEffect`, `useState`).
- Added a `useEffect` that calls `apiFetch('/sample/page')` on mount, stores the response in state, and guards with an `isMounted` flag.
- Render the fetched JSON directly as a flat string via `JSON.stringify(...)` inside a `<div>`, and show a simple error message `Failed to load /sample/page` on failure.

### Testing
- Ran formatter with `bun run format` in `web`, which completed successfully.  
- Attempted a production build with `bun run build` in `web`, which failed due to pre-existing TypeScript errors in unrelated files (for example `src/components/Test.tsx`, `src/components/ui/resizable.tsx`, and `src/components/ui/sidebar.tsx`).
- Started the dev server (`bun run dev`) and captured an automated screenshot of the ViaVai route to validate the runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699088c3a2d0832386f1eac79bbd8e6a)