### PR TITLE
Render ViaVai hero elements based on API element type

### DIFF
--- a/web/src/pages/ViaVai.tsx
+++ b/web/src/pages/ViaVai.tsx
@@ -1,9 +1,29 @@
 import { useEffect, useState } from 'react';
 
+import { Hero } from '@/components/viavai/Hero';
 import { apiFetch } from '@/lib/api';
 
+type HeroElement = {
+    type: string;
+    title: string;
+    subtitle?: string | null;
+};
+
+function isHeroElement(element: unknown): element is HeroElement {
+    if (!element || typeof element !== 'object') {
+        return false;
+    }
+
+    const candidate = element as Record<string, unknown>;
+    return (
+        typeof candidate.type === 'string' &&
+        candidate.type.toLowerCase() === 'hero' &&
+        typeof candidate.title === 'string'
+    );
+}
+
 export default function ViaVai() {
-    const [samplePageData, setSamplePageData] = useState<unknown>(null);
+    const [samplePageData, setSamplePageData] = useState<unknown[]>([]);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
@@ -13,7 +33,13 @@ export default function ViaVai() {
             try {
                 const data = await apiFetch<unknown>('/sample/page');
                 if (!isMounted) return;
-                setSamplePageData(data);
+
+                if (Array.isArray(data)) {
+                    setSamplePageData(data);
+                } else {
+                    setSamplePageData([]);
+                    setError('Unexpected response format for /sample/page');
+                }
             } catch (requestError) {
                 if (!isMounted) return;
                 setError('Failed to load /sample/page');
@@ -28,5 +54,25 @@ export default function ViaVai() {
         };
     }, []);
 
-    return <div>{error ? error : JSON.stringify(samplePageData)}</div>;
+    if (error) {
+        return <div>{error}</div>;
+    }
+
+    return (
+        <div className="space-y-4">
+            {samplePageData.map((element, index) => {
+                if (isHeroElement(element)) {
+                    return (
+                        <Hero
+                            key={`hero-${index}`}
+                            title={element.title}
+                            subtitle={element.subtitle ?? undefined}
+                        />
+                    );
+                }
+
+                return null;
+            })}
+        </div>
+    );
 }


### PR DESCRIPTION
### Motivation
- The ViaVai page should interpret page schema elements from the API and render the HERO component when an element has `type: "hero"` so the frontend matches the server-provided UI schema.

### Description
- Import and use the shared `Hero` component in `web/src/pages/ViaVai.tsx` to render hero elements.
- Add a `HeroElement` type and an `isHeroElement` type guard that detects `type === 'hero'` (case-insensitive) and requires a `title` field.
- Treat the `/sample/page` response as an array of page elements and validate the shape, setting a user-facing error when the payload is not an array.
- Map array elements to render `Hero` components for hero elements and ignore unknown element types.

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bun run build` which failed due to pre-existing unrelated TypeScript issues in other files and not due to this change.
- Started the API and frontend dev server and ran a Playwright script to capture a screenshot which shows the ViaVai page rendering the hero element from the API payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908b3dfe0c8323988330d167b92436)