### PR TITLE
web: move landing and legal pages under /home namespace

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,14 +4,14 @@ import { RouterProvider, createBrowserRouter } from 'react-router';
 import Layout from '@/Layout';
 
 // Import pages
-import Home from '@/pages/Home';
+import Home from '@/pages/home/Home';
 import Login from '@/pages/user/Login';
 import Profile from '@/pages/user/Profile';
 import Developer from '@/pages/Developer';
 import Organizations from '@/pages/user/Organizations';
-import Privacy from '@/pages/Privacy';
-import Tos from '@/pages/Tos';
-import Impressum from '@/pages/Impressum';
+import Privacy from '@/pages/home/Privacy';
+import Tos from '@/pages/home/Tos';
+import Impressum from '@/pages/home/Impressum';
 import NotFound from '@/pages/NotFound';
 
 // Organization related pages
@@ -27,10 +27,11 @@ import FormPage from '@/pages/Form';
 
 const router = createBrowserRouter([
     { path: '/', element: <Home /> },
+    { path: '/home', element: <Home /> },
     { path: '/login', element: <Login /> },
-    { path: '/privacy', element: <Privacy /> },
-    { path: '/terms', element: <Tos /> },
-    { path: '/impressum', element: <Impressum /> },
+    { path: '/home/privacy', element: <Privacy /> },
+    { path: '/home/tos', element: <Tos /> },
+    { path: '/home/impressum', element: <Impressum /> },
     {
         path: '/profile',
         element: <Layout />,

--- a/web/src/pages/home/Home.tsx
+++ b/web/src/pages/home/Home.tsx
@@ -297,13 +297,19 @@ export default function Home() {
                             © 2026 LongLink SAGL. All rights reserved.
                         </div>
                         <div className="flex gap-6">
-                            <Link to="/privacy" className="hover:text-white">
+                            <Link
+                                to="/home/privacy"
+                                className="hover:text-white"
+                            >
                                 Privacy
                             </Link>
-                            <Link to="/terms" className="hover:text-white">
+                            <Link to="/home/tos" className="hover:text-white">
                                 Terms
                             </Link>
-                            <Link to="/impressum" className="hover:text-white">
+                            <Link
+                                to="/home/impressum"
+                                className="hover:text-white"
+                            >
                                 Impressum
                             </Link>
                         </div>

--- a/web/src/pages/home/Impressum.tsx
+++ b/web/src/pages/home/Impressum.tsx
@@ -2,42 +2,36 @@ import { Link } from 'react-router';
 
 import { Card, CardContent } from '@/components/ui/card';
 
-export default function Tos() {
+export default function Impressum() {
     return (
         <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
             <Card className="w-full max-w-2xl border-white/10 bg-white/5">
                 <CardContent className="space-y-6 p-8">
                     <div className="space-y-2">
                         <p className="text-xs uppercase tracking-[0.2em] text-white/60">
-                            Terms &amp; Conditions
+                            Impressum
                         </p>
                         <h1 className="text-3xl font-semibold">
-                            Terms of service
+                            Company information
                         </h1>
                         <p className="text-sm text-white/70">
-                            These terms govern your use of LongLink and ViaVai.
-                            By accessing the platform, you agree to comply with
-                            organization policies, app licensing, and data
-                            governance requirements.
+                            LongLink SAGL is registered in Switzerland and
+                            operates the ViaVai platform. This page provides the
+                            required company details and contact information.
                         </p>
                     </div>
-                    <div className="space-y-3 text-sm text-white/70">
+                    <div className="space-y-2 text-sm text-white/70">
+                        <p>LongLink SAGL</p>
+                        <p>Via Industria 21, 6900 Lugano, Switzerland</p>
                         <p>
-                            You are responsible for maintaining the
-                            confidentiality of your account and for all
-                            activities that occur under your credentials.
-                        </p>
-                        <p>
-                            If you need a copy of the full agreement, please
-                            contact{' '}
+                            Email:{' '}
                             <span className="text-white">
-                                legal@longlink.com
+                                info@longlink.com
                             </span>
-                            .
                         </p>
                     </div>
                     <Link
-                        to="/"
+                        to="/home"
                         className="text-sm text-blue-300 hover:underline"
                     >
                         Back to home

--- a/web/src/pages/home/Privacy.tsx
+++ b/web/src/pages/home/Privacy.tsx
@@ -36,7 +36,7 @@ export default function Privacy() {
                         </p>
                     </div>
                     <Link
-                        to="/"
+                        to="/home"
                         className="text-sm text-blue-300 hover:underline"
                     >
                         Back to home

--- a/web/src/pages/home/Tos.tsx
+++ b/web/src/pages/home/Tos.tsx
@@ -2,36 +2,42 @@ import { Link } from 'react-router';
 
 import { Card, CardContent } from '@/components/ui/card';
 
-export default function Impressum() {
+export default function Tos() {
     return (
         <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
             <Card className="w-full max-w-2xl border-white/10 bg-white/5">
                 <CardContent className="space-y-6 p-8">
                     <div className="space-y-2">
                         <p className="text-xs uppercase tracking-[0.2em] text-white/60">
-                            Impressum
+                            Terms &amp; Conditions
                         </p>
                         <h1 className="text-3xl font-semibold">
-                            Company information
+                            Terms of service
                         </h1>
                         <p className="text-sm text-white/70">
-                            LongLink SAGL is registered in Switzerland and
-                            operates the ViaVai platform. This page provides the
-                            required company details and contact information.
+                            These terms govern your use of LongLink and ViaVai.
+                            By accessing the platform, you agree to comply with
+                            organization policies, app licensing, and data
+                            governance requirements.
                         </p>
                     </div>
-                    <div className="space-y-2 text-sm text-white/70">
-                        <p>LongLink SAGL</p>
-                        <p>Via Industria 21, 6900 Lugano, Switzerland</p>
+                    <div className="space-y-3 text-sm text-white/70">
                         <p>
-                            Email:{' '}
+                            You are responsible for maintaining the
+                            confidentiality of your account and for all
+                            activities that occur under your credentials.
+                        </p>
+                        <p>
+                            If you need a copy of the full agreement, please
+                            contact{' '}
                             <span className="text-white">
-                                info@longlink.com
+                                legal@longlink.com
                             </span>
+                            .
                         </p>
                     </div>
                     <Link
-                        to="/"
+                        to="/home"
                         className="text-sm text-blue-300 hover:underline"
                     >
                         Back to home


### PR DESCRIPTION
### Motivation
- Group public landing and legal pages under a dedicated `/home` namespace and directory to keep public pages organized and aligned with the requested `/pages/home` structure.

### Description
- Moved `Home`, `Privacy`, `Impressum`, and `Tos` into `web/src/pages/home/` and updated their internal links to point back to `/home`.
- Updated `web/src/App.tsx` imports to the new file locations, added an explicit `/home` route, and moved legal routes to `/home/privacy`, `/home/tos`, and `/home/impressum`.
- Updated the footer links on the landing page and the "Back to home" links in the legal pages to use the new `/home/*` routes.
- Ran code formatting with `bun run format` to apply style changes.

### Testing
- `cd web && bun run format` ran successfully and formatted affected files.
- `cd web && bun run build` was attempted but failed due to pre-existing TypeScript issues in unrelated files (errors reported but not caused by this change).
- `cd web && bun run dev --host 0.0.0.0 --port 4173` was used to verify the `/home` page manually and a screenshot was captured for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908db86c108323b08f6db7d6624e0e)