### PR TITLE
web: make home hero fill initial viewport

### DIFF
--- a/web/src/pages/home/Home.tsx
+++ b/web/src/pages/home/Home.tsx
@@ -26,7 +26,7 @@ export default function Home() {
     return (
         <div className="min-h-screen text-white">
             <div className="relative">
-                <div className="flex min-h-[1080px] flex-col">
+                <div className="flex min-h-screen flex-col">
                     <header className="border-b border-white/10">
                         <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
                             <div className="flex items-center gap-3">
@@ -48,7 +48,10 @@ export default function Home() {
                     </header>
 
                     <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 pb-20 pt-16">
-                        <section className="text-center" id="overview">
+                        <section
+                            className="flex min-h-[calc(100vh-81px)] items-center justify-center text-center"
+                            id="overview"
+                        >
                             <div className="mx-auto max-w-3xl">
                                 <p className="mb-3 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs text-white/70">
                                     <Sparkles className="h-3.5 w-3.5 text-blue-400" />


### PR DESCRIPTION
### Motivation
- Ensure the landing page hero fills the initial browser viewport on normal desktop screens so users must scroll to reach subsequent sections.

### Description
- Updated `web/src/pages/home/Home.tsx` to replace the fixed pixel wrapper `min-h-[1080px]` with `min-h-screen` and changed the `#overview` hero to `className="flex min-h-[calc(100vh-81px)] items-center justify-center text-center"` to occupy the available viewport under the header and center content vertically.

### Testing
- Ran formatting with `bun run format`, which completed successfully.
- Ran `bun run build`, which failed due to pre-existing unrelated TypeScript errors in other files (not caused by this change).
- Launched the dev server (`bun run dev`) and captured a full-page screenshot of the updated hero successfully via an automated Playwright script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c147182c8323939b0474c93a9b97)