### PR TITLE
Add reusable useData hook and adopt it in org ViaVai page

### DIFF
--- a/web/src/hooks/use-data.ts
+++ b/web/src/hooks/use-data.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { apiFetch } from '@/lib/api';
+
+type UseDataResult<T> = {
+    data: T | null;
+    isLoading: boolean;
+    error: string | null;
+    refresh: () => Promise<void>;
+};
+
+export function useData<T>(endpoint: string): UseDataResult<T> {
+    const [data, setData] = useState<T | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const refresh = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const response = await apiFetch<T>(endpoint);
+            setData(response);
+        } catch (err) {
+            setError(
+                err instanceof Error
+                    ? err.message
+                    : `Failed to load ${endpoint}`
+            );
+            setData(null);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [endpoint]);
+
+    useEffect(() => {
+        void refresh();
+    }, [refresh]);
+
+    return useMemo(
+        () => ({
+            data,
+            isLoading,
+            error,
+            refresh,
+        }),
+        [data, isLoading, error, refresh]
+    );
+}

--- a/web/src/pages/org/ViaVai.tsx
+++ b/web/src/pages/org/ViaVai.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from 'react';
-
 import { Hero } from '@/components/viavai/Hero';
 import { Table } from '@/components/viavai/Table';
-import { apiFetch } from '@/lib/api';
+import { useData } from '@/hooks/use-data';
 import { type TableSchemaConfig } from '@/types/viavai/table.types';
 
 type HeroElement = {
@@ -66,39 +64,20 @@ function isHeroElement(element: unknown): element is HeroElement {
 }
 
 export default function ViaVai() {
-    const [samplePageData, setSamplePageData] = useState<unknown[]>([]);
-    const [error, setError] = useState<string | null>(null);
+    const { data, isLoading, error } = useData<unknown>('/sample/page');
 
-    useEffect(() => {
-        let isMounted = true;
-
-        const loadSamplePage = async () => {
-            try {
-                const data = await apiFetch<unknown>('/sample/page');
-                if (!isMounted) return;
-
-                if (Array.isArray(data)) {
-                    setSamplePageData(data);
-                } else {
-                    setSamplePageData([]);
-                    setError('Unexpected response format for /sample/page');
-                }
-            } catch (requestError) {
-                if (!isMounted) return;
-                setError('Failed to load /sample/page');
-                console.error(requestError);
-            }
-        };
-
-        loadSamplePage();
-
-        return () => {
-            isMounted = false;
-        };
-    }, []);
+    const samplePageData = Array.isArray(data) ? data : [];
 
     if (error) {
         return <div>{error}</div>;
+    }
+
+    if (isLoading) {
+        return <div>Loading...</div>;
+    }
+
+    if (data !== null && !Array.isArray(data)) {
+        return <div>Unexpected response format for /sample/page</div>;
     }
 
     return (


### PR DESCRIPTION
### Motivation

- Consolidate endpoint fetching into a reusable hook to avoid repeating `useEffect`/`useState` fetch logic across pages.
- Make the org ViaVai page cleaner by delegating data loading and common states (loading/error) to a hook.

### Description

- Added a new hook `useData` at `web/src/hooks/use-data.ts` that wraps `apiFetch` and exposes `{ data, isLoading, error, refresh }` for a given endpoint.
- Replaced the inline fetch logic in `web/src/pages/org/ViaVai.tsx` with `useData('/sample/page')` and adapted the component to use the hook's `isLoading` and `error` states.
- Preserved response-shape validation in `ViaVai.tsx` by ensuring the returned `data` is an array before mapping and rendering `Hero`/`Table` elements.

### Testing

- Ran formatting with `bun run format`, which completed successfully.
- Ran the build/type-check with `bun run build`, which failed due to pre-existing unrelated TypeScript errors in other files (e.g., `src/components/Test.tsx`, `src/components/ui/resizable.tsx`, and missing imports in `src/pages/org/Organization.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c7099de883238d85b7ca219da7d1)