### PR TITLE
Add ViaVai layout renderer with columns support

### DIFF
--- a/web/src/components/viavai/Columns.tsx
+++ b/web/src/components/viavai/Columns.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react';
+
+type ColumnsProps = {
+    widths: number[];
+    children: ReactNode[];
+};
+
+function toGridTemplate(widths: number[]) {
+    if (widths.length === 0) {
+        return '1fr';
+    }
+
+    const total = widths.reduce((sum, width) => sum + width, 0);
+
+    if (total <= 0) {
+        return `repeat(${widths.length}, minmax(0, 1fr))`;
+    }
+
+    return widths
+        .map((width) => `minmax(0, ${(width / total) * 100}%)`)
+        .join(' ');
+}
+
+export function Columns({ widths, children }: ColumnsProps) {
+    return (
+        <div
+            className="grid gap-4"
+            style={{ gridTemplateColumns: toGridTemplate(widths) }}
+        >
+            {children.map((child, index) => (
+                <div key={`column-${index}`} className="space-y-4">
+                    {child}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default Columns;

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -1,0 +1,140 @@
+import { Fragment, type ReactNode } from 'react';
+
+import { Columns } from '@/components/viavai/Columns';
+import { Hero } from '@/components/viavai/Hero';
+import { Table } from '@/components/viavai/Table';
+import {
+    type ColumnsElement,
+    type HeroElement,
+    type LayoutElement,
+    type TableElement,
+} from '@/types/viavai/layout.types';
+import { type TableSchemaConfig } from '@/types/viavai/table.types';
+
+type ViaVaiLayoutProps = {
+    elements: unknown[];
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isHeroElement(element: unknown): element is HeroElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return element.type === 'hero' && typeof element.title === 'string';
+}
+
+function isTableElement(element: unknown): element is TableElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return (
+        element.type === 'table' &&
+        Array.isArray(element.columns) &&
+        Array.isArray(element.data)
+    );
+}
+
+function isColumnsElement(element: unknown): element is ColumnsElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return (
+        element.type === 'columns' &&
+        Array.isArray(element.widths) &&
+        Array.isArray(element.columns)
+    );
+}
+
+function isLayoutElement(element: unknown): element is LayoutElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return element.type === 'layout' && Array.isArray(element.components);
+}
+
+function toTableSchema(element: TableElement): TableSchemaConfig {
+    return {
+        title: 'Table',
+        schema: {
+            columns: element.columns.map((column) => ({
+                key: column.key,
+                label: column.label ?? column.key,
+                align: column.align ?? 'left',
+                cell: Array.isArray(column.cell) ? column.cell : [column.cell],
+            })),
+        },
+    };
+}
+
+function renderElement(element: unknown, index: string): ReactNode {
+    if (isHeroElement(element)) {
+        return (
+            <Hero
+                key={`hero-${index}`}
+                title={element.title}
+                subtitle={element.subtitle ?? undefined}
+            />
+        );
+    }
+
+    if (isTableElement(element)) {
+        return (
+            <Table
+                key={`table-${index}`}
+                schema={toTableSchema(element)}
+                data={element.data}
+            />
+        );
+    }
+
+    if (isColumnsElement(element)) {
+        return (
+            <Columns key={`columns-${index}`} widths={element.widths}>
+                {element.columns.map((column, columnIndex) => {
+                    const nestedElements = Array.isArray(column) ? column : [];
+
+                    return (
+                        <Fragment key={`columns-${index}-${columnIndex}`}>
+                            {nestedElements.map((nestedElement, nestedIndex) =>
+                                renderElement(
+                                    nestedElement,
+                                    `${index}-${columnIndex}-${nestedIndex}`
+                                )
+                            )}
+                        </Fragment>
+                    );
+                })}
+            </Columns>
+        );
+    }
+
+    if (isLayoutElement(element)) {
+        return (
+            <ViaVaiLayout
+                key={`layout-${index}`}
+                elements={element.components}
+            />
+        );
+    }
+
+    return null;
+}
+
+export function ViaVaiLayout({ elements }: ViaVaiLayoutProps) {
+    return (
+        <div className="space-y-4">
+            {elements.map((element, index) =>
+                renderElement(element, `${index}`)
+            )}
+        </div>
+    );
+}
+
+export default ViaVaiLayout;

--- a/web/src/pages/org/ViaVai.tsx
+++ b/web/src/pages/org/ViaVai.tsx
@@ -1,67 +1,5 @@
-import { Hero } from '@/components/viavai/Hero';
-import { Table } from '@/components/viavai/Table';
+import { ViaVaiLayout } from '@/components/viavai/Layout';
 import { useData } from '@/hooks/use-data';
-import { type TableSchemaConfig } from '@/types/viavai/table.types';
-
-type HeroElement = {
-    type: string;
-    title: string;
-    subtitle?: string | null;
-};
-
-type ApiTableColumn = {
-    key: string;
-    label?: string;
-    align?: 'left' | 'center' | 'right';
-    cell: string | string[];
-};
-
-type ApiTableElement = {
-    type: string;
-    columns: ApiTableColumn[];
-    data: Record<string, unknown>[];
-};
-
-function isTableElement(element: unknown): element is ApiTableElement {
-    if (!element || typeof element !== 'object') {
-        return false;
-    }
-
-    const candidate = element as Record<string, unknown>;
-    return (
-        typeof candidate.type === 'string' &&
-        candidate.type.toLowerCase() === 'table' &&
-        Array.isArray(candidate.columns) &&
-        Array.isArray(candidate.data)
-    );
-}
-
-function toTableSchema(element: ApiTableElement): TableSchemaConfig {
-    return {
-        title: 'Table',
-        schema: {
-            columns: element.columns.map((column) => ({
-                key: column.key,
-                label: column.label ?? column.key,
-                align: column.align ?? 'left',
-                cell: Array.isArray(column.cell) ? column.cell : [column.cell],
-            })),
-        },
-    };
-}
-
-function isHeroElement(element: unknown): element is HeroElement {
-    if (!element || typeof element !== 'object') {
-        return false;
-    }
-
-    const candidate = element as Record<string, unknown>;
-    return (
-        typeof candidate.type === 'string' &&
-        candidate.type.toLowerCase() === 'hero' &&
-        typeof candidate.title === 'string'
-    );
-}
 
 export default function ViaVai() {
     const { data, isLoading, error } = useData<unknown>('/sample/page');
@@ -80,31 +18,5 @@ export default function ViaVai() {
         return <div>Unexpected response format for /sample/page</div>;
     }
 
-    return (
-        <div className="space-y-4">
-            {samplePageData.map((element, index) => {
-                if (isHeroElement(element)) {
-                    return (
-                        <Hero
-                            key={`hero-${index}`}
-                            title={element.title}
-                            subtitle={element.subtitle ?? undefined}
-                        />
-                    );
-                }
-
-                if (isTableElement(element)) {
-                    return (
-                        <Table
-                            key={`table-${index}`}
-                            schema={toTableSchema(element)}
-                            data={element.data}
-                        />
-                    );
-                }
-
-                return null;
-            })}
-        </div>
-    );
+    return <ViaVaiLayout elements={samplePageData} />;
 }

--- a/web/src/pages/user/ViaVai.tsx
+++ b/web/src/pages/user/ViaVai.tsx
@@ -1,69 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { Hero } from '@/components/viavai/Hero';
-import { Table } from '@/components/viavai/Table';
+import { ViaVaiLayout } from '@/components/viavai/Layout';
 import { apiFetch } from '@/lib/api';
-import { type TableSchemaConfig } from '@/types/viavai/table.types';
-
-type HeroElement = {
-    type: string;
-    title: string;
-    subtitle?: string | null;
-};
-
-type ApiTableColumn = {
-    key: string;
-    label?: string;
-    align?: 'left' | 'center' | 'right';
-    cell: string | string[];
-};
-
-type ApiTableElement = {
-    type: string;
-    columns: ApiTableColumn[];
-    data: Record<string, unknown>[];
-};
-
-function isHeroElement(element: unknown): element is HeroElement {
-    if (!element || typeof element !== 'object') {
-        return false;
-    }
-
-    const candidate = element as Record<string, unknown>;
-    return (
-        typeof candidate.type === 'string' &&
-        candidate.type.toLowerCase() === 'hero' &&
-        typeof candidate.title === 'string'
-    );
-}
-
-function isTableElement(element: unknown): element is ApiTableElement {
-    if (!element || typeof element !== 'object') {
-        return false;
-    }
-
-    const candidate = element as Record<string, unknown>;
-    return (
-        typeof candidate.type === 'string' &&
-        candidate.type.toLowerCase() === 'table' &&
-        Array.isArray(candidate.columns) &&
-        Array.isArray(candidate.data)
-    );
-}
-
-function toTableSchema(element: ApiTableElement): TableSchemaConfig {
-    return {
-        title: 'Table',
-        schema: {
-            columns: element.columns.map((column) => ({
-                key: column.key,
-                label: column.label ?? column.key,
-                align: column.align ?? 'left',
-                cell: Array.isArray(column.cell) ? column.cell : [column.cell],
-            })),
-        },
-    };
-}
 
 export default function ViaVai() {
     const [samplePageData, setSamplePageData] = useState<unknown[]>([]);
@@ -101,31 +39,5 @@ export default function ViaVai() {
         return <div>{error}</div>;
     }
 
-    return (
-        <div className="space-y-4">
-            {samplePageData.map((element, index) => {
-                if (isHeroElement(element)) {
-                    return (
-                        <Hero
-                            key={`hero-${index}`}
-                            title={element.title}
-                            subtitle={element.subtitle ?? undefined}
-                        />
-                    );
-                }
-
-                if (isTableElement(element)) {
-                    return (
-                        <Table
-                            key={`table-${index}`}
-                            schema={toTableSchema(element)}
-                            data={element.data}
-                        />
-                    );
-                }
-
-                return null;
-            })}
-        </div>
-    );
+    return <ViaVaiLayout elements={samplePageData} />;
 }

--- a/web/src/types/viavai/layout.types.ts
+++ b/web/src/types/viavai/layout.types.ts
@@ -1,0 +1,37 @@
+import { type TableAlign } from '@/types/viavai/table.types';
+
+export type HeroElement = {
+    type: 'hero';
+    title: string;
+    subtitle?: string | null;
+};
+
+export type ApiTableColumn = {
+    key: string;
+    label?: string;
+    align?: TableAlign;
+    cell: string | string[];
+};
+
+export type TableElement = {
+    type: 'table';
+    columns: ApiTableColumn[];
+    data: Record<string, unknown>[];
+};
+
+export type ColumnsElement = {
+    type: 'columns';
+    widths: number[];
+    columns: unknown[];
+};
+
+export type LayoutElement = {
+    type: 'layout';
+    components: unknown[];
+};
+
+export type ViaVaiElement =
+    | HeroElement
+    | TableElement
+    | ColumnsElement
+    | LayoutElement;


### PR DESCRIPTION
### Motivation
- Align the frontend with the API-side `Layout`/`Columns` payload so the UI can render page schemas produced by the backend. 
- Support a `columns` element that expresses multi-column layouts with explicit widths coming from the API. 
- Remove duplicated element parsing logic from the user/org ViaVai pages by centralizing rendering in a single component.

### Description
- Added `ViaVaiLayout` (`web/src/components/viavai/Layout.tsx`) which maps API element payloads (`hero`, `table`, `columns`, `layout`) to UI components and recursively renders nested structures. 
- Implemented a `Columns` component (`web/src/components/viavai/Columns.tsx`) that builds a responsive CSS grid from API-provided `widths` and renders per-column content containers. 
- Introduced `web/src/types/viavai/layout.types.ts` with typed definitions for `HeroElement`, `TableElement`, `ColumnsElement`, `LayoutElement` and the union `ViaVaiElement`. 
- Refactored `web/src/pages/user/ViaVai.tsx` and `web/src/pages/org/ViaVai.tsx` to use the shared `ViaVaiLayout` renderer and removed duplicated element parsing logic; added `toTableSchema` conversion to adapt API table payloads to the existing `Table` component shape.

### Testing
- Ran `bun run format` (in `web/`) and it completed successfully. 
- Attempted `bun run build` (in `web/`), which failed due to pre-existing unrelated TypeScript errors in other files (examples: `src/components/Test.tsx`, `src/components/ui/resizable.tsx`, `src/pages/org/Organization.tsx`). 
- Started the API with `python main.py` and confirmed the `/sample/page` endpoint could be served for manual verification. 
- Started the frontend dev server with `bun run dev` (in `web/`) and performed a manual UI check; a Playwright screenshot of the ViaVai route was captured for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991229feef883238304b87f5dd5e61e)