### PR TITLE
Add ViaVai Separator component end-to-end

### DIFF
--- a/api/src/routes/sample.py
+++ b/api/src/routes/sample.py
@@ -50,6 +50,8 @@ async def form():
 
     col1.hero(title="Column 1", subtitle="This is the first column")
     col2.hero(title="Column 2", subtitle="This is the second column")
+    col2.separator()
+    col2.hero(title="After separator", subtitle="This section starts after a horizontal separator")
 
 
     table = col1.table(

--- a/api/src/ui/__layout__.py
+++ b/api/src/ui/__layout__.py
@@ -1,4 +1,5 @@
 from .hero import Hero
+from .separator import Separator
 from .table import Table
 from .columns import Columns
 
@@ -27,6 +28,11 @@ class Layout:
         columns = Columns(widths, layout_factory=Layout)
         self._components.append(columns)
         return columns.columns
+
+    def separator(self, orientation: str = 'horizontal') -> Separator:
+        separator = Separator(orientation=orientation)
+        self._components.append(separator)
+        return separator
     
     def __iter__(self):
         for component in self._components:

--- a/api/src/ui/separator.py
+++ b/api/src/ui/separator.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+
+class Separator:
+    orientation: Literal['horizontal', 'vertical']
+
+    def __init__(self, orientation: Literal['horizontal', 'vertical'] = 'horizontal'):
+        self.orientation = orientation
+
+    def __iter__(self):
+        yield 'type', 'separator'
+        yield 'orientation', self.orientation

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -3,10 +3,12 @@ import { Fragment, type ReactNode } from 'react';
 import { Columns } from '@/components/viavai/Columns';
 import { Hero } from '@/components/viavai/Hero';
 import { Table } from '@/components/viavai/Table';
+import { Separator } from '@/components/ui/separator';
 import {
     type ColumnsElement,
     type HeroElement,
     type LayoutElement,
+    type SeparatorElement,
     type TableElement,
 } from '@/types/viavai/layout.types';
 import { type TableSchemaConfig } from '@/types/viavai/table.types';
@@ -57,6 +59,14 @@ function isLayoutElement(element: unknown): element is LayoutElement {
     }
 
     return element.type === 'layout' && Array.isArray(element.components);
+}
+
+function isSeparatorElement(element: unknown): element is SeparatorElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return element.type === 'separator';
 }
 
 function toTableSchema(element: TableElement): TableSchemaConfig {
@@ -112,6 +122,15 @@ function renderElement(element: unknown, index: string): ReactNode {
                     );
                 })}
             </Columns>
+        );
+    }
+
+    if (isSeparatorElement(element)) {
+        return (
+            <Separator
+                key={`separator-${index}`}
+                orientation={element.orientation ?? 'horizontal'}
+            />
         );
     }
 

--- a/web/src/types/viavai/layout.types.ts
+++ b/web/src/types/viavai/layout.types.ts
@@ -30,8 +30,14 @@ export type LayoutElement = {
     components: unknown[];
 };
 
+export type SeparatorElement = {
+    type: 'separator';
+    orientation?: 'horizontal' | 'vertical';
+};
+
 export type ViaVaiElement =
     | HeroElement
     | TableElement
     | ColumnsElement
-    | LayoutElement;
+    | LayoutElement
+    | SeparatorElement;


### PR DESCRIPTION
### Motivation
- Provide a reusable `Separator` component in the ViaVai schema so pages can include horizontal/vertical separators rendered with the shadcn `Separator` on the frontend.
- Allow Python-based ViaVai apps to emit separators from the API layout flow just like `hero`, `table` and `columns`.

### Description
- Add a new API-side UI schema class `Separator` with `orientation` support at `api/src/ui/separator.py` and expose it via `Layout.separator()` in `api/src/ui/__layout__.py`.
- Add a usage example to the sample page handler at `/sample/page` so `col2` demonstrates `col2.separator()` followed by another `hero` in `api/src/routes/sample.py`.
- Extend frontend types with `SeparatorElement` in `web/src/types/viavai/layout.types.ts` and update the ViaVai renderer in `web/src/components/viavai/Layout.tsx` to import and render the shadcn `Separator` (`@/components/ui/separator`).

### Testing
- Ran `python -m compileall api/src/ui api/src/routes` which succeeded without errors.
- Ran `bun run format` in the `web` workspace which completed successfully.
- Ran `bun run build` in the `web` workspace which failed due to pre-existing unrelated TypeScript issues in the repository (missing modules and unrelated type errors), not caused by the separator changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c599d6b48323be2a3ba67dfd8e53)