### PR TITLE
Refactor layout type guards to component-scoped isX helpers

### DIFF
--- a/web/src/components/viavai/Columns.tsx
+++ b/web/src/components/viavai/Columns.tsx
@@ -1,9 +1,27 @@
 import { type ReactNode } from 'react';
 
+import { type ColumnsElement } from '@/types/viavai/layout.types';
+
 type ColumnsProps = {
     widths: number[];
     children: ReactNode[];
 };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+export function isColumns(element: unknown): element is ColumnsElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return (
+        element.type === 'columns' &&
+        Array.isArray(element.widths) &&
+        Array.isArray(element.columns)
+    );
+}
 
 function toGridTemplate(widths: number[]) {
     if (widths.length === 0) {

--- a/web/src/components/viavai/Hero.tsx
+++ b/web/src/components/viavai/Hero.tsx
@@ -1,7 +1,21 @@
+import { type HeroElement } from '@/types/viavai/layout.types';
+
 type HeroProps = {
     title: string;
     subtitle?: string;
 };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+export function isHero(element: unknown): element is HeroElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return element.type === 'hero' && typeof element.title === 'string';
+}
 
 export function Hero({ title, subtitle }: HeroProps) {
     return (

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -1,12 +1,10 @@
 import { Fragment, type ReactNode } from 'react';
 
-import { Columns } from '@/components/viavai/Columns';
-import { Hero } from '@/components/viavai/Hero';
-import { Table } from '@/components/viavai/Table';
+import { Columns, isColumns } from '@/components/viavai/Columns';
+import { Hero, isHero } from '@/components/viavai/Hero';
+import { Table, isTable } from '@/components/viavai/Table';
 import { Separator } from '@/components/ui/separator';
 import {
-    type ColumnsElement,
-    type HeroElement,
     type LayoutElement,
     type SeparatorElement,
     type TableElement,
@@ -21,39 +19,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
 
-function isHeroElement(element: unknown): element is HeroElement {
-    if (!isObject(element)) {
-        return false;
-    }
-
-    return element.type === 'hero' && typeof element.title === 'string';
-}
-
-function isTableElement(element: unknown): element is TableElement {
-    if (!isObject(element)) {
-        return false;
-    }
-
-    return (
-        element.type === 'table' &&
-        Array.isArray(element.columns) &&
-        Array.isArray(element.data)
-    );
-}
-
-function isColumnsElement(element: unknown): element is ColumnsElement {
-    if (!isObject(element)) {
-        return false;
-    }
-
-    return (
-        element.type === 'columns' &&
-        Array.isArray(element.widths) &&
-        Array.isArray(element.columns)
-    );
-}
-
-function isLayoutElement(element: unknown): element is LayoutElement {
+export function isLayout(element: unknown): element is LayoutElement {
     if (!isObject(element)) {
         return false;
     }
@@ -61,7 +27,7 @@ function isLayoutElement(element: unknown): element is LayoutElement {
     return element.type === 'layout' && Array.isArray(element.components);
 }
 
-function isSeparatorElement(element: unknown): element is SeparatorElement {
+export function isSeparator(element: unknown): element is SeparatorElement {
     if (!isObject(element)) {
         return false;
     }
@@ -84,7 +50,7 @@ function toTableSchema(element: TableElement): TableSchemaConfig {
 }
 
 function renderElement(element: unknown, index: string): ReactNode {
-    if (isHeroElement(element)) {
+    if (isHero(element)) {
         return (
             <Hero
                 key={`hero-${index}`}
@@ -94,7 +60,7 @@ function renderElement(element: unknown, index: string): ReactNode {
         );
     }
 
-    if (isTableElement(element)) {
+    if (isTable(element)) {
         return (
             <Table
                 key={`table-${index}`}
@@ -104,7 +70,7 @@ function renderElement(element: unknown, index: string): ReactNode {
         );
     }
 
-    if (isColumnsElement(element)) {
+    if (isColumns(element)) {
         return (
             <Columns key={`columns-${index}`} widths={element.widths}>
                 {element.columns.map((column, columnIndex) => {
@@ -125,7 +91,7 @@ function renderElement(element: unknown, index: string): ReactNode {
         );
     }
 
-    if (isSeparatorElement(element)) {
+    if (isSeparator(element)) {
         return (
             <Separator
                 key={`separator-${index}`}
@@ -134,7 +100,7 @@ function renderElement(element: unknown, index: string): ReactNode {
         );
     }
 
-    if (isLayoutElement(element)) {
+    if (isLayout(element)) {
         return (
             <ViaVaiLayout
                 key={`layout-${index}`}

--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -12,6 +12,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { type TableElement } from '@/types/viavai/layout.types';
 import {
     type TableAlign,
     type TableColumn,
@@ -23,6 +24,22 @@ const textAlignClasses: Record<TableAlign, string> = {
     center: 'text-center',
     right: 'text-right',
 };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+export function isTable(element: unknown): element is TableElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return (
+        element.type === 'table' &&
+        Array.isArray(element.columns) &&
+        Array.isArray(element.data)
+    );
+}
 
 function resolvePath(data: unknown, path: string): unknown {
     return path


### PR DESCRIPTION
### Motivation
- Keep element validation logic colocated with the component implementation so each component owns its own type guard.
- Simplify guard names by removing the `Element` suffix so callers use `isHero`, `isTable`, `isColumns`, `isLayout`, and `isSeparator` consistently.

### Description
- Moved the hero guard into `web/src/components/viavai/Hero.tsx` and exported it as `isHero` (replacing the previous `isHeroElement` logic).
- Added and exported `isTable` in `web/src/components/viavai/Table.tsx` (moved from `Layout.tsx`).
- Added and exported `isColumns` in `web/src/components/viavai/Columns.tsx` (moved from `Layout.tsx`).
- Updated `web/src/components/viavai/Layout.tsx` to import and use the new `isHero`, `isTable`, and `isColumns` helpers and to export `isLayout` and `isSeparator` (removing the `Element` suffix and duplicate local guards).

### Testing
- Ran `bun run format` which completed successfully to apply formatting changes.
- Ran `bun run build` which failed due to pre-existing TypeScript issues unrelated to this refactor (errors in `ui/resizable.tsx` and missing imports elsewhere), so the failure is not caused by the guard relocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d9bdd6a48323b2bb36fb98ce72b2)