### PR TITLE
refactor(web): centralize viavai isObject helper

### DIFF
--- a/web/src/components/viavai/Columns.tsx
+++ b/web/src/components/viavai/Columns.tsx
@@ -1,15 +1,12 @@
 import { type ReactNode } from 'react';
 
 import { type ColumnsElement } from '@/types/viavai/layout.types';
+import { isObject } from '@/components/viavai/utils';
 
 type ColumnsProps = {
     widths: number[];
     children: ReactNode[];
 };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
-}
 
 export function isColumns(element: unknown): element is ColumnsElement {
     if (!isObject(element)) {

--- a/web/src/components/viavai/Hero.tsx
+++ b/web/src/components/viavai/Hero.tsx
@@ -1,13 +1,10 @@
 import { type HeroElement } from '@/types/viavai/layout.types';
+import { isObject } from '@/components/viavai/utils';
 
 type HeroProps = {
     title: string;
     subtitle?: string;
 };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
-}
 
 export function isHero(element: unknown): element is HeroElement {
     if (!isObject(element)) {

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -10,14 +10,11 @@ import {
     type TableElement,
 } from '@/types/viavai/layout.types';
 import { type TableSchemaConfig } from '@/types/viavai/table.types';
+import { isObject } from '@/components/viavai/utils';
 
 type ViaVaiLayoutProps = {
     elements: unknown[];
 };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
-}
 
 export function isLayout(element: unknown): element is LayoutElement {
     if (!isObject(element)) {

--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -4,6 +4,8 @@ import {
     getCoreRowModel,
     useReactTable,
 } from '@tanstack/react-table';
+
+import { isObject } from '@/components/viavai/utils';
 import {
     Table as UITable,
     TableBody,
@@ -24,10 +26,6 @@ const textAlignClasses: Record<TableAlign, string> = {
     center: 'text-center',
     right: 'text-right',
 };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
-}
 
 export function isTable(element: unknown): element is TableElement {
     if (!isObject(element)) {

--- a/web/src/components/viavai/utils.ts
+++ b/web/src/components/viavai/utils.ts
@@ -1,0 +1,3 @@
+export function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}


### PR DESCRIPTION
### Motivation

- Remove duplicated `isObject` type-guard implementations across ViaVai components to improve maintainability and consistency.
- Provide a single, testable helper for runtime object checks used by layout/table components.

### Description

- Added `web/src/components/viavai/utils.ts` exporting `isObject(value: unknown): value is Record<string, unknown>`.
- Updated `Hero`, `Columns`, `Layout`, and `Table` to import and use the shared `isObject` helper and removed their local duplicates.
- Ran repository formatting using the configured formatter (`bun run format`).

### Testing

- Ran `bun run format` (Prettier) which completed successfully.
- Ran `bun run build` which failed due to pre-existing TypeScript errors in unrelated UI/page files; the build failure is unrelated to this refactor and no new type errors were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e18b419c8323888d99428cc76884)