### PR TITLE
Add ViaVai Button component support (API + web renderer)

### DIFF
--- a/api/src/routes/sample.py
+++ b/api/src/routes/sample.py
@@ -9,6 +9,7 @@ async def form():
     """Return an example page schema payload with a hero component."""
     page = Layout()
     page.hero(title="Data Table", subtitle="This is an example of a data table component.")
+    page.button(text='Primary action')
 
     table = page.table(
         [
@@ -50,6 +51,7 @@ async def form():
 
     col1.hero(title="Column 1", subtitle="This is the first column")
     col2.hero(title="Column 2", subtitle="This is the second column")
+    col2.button(text='Secondary action', variant='outline')
     col2.separator()
     col2.hero(title="After separator", subtitle="This section starts after a horizontal separator")
 

--- a/api/src/ui/__layout__.py
+++ b/api/src/ui/__layout__.py
@@ -1,6 +1,9 @@
+from typing import Literal
+
 from .hero import Hero
 from .separator import Separator
 from .table import Table
+from .button import Button
 from .columns import Columns
 
 
@@ -23,6 +26,15 @@ class Layout:
         table = Table(data=data)
         self._components.append(table)
         return table
+
+    def button(
+        self,
+        text: str,
+        variant: Literal['default', 'outline', 'secondary', 'ghost', 'destructive', 'link'] = 'default',
+    ) -> Button:
+        button = Button(text=text, variant=variant)
+        self._components.append(button)
+        return button
     
     def columns(self, widths: list[int]) -> list["Layout"]:
         columns = Columns(widths, layout_factory=Layout)

--- a/api/src/ui/button.py
+++ b/api/src/ui/button.py
@@ -1,6 +1,19 @@
+from typing import Literal
+
+
 class Button:
-    def __init__(self):
-        pass
+    text: str
+    variant: Literal['default', 'outline', 'secondary', 'ghost', 'destructive', 'link']
+
+    def __init__(
+        self,
+        text: str,
+        variant: Literal['default', 'outline', 'secondary', 'ghost', 'destructive', 'link'] = 'default',
+    ):
+        self.text = text
+        self.variant = variant
 
     def __iter__(self):
-        yield "Sample", "This is a sample page"
+        yield 'type', 'button'
+        yield 'text', self.text
+        yield 'variant', self.variant

--- a/web/src/components/viavai/Button.tsx
+++ b/web/src/components/viavai/Button.tsx
@@ -1,0 +1,52 @@
+import { Button as UIButton } from '@/components/ui/button';
+import { isObject } from '@/lib/utils';
+
+export type ButtonVariant =
+    | 'default'
+    | 'outline'
+    | 'secondary'
+    | 'ghost'
+    | 'destructive'
+    | 'link';
+
+export type ButtonElement = {
+    type: 'button';
+    text: string;
+    variant?: ButtonVariant;
+};
+
+type ButtonProps = {
+    text: string;
+    variant?: ButtonVariant;
+};
+
+const buttonVariants: ButtonVariant[] = [
+    'default',
+    'outline',
+    'secondary',
+    'ghost',
+    'destructive',
+    'link',
+];
+
+export function isButton(element: unknown): element is ButtonElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    if (element.type !== 'button' || typeof element.text !== 'string') {
+        return false;
+    }
+
+    if (element.variant === undefined) {
+        return true;
+    }
+
+    return buttonVariants.includes(element.variant as ButtonVariant);
+}
+
+export function Button({ text, variant = 'default' }: ButtonProps) {
+    return <UIButton variant={variant}>{text}</UIButton>;
+}
+
+export default Button;

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -1,6 +1,11 @@
 import { Fragment, type ReactNode } from 'react';
 
 import {
+    Button,
+    type ButtonElement,
+    isButton,
+} from '@/components/viavai/Button';
+import {
     Columns,
     type ColumnsElement,
     isColumns,
@@ -27,6 +32,7 @@ export type SeparatorElement = {
 
 export type ViaVaiElement =
     | HeroElement
+    | ButtonElement
     | TableElement
     | ColumnsElement
     | LayoutElement
@@ -73,6 +79,16 @@ function renderElement(element: unknown, index: string): ReactNode {
                 key={`hero-${index}`}
                 title={element.title}
                 subtitle={element.subtitle ?? undefined}
+            />
+        );
+    }
+
+    if (isButton(element)) {
+        return (
+            <Button
+                key={`button-${index}`}
+                text={element.text}
+                variant={element.variant ?? 'default'}
             />
         );
     }

--- a/web/src/components/viavai/Table.tsx
+++ b/web/src/components/viavai/Table.tsx
@@ -81,7 +81,9 @@ function renderTemplate(template: string, data: unknown): string {
     });
 }
 
-function buildColumns<T extends object>(columns: TableColumn[]): ColumnDef<T>[] {
+function buildColumns<T extends object>(
+    columns: TableColumn[]
+): ColumnDef<T>[] {
     return columns.map((column) => {
         const align = column.align ?? 'left';
 
@@ -143,10 +145,10 @@ export function Table<T extends object>({ schema, data }: TableProps<T>) {
                                         {header.isPlaceholder
                                             ? null
                                             : flexRender(
-                                                header.column.columnDef
-                                                    .header,
-                                                header.getContext()
-                                            )}
+                                                  header.column.columnDef
+                                                      .header,
+                                                  header.getContext()
+                                              )}
                                     </TableHead>
                                 );
                             })}


### PR DESCRIPTION
### Motivation
- Enable pages to declare and emit button elements via the API (e.g. `btn = page.button(text, variant='default')`) so the frontend can render actions alongside existing hero/table/columns components.
- Provide a typed API schema for buttons so payloads are consistent and can be validated/consumed by the ViaVai renderer.

### Description
- Added an API-side `Button` UI object with `type`, `text`, and `variant` serialization in `api/src/ui/button.py` and a typed `Layout.button(...)` helper in `api/src/ui/__layout__.py` so buttons can be appended to pages.
- Updated the sample page at `api/src/routes/sample.py` to exercise the new `page.button(...)` API with a primary and an `outline` secondary button.
- Implemented a web-side ViaVai element component `web/src/components/viavai/Button.tsx` with a runtime type guard `isButton` and mapping to the shared shadcn/base `ui/button` component.
- Wired button rendering into the dynamic ViaVai renderer at `web/src/components/viavai/Layout.tsx` so API `button` payloads are picked up and displayed; included a small formatting update to `web/src/components/viavai/Table.tsx` (non-functional styling/formatting change).

### Testing
- Ran `python -m compileall api/src` to validate Python modules; compilation passed successfully.
- Ran `bun run format` in `web/` to format changed frontend files; formatting completed successfully.
- Attempted `bun run build` in `web/`, which failed due to pre-existing unrelated TypeScript issues elsewhere in the project (errors in unrelated files like `resizable.tsx` and missing hooks/imports), so full production build was not completed here.
- Performed a small runtime check with `from api.src.ui.__layout__ import Layout` and `page.button(text='Click me')` to confirm the API layout emits the expected dict payload, which succeeded; also captured a browser screenshot of `/viavai` to visually validate rendering of the new button element.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992069902d88323bb4244d6f1448915)