### PR TITLE
Implement ViaVai dialog component rendering in web layout

### DIFF
--- a/web/src/components/viavai/Button.tsx
+++ b/web/src/components/viavai/Button.tsx
@@ -1,4 +1,8 @@
 import { Button as UIButton } from '@/components/ui/button';
+import {
+    type DialogElement,
+    isDialogElement,
+} from '@/components/viavai/Dialog';
 import { isObject } from '@/lib/utils';
 
 export type ButtonVariant =
@@ -13,6 +17,7 @@ export type ButtonElement = {
     type: 'button';
     text: string;
     variant?: ButtonVariant;
+    dialog?: DialogElement;
 };
 
 type ButtonProps = {
@@ -38,11 +43,18 @@ export function isButton(element: unknown): element is ButtonElement {
         return false;
     }
 
-    if (element.variant === undefined) {
+    if (
+        element.variant !== undefined &&
+        !buttonVariants.includes(element.variant as ButtonVariant)
+    ) {
+        return false;
+    }
+
+    if (element.dialog === undefined) {
         return true;
     }
 
-    return buttonVariants.includes(element.variant as ButtonVariant);
+    return isDialogElement(element.dialog);
 }
 
 export function Button({ text, variant = 'default' }: ButtonProps) {

--- a/web/src/components/viavai/Dialog.tsx
+++ b/web/src/components/viavai/Dialog.tsx
@@ -1,0 +1,68 @@
+import { type ReactElement, type ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogFooter,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { isObject } from '@/lib/utils';
+
+export type DialogElement = {
+    type: 'dialog';
+    confirm?: string;
+    cancel?: string;
+    components: unknown[];
+};
+
+type ViaVaiDialogProps = {
+    trigger: ReactElement;
+    confirm?: string;
+    cancel?: string;
+    children?: ReactNode;
+};
+
+export function isDialogElement(element: unknown): element is DialogElement {
+    if (!isObject(element)) {
+        return false;
+    }
+
+    return element.type === 'dialog' && Array.isArray(element.components);
+}
+
+export function ViaVaiDialog({
+    trigger,
+    confirm = 'Confirm',
+    cancel = 'Cancel',
+    children,
+}: ViaVaiDialogProps) {
+    return (
+        <Dialog>
+            <DialogTrigger render={trigger} />
+            <DialogContent className="min-w-[40rem] max-w-5xl">
+                <div className="max-h-[70vh] overflow-y-auto p-1">
+                    {children}
+                </div>
+                <DialogFooter>
+                    <DialogClose
+                        render={
+                            <Button
+                                variant="outline"
+                                className="cursor-pointer"
+                            />
+                        }
+                    >
+                        {cancel}
+                    </DialogClose>
+                    <DialogClose render={<Button className="cursor-pointer" />}>
+                        {confirm}
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default ViaVaiDialog;

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -5,6 +5,7 @@ import {
     type ButtonElement,
     isButton,
 } from '@/components/viavai/Button';
+import { ViaVaiDialog } from '@/components/viavai/Dialog';
 import {
     Columns,
     type ColumnsElement,
@@ -84,13 +85,27 @@ function renderElement(element: unknown, index: string): ReactNode {
     }
 
     if (isButton(element)) {
-        return (
+        const trigger = (
             <Button
-                key={`button-${index}`}
                 text={element.text}
                 variant={element.variant ?? 'default'}
             />
         );
+
+        if (element.dialog) {
+            return (
+                <ViaVaiDialog
+                    key={`button-${index}`}
+                    trigger={trigger}
+                    confirm={element.dialog.confirm}
+                    cancel={element.dialog.cancel}
+                >
+                    <ViaVaiLayout elements={element.dialog.components} />
+                </ViaVaiDialog>
+            );
+        }
+
+        return <Fragment key={`button-${index}`}>{trigger}</Fragment>;
     }
 
     if (isTable(element)) {


### PR DESCRIPTION
### Motivation

- Allow server-provided `dialog` payloads to be rendered as modal dialogs in the ViaVai web layout so button actions can open schema-driven dialogs with nested components and confirm/cancel actions.

### Description

- Add a new `ViaVaiDialog` component (`web/src/components/viavai/Dialog.tsx`) that maps `type: 'dialog'` payloads into a shadcn modal with `confirm`/`cancel` actions and a scrollable content area.
- Extend the `Button` element type (`web/src/components/viavai/Button.tsx`) to accept an optional `dialog` field and validate it via `isDialogElement`.
- Update `ViaVaiLayout` (`web/src/components/viavai/Layout.tsx`) to render a `ViaVaiDialog` when a `button` element includes a `dialog`, recursively rendering the dialog's nested components with `ViaVaiLayout`.
- Add a small typing tweak to accept `ReactElement` for the dialog trigger and ensure the dialog content size classes are reasonable (`min-w-[40rem] max-w-5xl`).

### Testing

- Ran `bun run format` and confirmed formatting completed successfully.
- Attempted `bun run build`; the build failed due to unrelated pre-existing TypeScript issues in other UI files and pages, while a local dialog typing issue was fixed as part of this change.
- Launched the dev server with `bun run dev --host 0.0.0.0 --port 4173` and verified the `/viavai` page renders, capturing a screenshot via an automated Playwright script to confirm the dialog rendering visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920a6258c08323ae824807b98c911c)