### PR TITLE
ViaVai: open dialog on button click

### DIFF
--- a/web/src/components/viavai/Button.tsx
+++ b/web/src/components/viavai/Button.tsx
@@ -1,4 +1,5 @@
 import { Button as UIButton } from '@/components/ui/button';
+import type { ComponentProps } from 'react';
 import {
     type DialogElement,
     isDialogElement,
@@ -23,7 +24,7 @@ export type ButtonElement = {
 type ButtonProps = {
     text: string;
     variant?: ButtonVariant;
-};
+} & Omit<ComponentProps<typeof UIButton>, 'children' | 'variant'>;
 
 const buttonVariants: ButtonVariant[] = [
     'default',
@@ -57,8 +58,12 @@ export function isButton(element: unknown): element is ButtonElement {
     return isDialogElement(element.dialog);
 }
 
-export function Button({ text, variant = 'default' }: ButtonProps) {
-    return <UIButton variant={variant}>{text}</UIButton>;
+export function Button({ text, variant = 'default', ...props }: ButtonProps) {
+    return (
+        <UIButton variant={variant} {...props}>
+            {text}
+        </UIButton>
+    );
 }
 
 export default Button;

--- a/web/src/components/viavai/Dialog.tsx
+++ b/web/src/components/viavai/Dialog.tsx
@@ -22,6 +22,8 @@ type ViaVaiDialogProps = {
     confirm?: string;
     cancel?: string;
     children?: ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
 };
 
 export function isDialogElement(element: unknown): element is DialogElement {
@@ -37,9 +39,11 @@ export function ViaVaiDialog({
     confirm = 'Confirm',
     cancel = 'Cancel',
     children,
+    open,
+    onOpenChange,
 }: ViaVaiDialogProps) {
     return (
-        <Dialog>
+        <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogTrigger render={trigger} />
             <DialogContent className="min-w-[40rem] max-w-5xl">
                 <div className="max-h-[70vh] overflow-y-auto p-1">

--- a/web/src/components/viavai/Layout.tsx
+++ b/web/src/components/viavai/Layout.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, type ReactNode, useState } from 'react';
 
 import {
     Button,
@@ -85,27 +85,23 @@ function renderElement(element: unknown, index: string): ReactNode {
     }
 
     if (isButton(element)) {
-        const trigger = (
-            <Button
-                text={element.text}
-                variant={element.variant ?? 'default'}
-            />
-        );
-
         if (element.dialog) {
             return (
-                <ViaVaiDialog
+                <ViaVaiButtonWithDialog
                     key={`button-${index}`}
-                    trigger={trigger}
-                    confirm={element.dialog.confirm}
-                    cancel={element.dialog.cancel}
-                >
-                    <ViaVaiLayout elements={element.dialog.components} />
-                </ViaVaiDialog>
+                    element={element}
+                />
             );
         }
 
-        return <Fragment key={`button-${index}`}>{trigger}</Fragment>;
+        return (
+            <Fragment key={`button-${index}`}>
+                <Button
+                    text={element.text}
+                    variant={element.variant ?? 'default'}
+                />
+            </Fragment>
+        );
     }
 
     if (isTable(element)) {
@@ -158,6 +154,36 @@ function renderElement(element: unknown, index: string): ReactNode {
     }
 
     return null;
+}
+
+type ViaVaiButtonWithDialogProps = {
+    element: ButtonElement;
+};
+
+function ViaVaiButtonWithDialog({ element }: ViaVaiButtonWithDialogProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    if (!element.dialog) {
+        return null;
+    }
+
+    return (
+        <ViaVaiDialog
+            trigger={
+                <Button
+                    text={element.text}
+                    variant={element.variant ?? 'default'}
+                    onClick={() => setIsOpen(true)}
+                />
+            }
+            open={isOpen}
+            onOpenChange={setIsOpen}
+            confirm={element.dialog.confirm}
+            cancel={element.dialog.cancel}
+        >
+            <ViaVaiLayout elements={element.dialog.components} />
+        </ViaVaiDialog>
+    );
 }
 
 export function ViaVaiLayout({ elements }: ViaVaiLayoutProps) {


### PR DESCRIPTION
### Motivation
- Enable ViaVai buttons that include a dialog to open the dialog when the user clicks the button, matching the sample `page.button(...).dialog(...)` usage.

### Description
- Forward native UI button props (including `onClick`) from the ViaVai button wrapper by extending `Button.tsx` props to accept and pass through `UIButton` props.
- Make `ViaVaiDialog` controllable by adding optional `open` and `onOpenChange` props in `Dialog.tsx` so dialogs can be opened programmatically.
- Add a stateful helper `ViaVaiButtonWithDialog` in `Layout.tsx` that renders dialog-backed buttons and opens the dialog on click, and wire layout rendering to use it for buttons with `dialog` definitions.
- Files changed: `web/src/components/viavai/Button.tsx`, `web/src/components/viavai/Dialog.tsx`, `web/src/components/viavai/Layout.tsx`.

### Testing
- `bun run format` executed in `web/` and succeeded. 
- `bun run build` was executed but failed due to pre-existing unrelated TypeScript errors in other files (build failure is not caused by these changes). 
- Ran the dev server and an automated Playwright script to visit the site and capture screenshots of the home and ViaVai page, which completed successfully and produced artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992165c7b148323b404280fc0cb5af3)