### PR TITLE
feat(web): add generic Render component registry

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -1,0 +1,45 @@
+import Button from '@/components/viavai/Button';
+import Dialog from '@/components/viavai/Dialog';
+import Hero from '@/components/viavai/Hero';
+import Layout from '@/components/viavai/Layout';
+
+type RenderNodeSchema = {
+    type: string;
+    props?: Record<string, unknown>;
+    children?: RenderNodeSchema[];
+};
+
+const registry: Record<string, any> = {
+    layout: Layout,
+    dialog: Dialog,
+    hero: Hero,
+    button: Button,
+};
+
+function RenderNode(node: any) {
+    const Component = registry[node.type];
+
+    if (!Component) {
+        return null;
+    }
+
+    return (
+        <Component {...node.props}>
+            {node.children?.map((child: any, i: number) => (
+                <RenderNode key={i} {...child} />
+            ))}
+        </Component>
+    );
+}
+
+type RenderProps = {
+    node: RenderNodeSchema;
+};
+
+export function Render({ node }: RenderProps) {
+    return <RenderNode {...node} />;
+}
+
+export { registry };
+
+export default Render;


### PR DESCRIPTION
### Motivation
- Provide a generic renderer to turn JSON-like node schemas into rendered ViaVai components so dynamic UI trees can be composed and reused.

### Description
- Add `web/src/components/Render.tsx` which defines a `registry` mapping (`layout`, `dialog`, `hero`, `button`) and implements a recursive `RenderNode` to render nested `children`, and exports a `Render` component and the `registry`.

### Testing
- Ran `bun run format` in `web` which completed successfully.
- Ran `bun run build` in `web` which failed due to pre-existing TypeScript issues unrelated to this change (formatting step passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992221801dc8323908c8ea3e45090e2)