### PR TITLE
api: normalize UI component iterators to RenderNodeSchema

### DIFF
--- a/api/src/ui/button.py
+++ b/api/src/ui/button.py
@@ -24,8 +24,10 @@ class Button:
 
     def __iter__(self):
         yield 'type', 'button'
-        yield 'text', self.text
-        yield 'variant', self.variant
+        yield 'props', {
+            'text': self.text,
+            'variant': self.variant,
+        }
 
         if self._dialog is not None:
-            yield 'dialog', dict(self._dialog)
+            yield 'children', [dict(self._dialog)]

--- a/api/src/ui/columns.py
+++ b/api/src/ui/columns.py
@@ -5,25 +5,29 @@ if TYPE_CHECKING:
 
 
 class Columns:
-    def __init__(self, widths: list[int], *, layout_factory: type["Layout"]):
+    def __init__(self, widths: list[int], *, layout_factory: type['Layout']):
         self._widths = widths
         self.columns = [layout_factory() for _ in widths]
-        
+
     def __iter__(self):
-        yield "type", "columns"
-        yield "widths", self._widths
-        yield "columns", [list(column) for column in self.columns]
+        yield 'type', 'columns'
+        yield 'children', [
+            {
+                'type': 'column',
+                'props': {'width': width},
+                'children': list(column),
+            }
+            for width, column in zip(self._widths, self.columns)
+        ]
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     from .__layout__ import Layout
 
     layout = Layout()
     col1, col2 = layout.columns([70, 30])
 
-    col1.hero(title="Column 1", subtitle="This is the first column")
-    col2.hero(title="Column 2", subtitle="This is the second column")
+    col1.hero(title='Column 1', subtitle='This is the first column')
+    col2.hero(title='Column 2', subtitle='This is the second column')
 
     print(list(layout))
-
-

--- a/api/src/ui/dialog.py
+++ b/api/src/ui/dialog.py
@@ -17,6 +17,8 @@ class Dialog:
 
     def __iter__(self):
         yield 'type', 'dialog'
-        yield 'confirm', self.confirm
-        yield 'cancel', self.cancel
-        yield 'components', [dict(component) for component in self._components]
+        yield 'props', {
+            'confirm': self.confirm,
+            'cancel': self.cancel,
+        }
+        yield 'children', [dict(component) for component in self._components]

--- a/api/src/ui/form.py
+++ b/api/src/ui/form.py
@@ -3,6 +3,4 @@ class Form:
         pass
 
     def __iter__(self):
-        yield "Sample", "This is a sample page"
-
-
+        yield 'type', 'form'

--- a/api/src/ui/hero.py
+++ b/api/src/ui/hero.py
@@ -8,9 +8,11 @@ class Hero:
         self.subtitle = subtitle
 
     def __iter__(self):
-        yield "type", "hero"
-        yield "title", self.title
-        yield "subtitle", self.subtitle
+        yield 'type', 'hero'
+        yield 'props', {
+            'title': self.title,
+            'subtitle': self.subtitle,
+        }
 
 
 if __name__ == "__main__":

--- a/api/src/ui/menu.py
+++ b/api/src/ui/menu.py
@@ -3,4 +3,4 @@ class Menu:
         pass
 
     def __iter__(self):
-        yield "Sample", "This is a sample page"
+        yield 'type', 'menu'

--- a/api/src/ui/separator.py
+++ b/api/src/ui/separator.py
@@ -9,4 +9,4 @@ class Separator:
 
     def __iter__(self):
         yield 'type', 'separator'
-        yield 'orientation', self.orientation
+        yield 'props', {'orientation': self.orientation}

--- a/api/src/ui/table.py
+++ b/api/src/ui/table.py
@@ -1,42 +1,47 @@
-from typing import Literal
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass
 class Column:
     key: str
     label: str
-    align: Literal["left", "center", "right"] = "left"
-    cell: str  | list[str] = ""
+    align: Literal['left', 'center', 'right'] = 'left'
+    cell: str | list[str] = ''
 
     def __iter__(self):
-        yield "key", self.key
-        yield "label", self.label
-        yield "align", self.align
-        yield "cell", self.cell
+        yield 'key', self.key
+        yield 'label', self.label
+        yield 'align', self.align
+        yield 'cell', self.cell
 
 
 class Table:
     def __init__(self, data: list[dict] | None = None):
         self._data = data or []
         self._columns = []
-        
-    def add_column(self,  key: str, label: str,  cell: str | list[str] = "",
-        align: Literal["left", "center", "right"] = "left") -> Column:
 
+    def add_column(
+        self,
+        key: str,
+        label: str,
+        cell: str | list[str] = '',
+        align: Literal['left', 'center', 'right'] = 'left',
+    ) -> Column:
         column = Column(key=key, label=label, align=align, cell=cell)
         self._columns.append(column)
 
         return column
 
-
     def __iter__(self):
-        yield "type", "table"
-        yield "columns", [dict(column) for column in self._columns]
-        yield "data", self._data
+        yield 'type', 'table'
+        yield 'props', {
+            'columns': [dict(column) for column in self._columns],
+            'data': self._data,
+        }
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     table = Table(
         [
             {
@@ -67,9 +72,9 @@ if __name__ == "__main__":
             },
         ]
     )
-    table.add_column("invoice", label="Invoice", cell=["{invoiceNumber}", "Issued {issueDate}", "Status: {status}"], align="left")
-    table.add_column("client", label="Client", cell=["{client.name}", "{client.email}"])
-    table.add_column("dueDate", label="Dates", cell=["{issueDate}", "Due date: {dueDate}"], align="left")
-    table.add_column("amount", label="Amount", cell=["€{subtotal}", "VAT €{vat}"], align="right")
+    table.add_column('invoice', label='Invoice', cell=['{invoiceNumber}', 'Issued {issueDate}', 'Status: {status}'], align='left')
+    table.add_column('client', label='Client', cell=['{client.name}', '{client.email}'])
+    table.add_column('dueDate', label='Dates', cell=['{issueDate}', 'Due date: {dueDate}'], align='left')
+    table.add_column('amount', label='Amount', cell=['€{subtotal}', 'VAT €{vat}'], align='right')
 
     print(dict(table))


### PR DESCRIPTION
### Motivation
- Standardize UI component serialization so each component yields a consistent render node matching `RenderNodeSchema` with `type`, optional `props`, and optional `children`.
- Make nested component data predictable for the frontend by replacing bespoke keys (`dialog`, `components`, `widths`, etc.) with a single `children` convention.

### Description
- Updated `__iter__` outputs for UI components to emit `type`, `props`, and `children` where appropriate; `Hero`, `Separator`, `Form`, and `Menu` now emit `props` or `type` nodes consistently.
- `Button` now nests `text`/`variant` under `props` and exposes nested dialog as `children` instead of `dialog`.
- `Dialog` now places `confirm`/`cancel` under `props` and exposes nested components as `children`.
- `Table` now nests `columns` and `data` under `props` and keeps column items as dicts; `Columns` now produces a `children` array of `column` nodes where each column node has `props` (width) and its own `children` (the column layout contents).

### Testing
- Ran `python -m compileall src/ui` which succeeded and compiled the modified modules.
- Executed a Python smoke test constructing a `Layout` with nested components and printing `list(page)`, which produced the expected normalized node structure.
- Ran `pytest -q` which reported no tests collected for this area (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922591d5348323a334ea9e6f7b95cb)