### PR TITLE
Use Render component on user ViaVai page

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -1,8 +1,8 @@
+import type React from 'react';
 import Button from '@/components/viavai/Button';
 import Dialog from '@/components/viavai/Dialog';
 import Hero from '@/components/viavai/Hero';
 import Layout from '@/components/viavai/Layout';
-
 
 const registry = {
     hero: Hero,
@@ -14,16 +14,14 @@ const registry = {
 type Registry = typeof registry;
 type RegistryKey = keyof Registry;
 
-
-type RenderNodeSchema = {
+export type RenderNodeSchema = {
     type: RegistryKey;
     props?: Record<string, unknown>;
     children?: RenderNodeSchema[];
 };
 
-
 function Render({ type, props, children }: RenderNodeSchema) {
-    const Component = registry[type];
+    const Component = registry[type] as React.ComponentType<any>;
 
     return (
         <Component {...props}>
@@ -33,6 +31,5 @@ function Render({ type, props, children }: RenderNodeSchema) {
         </Component>
     );
 }
-
 
 export default Render;

--- a/web/src/pages/user/ViaVai.tsx
+++ b/web/src/pages/user/ViaVai.tsx
@@ -1,10 +1,12 @@
-import { ViaVaiLayout } from '@/components/viavai/Layout';
+import Render, { type RenderNodeSchema } from '@/components/Render';
 import { useData } from '@/hooks/use-data';
 
 export default function ViaVai() {
     const { data, isLoading, error } = useData<unknown>('/sample/page');
 
-    const samplePageData = Array.isArray(data) ? data : [];
+    const samplePageData = Array.isArray(data)
+        ? (data as RenderNodeSchema[])
+        : [];
 
     if (error) {
         return <div>{error}</div>;
@@ -18,5 +20,11 @@ export default function ViaVai() {
         return <div>Unexpected response format for /sample/page</div>;
     }
 
-    return <ViaVaiLayout elements={samplePageData} />;
+    return (
+        <>
+            {samplePageData.map((node, index) => (
+                <Render key={index} {...node} />
+            ))}
+        </>
+    );
 }


### PR DESCRIPTION
### Motivation
- Render dynamic `/sample/page` nodes through the centralized renderer so ViaVai pages can compose heterogeneous ViaVai components from the registry. 
- Provide a shared `RenderNodeSchema` type so page consumers can type API response nodes consistently.

### Description
- Replaced `ViaVaiLayout` usage in `web/src/pages/user/ViaVai.tsx` with mapping over the `/sample/page` response and rendering each node via `Render` (`web/src/pages/user/ViaVai.tsx`).
- Exported `RenderNodeSchema` from `web/src/components/Render.tsx` and cast registry components as a generic React component type with `import type React` to support heterogeneous props at runtime (`web/src/components/Render.tsx`).
- Ran project formatting to apply consistent styling (`bun run format` in `web/`).

### Testing
- Ran `bun run format` in `web/`, which completed successfully.
- Ran `bun run build` in `web/`, which failed due to unrelated TypeScript issues in other files (errors in `src/components/ui/resizable.tsx`, missing modules `@/hooks/use-mobile` and `@/components/navigation`, and an unused import in `src/components/ui/scroll-area.tsx`).
- Started the dev server with `bun run dev` in `web/`, and Vite reported ready and served the site locally (server started successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699228688368832392b5cf7ee412eb70)