### PR TITLE
Align viavai Button with shadcn variant API and explicit props

### DIFF
--- a/web/src/components/viavai/Button.tsx
+++ b/web/src/components/viavai/Button.tsx
@@ -2,28 +2,40 @@ import { Button as UIButton } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import type { ComponentProps } from 'react';
 
-export type ButtonVariant =
-    | 'default'
-    | 'outline'
-    | 'secondary'
-    | 'ghost'
-    | 'destructive'
-    | 'link';
+export type ButtonVariant = NonNullable<
+    ComponentProps<typeof UIButton>['variant']
+>;
 
 type ButtonProps = {
     text: string;
     variant?: ButtonVariant;
+    size?: ComponentProps<typeof UIButton>['size'];
+    className?: ComponentProps<typeof UIButton>['className'];
+    disabled?: ComponentProps<typeof UIButton>['disabled'];
+    onClick?: ComponentProps<typeof UIButton>['onClick'];
+    type?: ComponentProps<typeof UIButton>['type'];
     children?: ComponentProps<'div'>['children'];
-} & Omit<ComponentProps<typeof UIButton>, 'variant'>;
+};
 
 export function Button({
     text,
     variant = 'default',
+    size = 'default',
+    className,
+    disabled,
+    onClick,
+    type,
     children,
-    ...props
 }: ButtonProps) {
     const trigger = (
-        <UIButton variant={variant} {...props}>
+        <UIButton
+            variant={variant}
+            size={size}
+            className={className}
+            disabled={disabled}
+            onClick={onClick}
+            type={type}
+        >
             {text}
         </UIButton>
     );


### PR DESCRIPTION
### Motivation
- Keep the VaiVai button wrapper aligned with the underlying shadcn `UIButton` API so available variants remain consistent and type-safe.
- Remove unrestricted prop spreading to enforce a controlled, explicit prop surface and prevent accidental forwarding of unexpected attributes.
- Preserve existing behavior where the button can act as a dialog trigger while restricting which button parameters are accepted.

### Description
- Updated `web/src/components/viavai/Button.tsx` to derive `ButtonVariant` from `ComponentProps<typeof UIButton>['variant']` so the type always matches shadcn variants.
- Replaced `...props` forwarding with explicit props: `size`, `className`, `disabled`, `onClick`, and `type`, and added sensible defaults for `variant` and `size`.
- Kept the existing dialog-trigger flow: the component still returns a plain button when no `children` are provided and a `Dialog` with `DialogTrigger` when `children` exist.

### Testing
- Ran `bun run format` in `web/` which completed successfully.
- Attempted `bun run build` in `web/` which failed due to pre-existing TypeScript issues in unrelated files (`resizable.tsx`, `scroll-area.tsx`, `sidebar.tsx`, `Organization.tsx`) and not because of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699237a621ac8323a83b094ec0cbf5b5)