### PR TITLE
Fix renderer support for column schema nodes

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import Button from '@/components/viavai/Button';
+import Column from '@/components/viavai/Column';
 import Columns from '@/components/viavai/Columns';
 import Dialog from '@/components/viavai/Dialog';
 import Hero from '@/components/viavai/Hero';
@@ -14,6 +15,7 @@ const registry = {
     button: Button,
     table: Table,
     columns: Columns,
+    column: Column,
     separator: Separator,
 };
 

--- a/web/src/components/viavai/Button.tsx
+++ b/web/src/components/viavai/Button.tsx
@@ -2,20 +2,14 @@ import { Button as UIButton } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import type { ComponentProps } from 'react';
 
-
 type ButtonProps = {
     text: string;
     variant?: NonNullable<ComponentProps<typeof UIButton>['variant']>;
     children?: ComponentProps<'div'>['children'];
 };
 
-
 export function Button({ text, variant = 'default', children }: ButtonProps) {
-    const trigger = (
-        <UIButton variant={variant}>
-            {text}
-        </UIButton>
-    );
+    const trigger = <UIButton variant={variant}>{text}</UIButton>;
 
     if (!children) {
         return trigger;


### PR DESCRIPTION
### Motivation
- The frontend crashed with `Objects are not valid as a React child (found: object with keys {type, props})` because backend `columns` payloads emit `column` nodes that were not mapped to a React component and were rendered as raw objects.
- Keep the viavai `Button` implementation consistent and formatted while making no behavioral change.

### Description
- Import and register the `Column` component in the dynamic renderer registry so nodes with `type: 'column'` are rendered via the `Column` component (`web/src/components/Render.tsx`).
- Simplified the `Button` trigger JSX expression for formatting consistency without changing behavior (`web/src/components/viavai/Button.tsx`).
- Ran project formatting after edits using `bun run format`.

### Testing
- Ran `bun run format`, which completed successfully.
- Ran `bun run build`, which failed due to unrelated pre-existing TypeScript errors in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`, and `src/pages/org/Organization.tsx` (these are not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923ba936c08323aca8e7af4eeadb07)