### PR TITLE
Fix React child rendering crash in ViaVai schema renderer

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -25,12 +25,38 @@ export type RegistryKey = keyof Registry;
 export type RenderNodeSchema = {
     type: RegistryKey;
     props?: Record<string, unknown>;
-    children?: RenderNodeSchema[];
+    children?: RenderNodeSchema[] | RenderNodeSchema;
 };
 
+function isRenderNodeSchema(value: unknown): value is RenderNodeSchema {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    return 'type' in value;
+}
+
+function normalizeChildren(
+    children?: RenderNodeSchema[] | RenderNodeSchema
+): RenderNodeSchema[] {
+    if (!children) {
+        return [];
+    }
+
+    if (Array.isArray(children)) {
+        return children.filter(isRenderNodeSchema);
+    }
+
+    return isRenderNodeSchema(children) ? [children] : [];
+}
+
 function Render({ type, props, children }: RenderNodeSchema) {
+    const resolvedChildren = normalizeChildren(children);
+
     if (type === 'button') {
-        const dialogChild = children?.find((child) => child.type === 'dialog');
+        const dialogChild = resolvedChildren.find(
+            (child) => child.type === 'dialog'
+        );
 
         if (dialogChild) {
             const dialogProps =
@@ -47,19 +73,23 @@ function Render({ type, props, children }: RenderNodeSchema) {
                     confirm={dialogProps.confirm}
                     cancel={dialogProps.cancel}
                 >
-                    {dialogChild.children?.map((child, index) => (
-                        <Render key={index} {...child} />
-                    ))}
+                    {normalizeChildren(dialogChild.children).map(
+                        (child, index) => (
+                            <Render key={index} {...child} />
+                        )
+                    )}
                 </Dialog>
             );
         }
     }
 
-    const Component = registry[type] as React.ComponentType<any>;
+    const Component = registry[type] as React.ComponentType<
+        Record<string, unknown>
+    >;
 
     return (
         <Component {...props}>
-            {children?.map((child, i) => (
+            {resolvedChildren.map((child, i) => (
                 <Render key={i} {...child} />
             ))}
         </Component>


### PR DESCRIPTION
### Motivation
- The renderer crashed with "Objects are not valid as a React child (found: object with keys {type, props})" when the backend returned a single child object instead of an array.
- Make the schema renderer robust to malformed/non-array `children` in page schemas so the UI does not attempt to render raw objects as React children.

### Description
- Broadened `RenderNodeSchema.children` to accept `RenderNodeSchema | RenderNodeSchema[]` and added a runtime type guard `isRenderNodeSchema`.
- Added `normalizeChildren` helper that converts children into a safe array and filters out invalid nodes before rendering.
- Replaced direct `children` usage with the normalized children in both the button/dialog flow and the generic component rendering path.
- Tightened the dynamic component cast from `any` to `Record<string, unknown>` to satisfy linting and avoid `any` types.

### Testing
- Ran code formatting with `cd web && bun run format`, which completed successfully.
- Ran linting for the changed file with `cd web && bunx eslint src/components/Render.tsx`, which completed successfully.
- Launched the dev server and exercised the `/viavai` page via Playwright to verify the renderer no longer throws the React child error and captured a screenshot; this confirmed the crash was resolved.
- Attempted a full build with `cd web && bun run build`, which failed due to unrelated pre-existing TypeScript issues in other files and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923c8528ec8323a2dd10a67add4d78)