### PR TITLE
Fix schema-driven column rendering in ViaVai layout

### DIFF
--- a/web/src/components/viavai/Columns.tsx
+++ b/web/src/components/viavai/Columns.tsx
@@ -10,6 +10,13 @@ type ColumnsProps = {
     children?: ReactNode;
 };
 
+type WidthProps = {
+    width?: number;
+    props?: {
+        width?: number;
+    };
+};
+
 function toGridTemplate(widths: number[]) {
     if (widths.length === 0) {
         return '1fr';
@@ -34,10 +41,14 @@ export function Columns({ width, children }: ColumnsProps) {
     const columns = Children.toArray(children);
     const widths = columns.map((column) => {
         if (isValidElement(column)) {
-            const columnElement = column as ReactElement<{ width?: number }>;
+            const columnElement = column as ReactElement<WidthProps>;
 
             if (typeof columnElement.props.width === 'number') {
                 return columnElement.props.width;
+            }
+
+            if (typeof columnElement.props.props?.width === 'number') {
+                return columnElement.props.props.width;
             }
         }
 
@@ -51,10 +62,7 @@ export function Columns({ width, children }: ColumnsProps) {
         >
             {columns.map((column, index) => (
                 <div key={`column-${index}`} className="space-y-4">
-                    {isValidElement(column)
-                        ? (column as ReactElement<{ children?: ReactNode }>)
-                              .props.children
-                        : column}
+                    {column}
                 </div>
             ))}
         </div>


### PR DESCRIPTION
### Motivation
- The ViaVai page renderer can receive schema nodes like `{ type, props }` and the previous `Columns` implementation unwrapped children via `props.children`, which caused raw schema objects to be passed to React and triggered the runtime error `Objects are not valid as a React child`.
- Column width values emitted by the schema may be present as either `column.props.width` or wrapped in `column.props.props.width`, so the grid sizing logic needed to be more tolerant of both shapes.

### Description
- Updated `web/src/components/viavai/Columns.tsx` to render each column child element directly (`{column}`) instead of extracting `props.children`, preventing schema objects from being sent as React children.
- Added a `WidthProps` type and extraction logic that reads width from either `column.props.width` or `column.props.props.width` so schema-generated `<column props={{ width }}>` nodes are handled correctly.
- Kept existing behavior where a numeric `width` prop on `Columns` short-circuits and returns the children unchanged.

### Testing
- Ran the project formatter with `bun run format` which completed successfully.
- Attempted a full build with `bun run build` which failed due to unrelated pre-existing TypeScript errors in other files and not due to this change. (Build failure observed and is unrelated to this PR.)
- Started the dev server with `bun run dev` and verified the `/viavai` page rendered without the previous React error, and captured a verification screenshot from the running app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699242f22db48323a436606fe95e0018)