### PR TITLE
api: make menu sections render layout children

### DIFF
--- a/api/src/ui/__layout__.py
+++ b/api/src/ui/__layout__.py
@@ -44,7 +44,7 @@ class Layout:
 
 
     def menu(self) -> Menu:
-        menu = Menu()
+        menu = Menu(layout_factory=Layout)
         self._components.append(menu)
         return menu
 

--- a/api/src/ui/menu.py
+++ b/api/src/ui/menu.py
@@ -1,3 +1,10 @@
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .__layout__ import Layout
+
+
 class MenuSubSection:
     title: str
     href: str
@@ -16,14 +23,22 @@ class MenuSubSection:
 
 class MenuSection:
     title: str
-    href: str | None
     icon: str | None
 
-    def __init__(self, title: str, href: str | None = None, icon: str | None = None):
+    def __init__(
+        self,
+        title: str,
+        icon: str | None = None,
+        layout_factory: Callable[[], 'Layout'] | None = None,
+    ):
         self.title = title
-        self.href = href
         self.icon = icon
+        self._layout = layout_factory() if layout_factory else None
         self._sub_sections: list[MenuSubSection] = []
+
+    @property
+    def layout(self) -> 'Layout | None':
+        return self._layout
 
     def sub_section(self, title: str, href: str) -> MenuSubSection:
         sub_section = MenuSubSection(title=title, href=href)
@@ -34,18 +49,19 @@ class MenuSection:
         yield 'type', 'menuSection'
         yield 'props', {
             'title': self.title,
-            'href': self.href,
             'icon': self.icon,
         }
-        yield 'children', [dict(sub_section) for sub_section in self._sub_sections]
+        yield 'sections', [dict(sub_section) for sub_section in self._sub_sections]
+        yield 'children', list(self._layout) if self._layout else []
 
 
 class Menu:
-    def __init__(self):
+    def __init__(self, layout_factory: Callable[[], 'Layout'] | None = None):
+        self._layout_factory = layout_factory
         self._sections: list[MenuSection] = []
 
-    def section(self, title: str, href: str | None = None, icon: str | None = None) -> MenuSection:
-        section = MenuSection(title=title, href=href, icon=icon)
+    def section(self, title: str, icon: str | None = None) -> MenuSection:
+        section = MenuSection(title=title, icon=icon, layout_factory=self._layout_factory)
         self._sections.append(section)
         return section
 


### PR DESCRIPTION
### Motivation
- Replace per-section `href` routing with per-section nested layout content so the API can provide the children to render when a menu section is active.
- Keep subsection links intact while avoiding payload conflicts between link lists and renderable section content.

### Description
- Removed `href` from `MenuSection` constructor and props and added support for an injected `layout_factory` so each section can own a `Layout` instance exposed via `layout` and serialized as `children`.
- Changed subsection serialization key from `children` to `sections` so `children` can be used for the section's renderable layout content.
- Updated `Menu` to accept a `layout_factory` and to create `MenuSection` instances with that factory, removing the `href` argument from `section(...)`.
- Updated `Layout.menu()` to pass `layout_factory=Layout` to `Menu` so sections can construct nested UI content; added type-only imports for `Layout` to avoid circular imports.

### Testing
- Ran `cd api && python -m compileall src` which completed successfully and compiled all changed modules without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992463e2c4883239f3d8e7d9f450540)