### PR TITLE
refactor(web): move ViaVai menu component and render sample page

### DIFF
--- a/web/src/components/viavai/Menu.tsx
+++ b/web/src/components/viavai/Menu.tsx
@@ -8,6 +8,9 @@ import {
     Shield,
 } from 'lucide-react';
 
+import Render, { type RenderNodeSchema } from '@/components/Render';
+import { useData } from '@/hooks/use-data';
+
 type ViaVaiSubMenuItem = {
     id: string;
     label: string;
@@ -70,6 +73,7 @@ const sectionSubtitle: Record<string, string> = {
 export function ViaVaiMenu() {
     const [openSection, setOpenSection] = useState<string>('billing');
     const [activeSection, setActiveSection] = useState<string>('overview');
+    const samplePage = useData<RenderNodeSchema>('/sample/page');
 
     const selectedTopLevel = useMemo(() => {
         return (
@@ -148,13 +152,23 @@ export function ViaVaiMenu() {
                 })}
             </aside>
 
-            <section className="space-y-2">
+            <section className="space-y-4">
                 <h2 className="text-2xl font-semibold">
                     {sectionTitle[activeSection]}
                 </h2>
                 <p className="max-w-xl text-sm text-white/60">
                     {sectionSubtitle[activeSection]}
                 </p>
+
+                {samplePage.isLoading && (
+                    <p className="text-sm text-white/60">
+                        Loading sample page...
+                    </p>
+                )}
+                {samplePage.error && (
+                    <p className="text-sm text-red-300">{samplePage.error}</p>
+                )}
+                {samplePage.data && <Render {...samplePage.data} />}
             </section>
         </div>
     );

--- a/web/src/pages/user/ViaVai.tsx
+++ b/web/src/pages/user/ViaVai.tsx
@@ -1,4 +1,4 @@
-import { ViaVaiMenu } from '@/components/viavai-menu';
+import { ViaVaiMenu } from '@/components/viavai/Menu';
 
 export default function ViaVai() {
     return <ViaVaiMenu />;


### PR DESCRIPTION
### Motivation
- Consolidate ViaVai UI by moving the standalone menu into the `viavai` component folder and surface a sample app page inside the menu content area.
- Provide a simple integration point that can render server-provided UI schema from the sample ViaVai app (`/sample/page`).

### Description
- Renamed `web/src/components/viavai-menu.tsx` to `web/src/components/viavai/Menu.tsx` and kept the exported `ViaVaiMenu` component in the new location.
- Updated `web/src/pages/user/ViaVai.tsx` to import from `@/components/viavai/Menu`.
- Wired the menu content area to fetch `/sample/page` via the existing `useData` hook (`useData<RenderNodeSchema>('/sample/page')`) and render the result with the shared `Render` component, including loading and error states.
- Ran formatting on the `web/` package (`bun run format`) and applied resulting changes.

### Testing
- Ran `bun run format` in `web/` which completed successfully.
- Ran `bun run build` in `web/` which failed due to pre-existing TypeScript issues unrelated to these edits (errors in `resizable.tsx`, missing `@/hooks/use-mobile`, and missing `@/components/navigation`).
- Launched the dev server and executed an automated Playwright script to open `http://localhost:4173/viavai` and capture a screenshot of the rendered ViaVai menu and sample content, which produced an artifact (`artifacts/viavai-menu-render.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992582f23fc8323abeb44a7c6e61a5b)