### PR TITLE
Delegate layout methods on Tab and fix sample table API usage

### DIFF
--- a/api/src/routes/sample.py
+++ b/api/src/routes/sample.py
@@ -139,10 +139,10 @@ async def form():
             },
         ]
     )
-    table.add_column("invoice", label="Invoice", cell=["{invoiceNumber}", "Issued {issueDate}", "Status: {status}"], align="left")
-    table.add_column("client", label="Client", cell=["{client.name}", "{client.email}"])
-    table.add_column("dueDate", label="Dates", cell=["{issueDate}", "Due date: {dueDate}"], align="left")
-    table.add_column("amount", label="Amount", cell=["€{subtotal}", "VAT €{vat}"], align="right")
+    table.column('invoice', label='Invoice', cell=['{invoiceNumber}', 'Issued {issueDate}', 'Status: {status}'], align='left')
+    table.column('client', label='Client', cell=['{client.name}', '{client.email}'])
+    table.column('dueDate', label='Dates', cell=['{issueDate}', 'Due date: {dueDate}'], align='left')
+    table.column('amount', label='Amount', cell=['€{subtotal}', 'VAT €{vat}'], align='right')
 
 
     return list(page)

--- a/api/src/ui/Tabs.py
+++ b/api/src/ui/Tabs.py
@@ -11,6 +11,9 @@ class Tab:
     title: str
     _layout: 'Layout'
 
+    def __getattr__(self, item: str):
+        return getattr(self._layout, item)
+
     def __iter__(self):
         yield 'type', 'tab'
         yield 'props', {


### PR DESCRIPTION
### Motivation
- The sample page raised `AttributeError: 'Tab' object has no attribute 'hero'` because tab instances did not forward layout builder methods to their internal layout. 
- The sample route used a non-existent `add_column` API on `Table`, causing a runtime error when constructing the final table.

### Description
- Add `__getattr__` to `Tab` so attribute access delegates to the underlying layout and builder methods like `hero`, `table`, and `button` work on `Tab` instances (`api/src/ui/Tabs.py`).
- Replace incorrect `table.add_column(...)` calls with the correct `table.column(...)` API in the sample route (`api/src/routes/sample.py`).
- The changes keep the public `Table` API and improve ergonomics for building tab content by forwarding calls to the tab's internal layout.

### Testing
- Ran a local automated invocation of `src.routes.sample.form` which successfully returned the page schema and included the `tabs` payload with the expected tab titles, and the script completed without raising the previous `AttributeError`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925d04bc808323a1d8de6bb3cc3d7b)