### PR TITLE
Add sidebar-based UI component showcase to /sample/page and fix UI builders

### DIFF
--- a/api/src/routes/sample.py
+++ b/api/src/routes/sample.py
@@ -1,148 +1,86 @@
-from src.ui import Layout
 from src.router import router
+from src.ui import Page
 
 
-# A LongLink page takes a URL, with filders and stuff. If is not possible to show in a single page then the content is too complex
-# Each POST request from the page shall automatically re-render the page. Given that we assume new data has come
+# A LongLink page takes a URL, with folders and stuff. If it's not possible to show in a single
+# page then the content is too complex.
 @router.get('/sample/page')
 async def form():
-    """Return an example page schema payload with a hero component."""
-    page = Layout()
-    page.hero(title='Data Table', subtitle='This is an example of a data table component.')
-    primary_action = page.button(text='Primary action')
-    dialog = primary_action.dialog(confirm='Submit', cancel='Cancel')
+    """Return a showcase page schema payload for UI component examples."""
+    page = Page()
 
-    dialog_table = dialog.table(
+    page.hero(
+        title='UI Components Showcase',
+        subtitle='A complete sample using sidebar, table, tabs, hero, columns, buttons and dialog.',
+    )
+
+    menu = page.menu()
+
+    first_section = menu.section('1) Table Showcase', icon='table')
+    first_section.hero(
+        title='Customers Table',
+        subtitle='The first sidebar section demonstrates table rendering.',
+    )
+    customers_table = first_section.table(
         [
             {
                 'id': '1',
                 'name': 'Acme Corp',
                 'owner': 'Adriano Saurwein',
+                'status': 'Active',
             },
             {
                 'id': '2',
                 'name': 'LongLink',
                 'owner': 'Leonardo Saurwein',
+                'status': 'Pilot',
             },
         ]
     )
-    dialog_table.column('name', label='Name', cell='{name}')
-    dialog_table.column('owner', label='Owner', cell='{owner}')
+    customers_table.column('name', label='Name', cell='{name}')
+    customers_table.column('owner', label='Owner', cell='{owner}')
+    customers_table.column('status', label='Status', cell='{status}', align='right')
 
-    table = page.table(
+    second_section = menu.section('2) Tabs Showcase', icon='tabs')
+    second_section.hero(
+        title='Tabbed navigation',
+        subtitle='The second sidebar section includes two subsections with tabs and extra UI.',
+    )
+
+    hero_subsection = second_section.section('Hero subsection')
+    hero_subsection.hero(
+        title='Hero in subsection',
+        subtitle='This subsection starts with a hero and a call to action button.',
+    )
+    action_button = hero_subsection.button(text='Open dialog', variant='outline')
+    action_dialog = action_button.dialog(confirm='Create', cancel='Close')
+    action_dialog.hero(title='Dialog example', subtitle='This is a dialog opened from a button.')
+
+    tabs_subsection = second_section.section('Tabs subsection')
+    overview_tab, details_tab = tabs_subsection.tabs(['Overview', 'Details'])
+
+    overview_tab.hero(
+        title='Overview tab content',
+        subtitle='Quick project metrics and contextual information.',
+    )
+    overview_tab.button(text='Primary action')
+    overview_tab.separator()
+
+    detail_table = details_tab.table(
         [
-            {
-                'id': '1',
-                'client': {
-                    'name': 'Adriano Saurwein',
-                    'email': 'adriano@email.com',
-                },
-                'invoiceNumber': 'INV-001',
-                'issueDate': '2024-01-10',
-                'dueDate': '2024-01-20',
-                'status': 'Paid',
-                'subtotal': 1000,
-                'vat': 200,
-            },
-            {
-                'id': '2',
-                'client': {
-                    'name': 'Leonardo Saurwein',
-                    'email': 'leo@email.com',
-                },
-                'invoiceNumber': 'INV-002',
-                'issueDate': '2024-01-15',
-                'dueDate': '2024-01-30',
-                'status': 'Pending',
-                'subtotal': 450,
-                'vat': 90,
-            },
+            {'id': 'a1', 'metric': 'Open invoices', 'value': '12'},
+            {'id': 'a2', 'metric': 'Overdue invoices', 'value': '3'},
+            {'id': 'a3', 'metric': 'Total clients', 'value': '27'},
         ]
     )
-    table.column("invoice", label="Invoice", cell=["{invoiceNumber}", "Issued {issueDate}", "Status: {status}"], align="left")
-    table.column("client", label="Client", cell=["{client.name}", "{client.email}"])
-    table.column("dueDate", label="Dates", cell=["{issueDate}", "Due date: {dueDate}"], align="left")
-    table.column("amount", label="Amount", cell=["€{subtotal}", "VAT €{vat}"], align="right")
+    detail_table.column('metric', label='Metric', cell='{metric}')
+    detail_table.column('value', label='Value', cell='{value}', align='right')
 
-    
-    col1, col2 = page.columns([70, 30])
+    page.separator()
 
-    col1.hero(title="Column 1", subtitle="This is the first column")
-    col2.hero(title="Column 2", subtitle="This is the second column")
-    col2.button(text='Secondary action', variant='outline')
-    col2.separator()
-    col2.hero(title="After separator", subtitle="This section starts after a horizontal separator")
-
-    tabs = page.tabs(default_tab='Overview')
-
-    overview_tab = tabs.tab('Overview')
-    overview_tab.hero(title='Overview tab', subtitle='This content is rendered inside a tab component.')
-
-    details_tab = tabs.tab('Details')
-    details_tab.table(
-        [
-            {
-                'id': 'a1',
-                'metric': 'Open invoices',
-                'value': '12',
-            },
-            {
-                'id': 'a2',
-                'metric': 'Overdue invoices',
-                'value': '3',
-            },
-        ]
-    ).column('metric', label='Metric', cell='{metric}')
-    details_tab.table(
-        [
-            {
-                'id': 'b1',
-                'metric': 'Open invoices',
-                'value': '12',
-            },
-            {
-                'id': 'b2',
-                'metric': 'Overdue invoices',
-                'value': '3',
-            },
-        ]
-    ).column('value', label='Value', cell='{value}', align='right')
-
-
-    table = col1.table(
-        [
-            {
-                'id': '1',
-                'client': {
-                    'name': 'Adriano Saurwein',
-                    'email': 'adriano@email.com',
-                },
-                'invoiceNumber': 'INV-001',
-                'issueDate': '2024-01-10',
-                'dueDate': '2024-01-20',
-                'status': 'Paid',
-                'subtotal': 1000,
-                'vat': 200,
-            },
-            {
-                'id': '2',
-                'client': {
-                    'name': 'Leonardo Saurwein',
-                    'email': 'leo@email.com',
-                },
-                'invoiceNumber': 'INV-002',
-                'issueDate': '2024-01-15',
-                'dueDate': '2024-01-30',
-                'status': 'Pending',
-                'subtotal': 450,
-                'vat': 90,
-            },
-        ]
-    )
-    table.column('invoice', label='Invoice', cell=['{invoiceNumber}', 'Issued {issueDate}', 'Status: {status}'], align='left')
-    table.column('client', label='Client', cell=['{client.name}', '{client.email}'])
-    table.column('dueDate', label='Dates', cell=['{issueDate}', 'Due date: {dueDate}'], align='left')
-    table.column('amount', label='Amount', cell=['€{subtotal}', 'VAT €{vat}'], align='right')
-
+    left_col, right_col = page.columns([70, 30])
+    left_col.hero(title='Columns: main area', subtitle='A wider column for primary information.')
+    right_col.hero(title='Columns: side area', subtitle='A narrow column for quick actions.')
+    right_col.button(text='Secondary action', variant='secondary')
 
     return list(page)

--- a/api/src/ui/Tabs.py
+++ b/api/src/ui/Tabs.py
@@ -1,13 +1,11 @@
 from dataclasses import dataclass, field
+
 from src.ui.__root__ import Component
-
-
-# Importing components that can be used in a Page
-from src.ui.hero import Hero
-from src.ui.table import Table
 from src.ui.button import Button, ButtonVariants
 from src.ui.columns import Column, Columns
+from src.ui.hero import Hero
 from src.ui.separator import Separator
+from src.ui.table import Table
 
 
 @dataclass
@@ -31,24 +29,24 @@ class Tab(Component):
         table = Table(data=data)
         self._children.append(table)
         return table
-    
+
     def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
         button = Button(text=text, variant=variant)
         self._children.append(button)
         return button
-    
+
     def columns(self, widths: list[int]) -> list[Column]:
         columns = Columns()
         self._children.append(columns)
         return [columns.column(width=width) for width in widths]
-    
+
     def separator(self) -> Separator:
         separator = Separator()
         self._children.append(separator)
         return separator
 
 
-
+@dataclass
 class Tabs(Component):
     _children: list[Tab] = field(default_factory=list)
 

--- a/api/src/ui/columns.py
+++ b/api/src/ui/columns.py
@@ -1,12 +1,10 @@
 from dataclasses import dataclass, field
+
 from src.ui.__root__ import Component
-
-
-# Importing components that can be used in a Column
-from src.ui.hero import Hero
-from src.ui.table import Table
 from src.ui.button import Button, ButtonVariants
+from src.ui.hero import Hero
 from src.ui.separator import Separator
+from src.ui.table import Table
 
 
 @dataclass
@@ -23,23 +21,24 @@ class Column(Component):
         hero = Hero(title=title, subtitle=subtitle)
         self._components.append(hero)
         return hero
-    
+
     def table(self, data: list[dict]) -> Table:
         table = Table(data=data)
         self._components.append(table)
         return table
-    
+
     def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
         button = Button(text=text, variant=variant)
         self._components.append(button)
         return button
-    
+
     def separator(self) -> Separator:
         separator = Separator()
         self._components.append(separator)
         return separator
-    
 
+
+@dataclass
 class Columns(Component):
     _children: list[Column] = field(default_factory=list)
 

--- a/api/src/ui/menu.py
+++ b/api/src/ui/menu.py
@@ -1,16 +1,12 @@
-from collections.abc import Callable
 from dataclasses import dataclass, field
+
 from src.ui.__root__ import Component
-
-
-# Importing components that can be used in a Page
-from src.ui.tabs import Tab, Tabs
-from src.ui.menu import Menu
-from src.ui.hero import Hero
-from src.ui.table import Table
+from src.ui.Tabs import Tab, Tabs
 from src.ui.button import Button, ButtonVariants
 from src.ui.columns import Column, Columns
+from src.ui.hero import Hero
 from src.ui.separator import Separator
+from src.ui.table import Table
 
 
 @dataclass
@@ -23,32 +19,32 @@ class MenuSubSection(Component):
         hero = Hero(title=title, subtitle=subtitle)
         self._children.append(hero)
         return hero
-    
+
     def table(self, data: list[dict]) -> Table:
         table = Table(data=data)
         self._children.append(table)
         return table
-    
+
     def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
         button = Button(text=text, variant=variant)
         self._children.append(button)
         return button
-    
+
     def columns(self, widths: list[int]) -> list[Column]:
         columns = Columns()
         self._children.append(columns)
         return [columns.column(width=width) for width in widths]
-    
+
     def separator(self) -> Separator:
         separator = Separator()
         self._children.append(separator)
         return separator
-    
+
     def tabs(self, names: list[str]) -> list[Tab]:
         tabs = Tabs()
         self._children.append(tabs)
         return [tabs.tab(name=name) for name in names]
-    
+
     def __iter__(self):
         yield 'type', 'menuSubSection'
         yield 'props', {
@@ -74,27 +70,27 @@ class MenuSection(Component):
         hero = Hero(title=title, subtitle=subtitle)
         self._root._children.append(hero)
         return hero
-    
+
     def table(self, data: list[dict]) -> Table:
         table = Table(data=data)
         self._root._children.append(table)
         return table
-    
+
     def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
         button = Button(text=text, variant=variant)
         self._root._children.append(button)
         return button
-    
+
     def columns(self, widths: list[int]) -> list[Column]:
         columns = Columns()
         self._root._children.append(columns)
         return [columns.column(width=width) for width in widths]
-    
+
     def separator(self) -> Separator:
         separator = Separator()
         self._root._children.append(separator)
         return separator
-    
+
     def tabs(self, names: list[str]) -> list[Tab]:
         tabs = Tabs()
         self._root._children.append(tabs)

--- a/api/src/ui/page.py
+++ b/api/src/ui/page.py
@@ -1,29 +1,26 @@
 from dataclasses import dataclass, field
-from src.ui.__root__ import Component
 
-# Importing components that can be used in a Page
-from src.ui.tabs import Tab, Tabs
-from src.ui.menu import Menu
-from src.ui.hero import Hero
-from src.ui.table import Table
+from src.ui.__root__ import Component
+from src.ui.Tabs import Tab, Tabs
 from src.ui.button import Button, ButtonVariants
 from src.ui.columns import Column, Columns
+from src.ui.hero import Hero
+from src.ui.menu import Menu
 from src.ui.separator import Separator
+from src.ui.table import Table
 
 
 @dataclass
 class Page:
-    """Top-level component that represents a page in the UI
-    
-    A Page renders the components in the order they were added.
-    """
+    """Top-level component that represents a page in the UI."""
+
     _children: list[Component] = field(default_factory=list)
-    
+
     def hero(self, title: str, subtitle: str | None = None) -> Hero:
         hero = Hero(title=title, subtitle=subtitle)
         self._children.append(hero)
         return hero
-    
+
     def table(self, data: list[dict]) -> Table:
         table = Table(data=data)
         self._children.append(table)
@@ -33,7 +30,7 @@ class Page:
         button = Button(text=text, variant=variant)
         self._children.append(button)
         return button
-    
+
     def columns(self, widths: list[int]) -> list[Column]:
         columns = Columns()
         self._children.append(columns)
@@ -53,7 +50,7 @@ class Page:
         separator = Separator()
         self._children.append(separator)
         return separator
-    
+
     def __iter__(self):
         for component in self._children:
             yield dict(component)


### PR DESCRIPTION
### Motivation
- Update the sample page to reflect the new UI elements by providing a comprehensive showcase using a sidebar with two elements, the second containing two subsections. 
- Ensure the SDK/API UI builder internals are correct so composed components (tabs, columns, menu subsections, dialog) can be constructed without runtime errors.

### Description
- Reworked `GET /sample/page` to use `Page()` and return a showcase that includes a `menu` (sidebar) with two sections: a table showcase and a tabs showcase with two subsections, plus `hero`, `separator`, and `columns` examples (`api/src/routes/sample.py`).
- Implemented subsection composition (hero, button→dialog, tabs→tab content, tables) so the second menu section contains a `Hero subsection` and a `Tabs subsection` with `Overview` and `Details` content (`api/src/routes/sample.py`).
- Fixed UI builder classes and imports to use dataclass-backed mutable child lists and correct module names so children can be appended safely (changes in `api/src/ui/page.py`, `api/src/ui/menu.py`, `api/src/ui/Tabs.py`, `api/src/ui/columns.py`).
- Small API surface cleanup and wiring so `Page.menu()`, `Menu.section()`, `MenuSubSection.tabs()`, `Columns.column()` and `Tabs.tab()` behave consistently when building the page schema.

### Testing
- Ran `python -m compileall api/src` and the source under `api/src` compiled successfully. 
- Executed the page generator with `PYTHONPATH=api python - <<'PY' ...` to run `src.routes.sample.form()` and verified it returns a list schema (execution completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699268c2c4688323acf68661af529cad)