### PR TITLE
Fix ViaVai menu rendering so sidebar appears

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -60,6 +60,58 @@ function normalizeChildren(
 function Render({ type, props, children }: RenderNodeSchema) {
     const resolvedChildren = normalizeChildren(children);
 
+    if (type === 'menu') {
+        return (
+            <Menu>
+                {resolvedChildren.map((section, sectionIndex) => {
+                    if (section.type !== 'menusection') {
+                        return <Render key={sectionIndex} {...section} />;
+                    }
+
+                    return (
+                        <MenuSection
+                            key={sectionIndex}
+                            {...(section.props as React.ComponentProps<
+                                typeof MenuSection
+                            >)}
+                        >
+                            {normalizeChildren(section.children).map(
+                                (subSection, subSectionIndex) => {
+                                    if (subSection.type !== 'menuSubSection') {
+                                        return (
+                                            <Render
+                                                key={subSectionIndex}
+                                                {...subSection}
+                                            />
+                                        );
+                                    }
+
+                                    return (
+                                        <MenuSubSection
+                                            key={subSectionIndex}
+                                            {...(subSection.props as React.ComponentProps<
+                                                typeof MenuSubSection
+                                            >)}
+                                        >
+                                            {normalizeChildren(
+                                                subSection.children
+                                            ).map((child, childIndex) => (
+                                                <Render
+                                                    key={childIndex}
+                                                    {...child}
+                                                />
+                                            ))}
+                                        </MenuSubSection>
+                                    );
+                                }
+                            )}
+                        </MenuSection>
+                    );
+                })}
+            </Menu>
+        );
+    }
+
     if (type === 'button') {
         const dialogChild = resolvedChildren.find(
             (child) => child.type === 'dialog'


### PR DESCRIPTION
### Motivation
- The ViaVai menu/sidebar was not appearing because menu schema nodes were being rendered through the generic renderer and lost the structural relationship `Menu.tsx` expects (MenuSection / MenuSubSection). 
- Restore the explicit mapping of API schema nodes to the Menu components so the sidebar can be built from the page schema.

### Description
- Add a dedicated `menu` branch in `web/src/components/Render.tsx` that reconstructs `<Menu>`, `<MenuSection>`, and `<MenuSubSection>` from `menusection` and `menuSubSection` schema nodes before recursively rendering children. 
- Preserve the generic recursive rendering fallback for unexpected child node types so non-menu nodes continue to work. 
- Apply formatting to the web project file modified (`Render.tsx`).

### Testing
- Ran `bun run format` in `web` and it completed successfully. 
- Ran `bunx eslint src/components/Render.tsx` and linting for the modified file passed. 
- Attempted `bun run build` in `web` which failed due to unrelated pre-existing TypeScript/type-import issues in other files (`resizable.tsx`, `scroll-area.tsx`, `sidebar.tsx`, `Organization.tsx`). 
- Started the dev server and executed an automated Playwright script to capture a screenshot which produced an artifact demonstrating the menu render change (`browser:/tmp/codex_browser_invocations/.../artifacts/artifacts/menu-fixed.png`), noting that end-to-end data fetching in the browser was blocked by the API CORS policy in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927178773c8323a7b1e582e9dd8b71)