### PR TITLE
web: let Button handle dialog children directly

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -112,36 +112,6 @@ function Render({ type, props, children }: RenderNodeSchema) {
         );
     }
 
-    if (type === 'button') {
-        const dialogChild = resolvedChildren.find(
-            (child) => child.type === 'dialog'
-        );
-
-        if (dialogChild) {
-            const dialogProps =
-                (dialogChild.props as { confirm?: string; cancel?: string }) ??
-                {};
-
-            return (
-                <Dialog
-                    trigger={
-                        <Button
-                            {...(props as React.ComponentProps<typeof Button>)}
-                        />
-                    }
-                    confirm={dialogProps.confirm}
-                    cancel={dialogProps.cancel}
-                >
-                    {normalizeChildren(dialogChild.children).map(
-                        (child, index) => (
-                            <Render key={index} {...child} />
-                        )
-                    )}
-                </Dialog>
-            );
-        }
-    }
-
     const Component = registry[type] as React.ComponentType<
         Record<string, unknown>
     >;


### PR DESCRIPTION
### Motivation

- Simplify `Render` by removing a special-case branch that detected `type === 'button'` and inlined dialog handling, because the `Button` component already wraps children into a dialog when present.

### Description

- Removed the `type === 'button'` branch in `web/src/components/Render.tsx` so `button` nodes follow the generic rendering path like other components.
- `Render` now forwards children to the registered component directly and relies on `Button` (in `web/src/components/viavai/Button.tsx`) to create a `Dialog` when it has children.

### Testing

- Ran formatting with `bun run format` in `web/` and it completed successfully.
- Attempted build with `bun run build` in `web/` and it failed due to pre-existing TypeScript errors unrelated to this change (errors in `src/components/ui/resizable.tsx` and missing module references elsewhere).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992734dba788323a50204f75f63bb82)