### PR TITLE
web: align VaiVai tabs with default shadcn appearance

### DIFF
--- a/web/src/components/viavai/Tabs.tsx
+++ b/web/src/components/viavai/Tabs.tsx
@@ -80,7 +80,7 @@ export function Tabs({ children, defaultTab }: TabsProps) {
 
     return (
         <UITabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList variant="line">
+            <TabsList>
                 {tabs.map((tab, index) => {
                     const title = tab.props.title ?? tab.props.props?.title;
                     const resolvedTitle =


### PR DESCRIPTION
### Motivation
- Make rendered VaiVai tabs match the default shadcn tab appearance so app subsections look like segmented tabs instead of button-like toggles.

### Description
- Remove the `variant="line"` prop from `TabsList` in `web/src/components/viavai/Tabs.tsx` so the default shadcn `TabsList` styling is applied.

### Testing
- Ran `bun run format` in `web` (succeeded), attempted `bun run build` in `web` (failed due to pre-existing TypeScript issues unrelated to this change), and started the dev server and captured a screenshot of `/viavai` with a mocked `/sample/page` response to visually confirm the tab styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992739f23e883238c67728fe55dfadf)