### PR TITLE
web: update VaiVai Tabs to consume `tabs` prop and use shadcn defaultValue

### DIFF
--- a/web/src/components/viavai/Tabs.tsx
+++ b/web/src/components/viavai/Tabs.tsx
@@ -2,7 +2,6 @@ import {
     Children,
     isValidElement,
     useMemo,
-    useState,
     type ReactElement,
     type ReactNode,
 } from 'react';
@@ -15,8 +14,8 @@ import {
 } from '@/components/ui/tabs';
 
 type TabsProps = {
+    tabs: string[];
     children?: ReactNode;
-    defaultTab?: string;
 };
 
 export type TabProps = {
@@ -25,7 +24,7 @@ export type TabProps = {
 };
 
 type ParsedTab = {
-    name: string;
+    name?: string;
     children?: ReactNode;
 };
 
@@ -33,8 +32,8 @@ export function Tab({ children }: TabProps) {
     return <>{children}</>;
 }
 
-export function Tabs({ children, defaultTab }: TabsProps) {
-    const tabs = useMemo<ParsedTab[]>(() => {
+export function Tabs({ tabs, children }: TabsProps) {
+    const parsedTabs = useMemo<ParsedTab[]>(() => {
         return Children.toArray(children)
             .filter((child): child is ReactElement<TabProps> => {
                 return isValidElement(child) && child.type === Tab;
@@ -42,33 +41,31 @@ export function Tabs({ children, defaultTab }: TabsProps) {
             .map((tab) => ({
                 name: tab.props.name,
                 children: tab.props.children,
-            }))
-            .filter((tab) => Boolean(tab.name));
+            }));
     }, [children]);
 
-    const firstTab = tabs[0]?.name;
-    const [selectedTab, setSelectedTab] = useState<string | undefined>();
+    const tabItems = useMemo(
+        () =>
+            tabs.map((name, index) => {
+                const tabByName = parsedTabs.find((tab) => tab.name === name);
 
-    const activeTab = useMemo(() => {
-        if (defaultTab && tabs.some((tab) => tab.name === defaultTab)) {
-            return defaultTab;
-        }
+                return {
+                    name,
+                    children:
+                        tabByName?.children ?? parsedTabs[index]?.children,
+                };
+            }),
+        [parsedTabs, tabs]
+    );
 
-        if (selectedTab && tabs.some((tab) => tab.name === selectedTab)) {
-            return selectedTab;
-        }
-
-        return firstTab;
-    }, [defaultTab, firstTab, selectedTab, tabs]);
-
-    if (!tabs.length || !activeTab) {
+    if (!tabItems.length) {
         return null;
     }
 
     return (
-        <UITabs value={activeTab} onValueChange={setSelectedTab}>
+        <UITabs defaultValue={tabItems[0]?.name}>
             <TabsList>
-                {tabs.map((tab) => (
+                {tabItems.map((tab) => (
                     <TabsTrigger
                         key={`tab-trigger-${tab.name}`}
                         value={tab.name}
@@ -78,7 +75,7 @@ export function Tabs({ children, defaultTab }: TabsProps) {
                 ))}
             </TabsList>
 
-            {tabs.map((tab) => (
+            {tabItems.map((tab) => (
                 <TabsContent key={`tab-content-${tab.name}`} value={tab.name}>
                     <div className="space-y-4">{tab.children}</div>
                 </TabsContent>


### PR DESCRIPTION
### Motivation
- The API/tab schema now provides an explicit `tabs` list and the UI should follow shadcn's default tab behavior instead of a custom `defaultTab` prop.
- Simplify the Tabs component to use the incoming `tabs` array as the source of truth for ordering and default selection.

### Description
- Updated `web/src/components/viavai/Tabs.tsx` to accept `tabs: string[]` and `children` and removed the `defaultTab` prop and internal controlled state.
- Parse `Tab` children via `Children.toArray` and map each incoming `tabs` entry to its corresponding child content (matching by name with an index fallback).
- Use shadcn-style `UITabs` initialization with `defaultValue={tabItems[0]?.name}` and render triggers/content from the computed `tabItems` list.
- Minor type adjustments for parsed tab shapes and simplification of rendering loops.

### Testing
- Ran code formatting with `bun run format` in `web/` and `bunx prettier web/src/components/viavai/Tabs.tsx --check`, both succeeded.
- Started the dev server with `bun run dev` and captured a screenshot of `/viavai` to validate runtime UI changes (succeeded).
- Attempted a production build with `bun run build`, which failed due to pre-existing unrelated TypeScript errors in other files, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699325e4dcd883239aa2bfc33236bce2)