### PR TITLE
web: clarify Columns layout handling with new `widths` prop

### DIFF
--- a/web/src/components/viavai/Columns.tsx
+++ b/web/src/components/viavai/Columns.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react';
 
 type ColumnsProps = {
-    width?: number;
+    widths?: number[];
     children?: ReactNode;
 };
 
@@ -17,20 +17,20 @@ type ColumnProps = {
 
 type WidthProps = {
     width?: number;
-    props?: {
-        width?: number;
-    };
 };
 
-function toGridTemplate(widths: number[]) {
-    if (widths.length === 0) {
-        return '1fr';
-    }
+function hasUsableWidths(
+    widths: number[] | undefined,
+    columnsCount: number
+): widths is number[] {
+    return Array.isArray(widths) && widths.length === columnsCount;
+}
 
+function toGridTemplate(widths: number[]) {
     const total = widths.reduce((sum, width) => sum + width, 0);
 
     if (total <= 0) {
-        return `repeat(${widths.length}, minmax(0, 1fr))`;
+        return `repeat(${widths.length || 1}, minmax(0, 1fr))`;
     }
 
     return widths
@@ -38,32 +38,30 @@ function toGridTemplate(widths: number[]) {
         .join(' ');
 }
 
-export function Columns({ width, children }: ColumnsProps) {
-    if (typeof width === 'number') {
-        return <>{children}</>;
-    }
-
-    const columns = Children.toArray(children);
-    const widths = columns.map((column) => {
-        if (isValidElement(column)) {
-            const columnElement = column as ReactElement<WidthProps>;
-
-            if (typeof columnElement.props.width === 'number') {
-                return columnElement.props.width;
-            }
-
-            if (typeof columnElement.props.props?.width === 'number') {
-                return columnElement.props.props.width;
-            }
+function getLegacyColumnWidths(columns: ReactNode[]) {
+    return columns.map((column) => {
+        if (!isValidElement(column)) {
+            return 1;
         }
 
-        return 1;
+        const columnElement = column as ReactElement<WidthProps>;
+
+        return typeof columnElement.props.width === 'number'
+            ? columnElement.props.width
+            : 1;
     });
+}
+
+export function Columns({ widths, children }: ColumnsProps) {
+    const columns = Children.toArray(children);
+    const resolvedWidths = hasUsableWidths(widths, columns.length)
+        ? widths
+        : getLegacyColumnWidths(columns);
 
     return (
         <div
             className="grid gap-4"
-            style={{ gridTemplateColumns: toGridTemplate(widths) }}
+            style={{ gridTemplateColumns: toGridTemplate(resolvedWidths) }}
         >
             {columns.map((column, index) => (
                 <div key={`column-${index}`} className="space-y-4">


### PR DESCRIPTION
### Motivation
- Backend `Columns` now exposes a `widths` array in the schema, so the frontend needs to consume that instead of the legacy top-level `width` prop. 
- Make the `Columns` implementation clearer and easier to reason about by splitting width resolution into small helpers, following the readability style used in `Tabs.tsx`.

### Description
- Replace `width?: number` with `widths?: number[]` on `Columns` and accept the backend-provided widths when available by checking `hasUsableWidths`. 
- Add `getLegacyColumnWidths` to preserve backward compatibility by extracting per-child `width` props when `widths` is missing or the length mismatches. 
- Consolidate grid calculation into `toGridTemplate` which computes relative `minmax(...)` column sizes and falls back to safe `repeat(..., minmax(0, 1fr))` behavior when totals are invalid. 
- Keep `Column` as a passthrough component; update types to reflect the new shape and make intent explicit.

### Testing
- Ran formatter with `bun run format` and formatting completed successfully. 
- Ran a build with `bun run build`; the build fails due to unrelated pre-existing TypeScript issues in other files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`, `src/pages/org/Organization.tsx`), and there are no new type errors reported from the updated `Columns.tsx`. 
- Launched the dev server with `bun run dev --host 0.0.0.0 --port 4173` and captured a screenshot to validate the runtime UI rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932e8b2f988323a3e45e994f8ee4d5)