### PR TITLE
web: enforce single active menu section and pointer cursor

### DIFF
--- a/web/src/components/ui/menu.tsx
+++ b/web/src/components/ui/menu.tsx
@@ -29,7 +29,7 @@ type MenuProps = {
 };
 
 const menuItemVariants = cva(
-    'group/menu-item focus-visible:ring-ring/50 relative inline-flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+    'group/menu-item focus-visible:ring-ring/50 relative inline-flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
     {
         variants: {
             active: {
@@ -76,18 +76,17 @@ export function Menu({
 
     const activeValue = isControlled ? value : internalValue;
 
-    const [expandedSections, setExpandedSections] = React.useState<Set<string>>(
-        () => {
-            const activeSectionId = sections.find(
+    const [expandedSectionId, setExpandedSectionId] = React.useState<
+        string | undefined
+    >(
+        () =>
+            sections.find(
                 (section) =>
                     section.id === activeValue ||
                     section.subSections?.some(
                         (subSection) => subSection.id === activeValue
                     )
-            )?.id;
-
-            return new Set(activeSectionId ? [activeSectionId] : []);
-        }
+            )?.id
     );
 
     React.useEffect(() => {
@@ -126,15 +125,7 @@ export function Menu({
             return;
         }
 
-        setExpandedSections((previous) => {
-            if (previous.has(activeSectionId)) {
-                return previous;
-            }
-
-            const next = new Set(previous);
-            next.add(activeSectionId);
-            return next;
-        });
+        setExpandedSectionId(activeSectionId);
     }, [activeValue, sections]);
 
     const commitValue = React.useCallback(
@@ -148,15 +139,9 @@ export function Menu({
     );
 
     const toggleExpanded = React.useCallback((sectionId: string) => {
-        setExpandedSections((previous) => {
-            const next = new Set(previous);
-            if (next.has(sectionId)) {
-                next.delete(sectionId);
-            } else {
-                next.add(sectionId);
-            }
-            return next;
-        });
+        setExpandedSectionId((previous) =>
+            previous === sectionId ? undefined : sectionId
+        );
     }, []);
 
     const onKeyDown = React.useCallback(
@@ -208,12 +193,8 @@ export function Menu({
             <ul className="space-y-1" role="list">
                 {sections.map((section) => {
                     const hasSubSections = Boolean(section.subSections?.length);
-                    const isExpanded = expandedSections.has(section.id);
-                    const sectionIsActive =
-                        activeValue === section.id ||
-                        section.subSections?.some(
-                            (subSection) => subSection.id === activeValue
-                        );
+                    const isExpanded = expandedSectionId === section.id;
+                    const sectionIsActive = activeValue === section.id;
                     const SectionIcon = section.icon;
 
                     return (


### PR DESCRIPTION
### Motivation
- Improve sidebar UX by ensuring only one top-level section can be expanded at a time to avoid multiple open sections cluttering the view. 
- Prevent a parent section and one of its subsections from appearing simultaneously active to make selection state unambiguous. 
- Make menu items show a pointer cursor to improve click affordance for users.

### Description
- Replace the previous `Set<string>` expanded state with a single `expandedSectionId` in `web/src/components/ui/menu.tsx` so opening one section closes any other. 
- Change `sectionIsActive` logic to `activeValue === section.id` so section active styling is exclusive to direct selection and not implied by an active subsection. 
- Add `cursor-pointer` to the base `menuItemVariants` classes in `web/src/components/ui/menu.tsx` to enable pointer cursor on items. 
- Preserve existing controlled/uncontrolled behavior and initial selection via `getInitialValue` so defaults and `value`-driven usage continue to work.

### Testing
- Ran `bun run format` (in `web/`) and formatting completed successfully. 
- Ran `bunx prettier web/src/components/ui/menu.tsx --check` and the file passed the Prettier check. 
- Started the dev server (`bun run dev`) and captured a visual verification screenshot of the menu behavior at `http://localhost:4173/viavai`, confirming the intended UI changes. 
- Attempted `bun run build` which failed due to unrelated existing TypeScript issues in other files (errors reported in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`, and `src/pages/org/Organization.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993328fa4f483238edef38952edd329)