### PR TITLE
Make sidebar subsections iconless and more compact

### DIFF
--- a/web/src/components/ui/menu.tsx
+++ b/web/src/components/ui/menu.tsx
@@ -36,14 +36,14 @@ const menuItemVariants = cva(
                 true: 'bg-white/10 text-white shadow-[inset_3px_0_0_0_rgba(255,255,255,0.75)]',
                 false: 'text-white/70 hover:bg-white/5 hover:text-white',
             },
-            inset: {
-                true: 'pl-8',
-                false: '',
+            level: {
+                root: '',
+                sub: 'gap-2 px-2.5 py-1.5 text-[0.9375rem] font-medium',
             },
         },
         defaultVariants: {
             active: false,
-            inset: false,
+            level: 'root',
         },
     }
 );
@@ -256,8 +256,6 @@ export function Menu({
                                     {section.subSections?.map((subSection) => {
                                         const subSectionIsActive =
                                             activeValue === subSection.id;
-                                        const SubSectionIcon = subSection.icon;
-
                                         return (
                                             <li
                                                 key={subSection.id}
@@ -282,7 +280,7 @@ export function Menu({
                                                     className={cn(
                                                         menuItemVariants({
                                                             active: subSectionIsActive,
-                                                            inset: true,
+                                                            level: 'sub',
                                                         })
                                                     )}
                                                     onClick={() =>
@@ -291,12 +289,6 @@ export function Menu({
                                                         )
                                                     }
                                                 >
-                                                    {SubSectionIcon ? (
-                                                        <SubSectionIcon
-                                                            className="size-4 text-white/70 group-data-[state=active]/menu-item:text-white"
-                                                            aria-hidden="true"
-                                                        />
-                                                    ) : null}
                                                     <span className="truncate">
                                                         {subSection.label}
                                                     </span>

--- a/web/src/pages/user/ViaVai.tsx
+++ b/web/src/pages/user/ViaVai.tsx
@@ -1,14 +1,7 @@
 import Render, { type RenderNodeSchema } from '@/components/Render';
 import { useData } from '@/hooks/use-data';
 import * as React from 'react';
-import {
-    LayoutDashboard,
-    Users,
-    UserPlus,
-    Settings,
-    Shield,
-    CreditCard,
-} from 'lucide-react';
+import { LayoutDashboard, Users, Settings, CreditCard } from 'lucide-react';
 
 import { Menu, type MenuSection } from '@/components/ui/menu';
 
@@ -29,12 +22,10 @@ function DashboardSidebar() {
                 {
                     id: 'all-users',
                     label: 'All Users',
-                    icon: Users,
                 },
                 {
                     id: 'invite-user',
                     label: 'Invite User',
-                    icon: UserPlus,
                 },
             ],
         },
@@ -51,12 +42,10 @@ function DashboardSidebar() {
                 {
                     id: 'general-settings',
                     label: 'General',
-                    icon: Settings,
                 },
                 {
                     id: 'security-settings',
                     label: 'Security',
-                    icon: Shield,
                 },
             ],
         },
@@ -76,9 +65,6 @@ function DashboardSidebar() {
         </aside>
     );
 }
-
-
-
 
 export default function ViaVai() {
     const { data, isLoading, error } = useData<unknown>('/sample/page');


### PR DESCRIPTION
### Motivation
- Subsections should not display an icon and should render with tighter spacing so nested menu items are visually compact and align with the requested UI change.

### Description
- Updated `web/src/components/ui/menu.tsx` to add a `level` variant to `menuItemVariants` and apply a compact `sub` style (`gap-2 px-2.5 py-1.5 text-[0.9375rem] font-medium`) for subsection items, and removed subsection icon rendering. 
- Updated `web/src/pages/user/ViaVai.tsx` to remove subsection `icon` fields and clean up unused icon imports so seed data matches the new no-icon behavior. 
- Ran project formatting to keep code style consistent using `bun run format`.

### Testing
- Ran `bunx eslint src/components/ui/menu.tsx src/pages/user/ViaVai.tsx` which completed successfully. 
- Ran `bun run build` which failed due to unrelated pre-existing TypeScript issues in other files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`, `src/pages/org/Organization.tsx`).
- Launched the dev server (`bun run dev`) and captured a Playwright screenshot of `/viavai` to validate the compact, iconless subsections; the artifact was saved during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933389698483238eb90dfac45c30c2)