### PR TITLE
Fix dashboard menu to enforce single expanded section

### DIFF
--- a/web/src/components/ui/menu.tsx
+++ b/web/src/components/ui/menu.tsx
@@ -76,17 +76,16 @@ export function Menu({
 
     const activeValue = isControlled ? value : internalValue;
 
-    const [expandedSectionId, setExpandedSectionId] = React.useState<
-        string | undefined
-    >(
-        () =>
-            sections.find(
-                (section) =>
-                    section.id === activeValue ||
-                    section.subSections?.some(
-                        (subSection) => subSection.id === activeValue
-                    )
-            )?.id
+    const [expandedSectionIndex, setExpandedSectionIndex] = React.useState<
+        number | undefined
+    >(() =>
+        sections.findIndex(
+            (section) =>
+                section.id === activeValue ||
+                section.subSections?.some(
+                    (subSection) => subSection.id === activeValue
+                )
+        )
     );
 
     React.useEffect(() => {
@@ -113,19 +112,19 @@ export function Menu({
     }, [internalValue, isControlled, sections]);
 
     React.useEffect(() => {
-        const activeSectionId = sections.find(
+        const activeSectionIndex = sections.findIndex(
             (section) =>
                 section.id === activeValue ||
                 section.subSections?.some(
                     (subSection) => subSection.id === activeValue
                 )
-        )?.id;
+        );
 
-        if (!activeSectionId) {
+        if (activeSectionIndex < 0) {
             return;
         }
 
-        setExpandedSectionId(activeSectionId);
+        setExpandedSectionIndex(activeSectionIndex);
     }, [activeValue, sections]);
 
     const commitValue = React.useCallback(
@@ -138,9 +137,9 @@ export function Menu({
         [isControlled, onValueChange]
     );
 
-    const toggleExpanded = React.useCallback((sectionId: string) => {
-        setExpandedSectionId((previous) =>
-            previous === sectionId ? undefined : sectionId
+    const toggleExpanded = React.useCallback((sectionIndex: number) => {
+        setExpandedSectionIndex((previous) =>
+            previous === sectionIndex ? undefined : sectionIndex
         );
     }, []);
 
@@ -191,9 +190,9 @@ export function Menu({
             onKeyDown={onKeyDown}
         >
             <ul className="space-y-1" role="list">
-                {sections.map((section) => {
+                {sections.map((section, sectionIndex) => {
                     const hasSubSections = Boolean(section.subSections?.length);
-                    const isExpanded = expandedSectionId === section.id;
+                    const isExpanded = expandedSectionIndex === sectionIndex;
                     const sectionIsActive = activeValue === section.id;
                     const SectionIcon = section.icon;
 
@@ -224,7 +223,7 @@ export function Menu({
                                     onClick={() => {
                                         commitValue(section.id);
                                         if (hasSubSections) {
-                                            toggleExpanded(section.id);
+                                            toggleExpanded(sectionIndex);
                                         }
                                     }}
                                 >


### PR DESCRIPTION
### Motivation

- The dashboard menu allowed multiple sections to be expanded simultaneously which is confusing; the intent is to ensure only one section is expanded at a time and that selecting a section/subsection auto-expands its parent.

### Description

- Switched expansion tracking from section id to section index in `web/src/components/ui/menu.tsx` to avoid multiple sections expanding when ids overlap or when multiple sections become eligible for expansion.
- Updated initialization, active-value sync effect, toggle handler, and render logic to use `expandedSectionIndex` instead of an `expandedSectionId`.
- Kept existing value/controlled-state behavior and keyboard navigation unchanged.

### Testing

- Ran formatter in `web` with `bun run format`, which completed successfully.
- Attempted a full web build with `bun run build`, which failed due to pre-existing unrelated TypeScript/module issues in other files (errors in `resizable.tsx` and missing imports), so the build failure is not caused by this change.
- Started the dev server (`vite`) and attempted a Playwright script to confirm only one section expands, but the automated browser run timed out locating the expected buttons so no screenshot was produced; the failure appears related to the rendered test page in this environment rather than the menu logic itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993357b7af08323b6779c54b21513c4)