### PR TITLE
fix(web): persist active state in ViaVai nested menu

### DIFF
--- a/web/src/components/viavai/Menu.tsx
+++ b/web/src/components/viavai/Menu.tsx
@@ -1,7 +1,9 @@
 import {
     Children,
     isValidElement,
+    useEffect,
     useMemo,
+    useState,
     type ReactElement,
     type ReactNode,
 } from 'react';
@@ -54,6 +56,22 @@ type NormalizedSection = {
     rootSubSection?: NormalizedSubSection;
     subSections: NormalizedSubSection[];
 };
+
+function getDefaultActiveValue(
+    sections: NormalizedSection[]
+): string | undefined {
+    const firstSection = sections[0];
+
+    if (!firstSection) {
+        return undefined;
+    }
+
+    if (firstSection.rootSubSection) {
+        return firstSection.id;
+    }
+
+    return firstSection.subSections[0]?.id ?? firstSection.id;
+}
 
 const iconByName: Record<string, LucideIcon> = {
     table: Table2,
@@ -135,13 +153,39 @@ export function MenuSubSection({ children }: MenuSubSectionProps) {
 
 export function Menu({ children }: MenuProps) {
     const sections = useMemo(() => normalizeSections(children), [children]);
+    const [activeValue, setActiveValue] = useState<string | undefined>(() =>
+        getDefaultActiveValue(sections)
+    );
+
+    useEffect(() => {
+        if (!sections.length) {
+            setActiveValue(undefined);
+            return;
+        }
+
+        const hasActiveValue = sections.some(
+            (section) =>
+                section.id === activeValue ||
+                section.subSections.some(
+                    (subSection) => subSection.id === activeValue
+                )
+        );
+
+        if (!hasActiveValue) {
+            setActiveValue(getDefaultActiveValue(sections));
+        }
+    }, [activeValue, sections]);
 
     if (!sections.length) {
         return null;
     }
 
     return (
-        <BaseMenu ariaLabel="ViaVai menu">
+        <BaseMenu
+            value={activeValue}
+            onValueChange={setActiveValue}
+            ariaLabel="ViaVai menu"
+        >
             <aside className="w-64">
                 <MenuList>
                     {sections.map((section) => (


### PR DESCRIPTION
### Motivation
- Fix a UX bug where clicking a menu item in the ViaVai nested menu briefly highlighted it and then it became deselected due to the menu relying on uncontrolled internal selection that reset when the menu children were re-created.

### Description
- Make the ViaVai wrapper control the underlying `BaseMenu` selection by passing `value` and `onValueChange` to keep the clicked item selected across re-renders.
- Add `getDefaultActiveValue` to compute a stable initial/fallback selection (prefer root subsection, then first subsection, then section) for first render.
- Add reconciliation logic in a `useEffect` to restore a valid active value when the menu schema changes so selection does not flash away.
- Modified file: `web/src/components/viavai/Menu.tsx`.

### Testing
- Ran formatting with `bun run format` in `web` which completed successfully.
- Ran `bun run dev` (Vite) which started successfully and served the app for manual verification.
- Ran `bun run build` which failed due to pre-existing TypeScript issues in unrelated files (errors in `resizable.tsx` and missing modules), so the build failure is not caused by this menu change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b514bfd48323813b95625217668a)