### PR TITLE
Prevent menu section blink when revisiting active section

### DIFF
--- a/web/src/components/ui/menu.tsx
+++ b/web/src/components/ui/menu.tsx
@@ -240,8 +240,17 @@ export function MenuList({ className, children }: MenuListProps) {
         []
     );
 
-    const toggleExpanded = (sectionValue: string) => {
+    const toggleExpanded = (
+        sectionValue: string,
+        options: {
+            preserveIfExpanded?: boolean;
+        } = {}
+    ) => {
         setExpandedSectionIds((previous) => {
+            if (options.preserveIfExpanded && previous.has(sectionValue)) {
+                return previous;
+            }
+
             const next = new Set(previous);
             if (next.has(sectionValue)) {
                 next.delete(sectionValue);
@@ -289,7 +298,10 @@ export function MenuList({ className, children }: MenuListProps) {
                                 onClick={() => {
                                     onValueChange(section.value);
                                     if (hasSubSections) {
-                                        toggleExpanded(section.value);
+                                        toggleExpanded(section.value, {
+                                            preserveIfExpanded:
+                                                !sectionIsActive,
+                                        });
                                     }
                                 }}
                             >


### PR DESCRIPTION
### Motivation
- Clicking another menu section and then returning to an already-open section caused the section to collapse and immediately reopen, producing a visible blink; the change aims to keep stable expansion state to avoid that flicker.

### Description
- Add an optional `preserveIfExpanded` option to `toggleExpanded` in `web/src/components/ui/menu.tsx` so callers can avoid collapsing an already-expanded section. 
- Update the root section click handler to call `toggleExpanded(section.value, { preserveIfExpanded: !sectionIsActive })` so returning to an active section preserves its expanded state while other interactions still toggle normally. 
- The change is localized to `MenuList` logic and does not change the public API of the `Menu` component.

### Testing
- Ran `bun run format`, which completed successfully. 
- Launched the dev server and captured a Playwright screenshot to validate the UI behavior change, which completed and produced an artifact. 
- Ran `bun run build`, which failed due to pre-existing TypeScript errors in unrelated files and is not caused by this change. 
- Ran `bunx eslint src/components/ui/menu.tsx`, which reported pre-existing unused `_props` lint warnings in the same file unrelated to the new logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993be6528cc8323b43b22e98069fa3e)