### PR TITLE
Remove Organizations from account navigation

### DIFF
--- a/web/src/components/breadcrumb.tsx
+++ b/web/src/components/breadcrumb.tsx
@@ -33,7 +33,7 @@ export function Breadcrumb() {
         locationPath: location.pathname,
         basePath,
     });
-    const accountBreadcrumbLabel = activeTabConfig?.label ?? 'Organizations';
+    const accountBreadcrumbLabel = activeTabConfig?.label ?? 'Profile';
     const accountBreadcrumbPath = `/${activeTabConfig?.path ?? ''}`.replace(
         /\/$/,
         ''

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -41,12 +41,6 @@ const defaultAppTabs: NavigationTab[] = [
 ];
 
 const accountTabs: NavigationTab[] = [
-    {
-        value: 'organizations',
-        label: 'Organizations',
-        path: 'organizations',
-        icon: Users,
-    },
     { value: 'profile', label: 'Profile', path: 'profile', icon: User },
     { value: 'viavai', label: 'ViaVai', path: 'viavai', icon: Sparkles },
 ];


### PR DESCRIPTION
### Motivation
- Remove the Organizations entry from the account-level user navigation so the default account view surfaces the user Profile and ViaVai tabs instead of an Organizations tab.

### Description
- Deleted the `organizations` tab from `web/src/lib/navigation.ts` and updated the account breadcrumb fallback label to `Profile` in `web/src/components/breadcrumb.tsx` to keep breadcrumb text aligned with the new default account tab.

### Testing
- Ran `bun run format` which succeeded; attempted `bun run build` which failed due to pre-existing TypeScript issues unrelated to this change; and executed a headless page capture (Playwright script) against the running dev server which completed and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994845c2fc8832394594fdd82efb05d)