### PR TITLE
Keep organization nav on profile and remove Dashboard from user menu

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,10 +1,4 @@
-import {
-    Link,
-    Outlet,
-    useLocation,
-    useNavigate,
-    useParams,
-} from 'react-router';
+import { Link, Outlet, useNavigate, useParams } from 'react-router';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { UserProfile } from '@/components/Profile';
@@ -21,13 +15,10 @@ type NavigationProps = {
 
 export default function Layout() {
     const { app } = useParams();
-    const location = useLocation();
-    const section =
-        location.pathname.startsWith('/profile') ||
-        location.pathname.startsWith('/viavai')
-            ? 'account'
-            : 'organization';
-    const { tabs, basePathSuffix } = getTabsConfig({ section, app });
+    const { tabs, basePathSuffix } = getTabsConfig({
+        section: 'organization',
+        app,
+    });
 
     return <Navigation tabs={tabs} basePathSuffix={basePathSuffix} />;
 }
@@ -35,19 +26,13 @@ export default function Layout() {
 export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
     const { app } = useParams();
     const navigate = useNavigate();
-    const location = useLocation();
 
     const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
-    const isAccountView =
-        location.pathname.startsWith('/profile') ||
-        location.pathname.startsWith('/viavai');
     const basePath = app
         ? normalizedSuffix
             ? `/${normalizedSuffix}`
             : '/'
-        : isAccountView
-          ? ''
-          : '/';
+        : '/';
 
     const activeTabConfig = getActiveTabConfig({
         tabs,

--- a/web/src/components/Profile.tsx
+++ b/web/src/components/Profile.tsx
@@ -1,4 +1,4 @@
-import { Building2, LogOut, User } from 'lucide-react';
+import { LogOut, User } from 'lucide-react';
 import { Link, useNavigate } from 'react-router';
 import {
     DropdownMenu,
@@ -55,12 +55,6 @@ export function UserProfile() {
                     </DropdownMenuLabel>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator className="my-2" />
-                <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
-                    <Link to="/" className="flex w-full items-center">
-                        <Building2 className="mr-2 h-4 w-4 text-white/70" />
-                        Dashboard
-                    </Link>
-                </DropdownMenuItem>
                 <DropdownMenuItem className="cursor-pointer transition-colors hover:bg-white/10 p-2">
                     <Link to="/profile" className="flex w-full items-center">
                         <User className="mr-2 h-4 w-4 text-white/70" />

--- a/web/src/components/breadcrumb.tsx
+++ b/web/src/components/breadcrumb.tsx
@@ -5,114 +5,68 @@ import {
     BreadcrumbList,
     BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import {
-    formatAppName,
-    getActiveTabConfig,
-    getTabsConfig,
-} from '@/lib/navigation';
+import { formatAppName } from '@/lib/navigation';
 import { Link, useLocation, useParams } from 'react-router';
 
 export function Breadcrumb() {
     const { app } = useParams();
     const location = useLocation();
-    const isAccountView =
-        location.pathname.startsWith('/profile') ||
-        location.pathname.startsWith('/viavai');
-    const section = isAccountView ? 'account' : 'organization';
-    const { tabs, basePathSuffix } = getTabsConfig({ section, app });
 
     const appName = app ? formatAppName(app) : undefined;
-    const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
-    const basePath = app
-        ? normalizedSuffix
-            ? `/${normalizedSuffix}`
-            : '/'
-        : isAccountView
-          ? ''
-          : '/';
-    const accountRootPath = '/';
-    const activeTabConfig = getActiveTabConfig({
-        tabs,
-        locationPath: location.pathname,
-        basePath,
-    });
-    const accountBreadcrumbLabel = activeTabConfig?.label ?? 'Profile';
-    const accountBreadcrumbPath = `/${activeTabConfig?.path ?? ''}`.replace(
-        /\/$/,
-        ''
-    );
+    const isProfileView = location.pathname.startsWith('/profile');
 
     return (
         <UIBreadcrumb>
             <BreadcrumbList>
-                {isAccountView ? (
+                <BreadcrumbItem>
+                    <BreadcrumbLink
+                        render={(props) => (
+                            <Link
+                                {...props}
+                                to="/"
+                                className="text-sm font-semibold text-white/70"
+                            >
+                                Organization
+                            </Link>
+                        )}
+                    />
+                </BreadcrumbItem>
+                {appName ? (
                     <>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink
-                                render={(props) => (
-                                    <Link
-                                        {...props}
-                                        to={accountRootPath}
-                                        className="text-sm font-semibold text-white/70"
-                                    >
-                                        User
-                                    </Link>
-                                )}
-                            />
-                        </BreadcrumbItem>
                         <BreadcrumbSeparator />
                         <BreadcrumbItem>
                             <BreadcrumbLink
                                 render={(props) => (
                                     <Link
                                         {...props}
-                                        to={
-                                            accountBreadcrumbPath ||
-                                            accountRootPath
-                                        }
+                                        to={`/apps/${app}`}
                                         className="text-sm font-semibold text-white/70"
                                     >
-                                        {accountBreadcrumbLabel}
+                                        {appName}
                                     </Link>
                                 )}
                             />
                         </BreadcrumbItem>
                     </>
-                ) : (
+                ) : null}
+                {isProfileView ? (
                     <>
+                        <BreadcrumbSeparator />
                         <BreadcrumbItem>
                             <BreadcrumbLink
                                 render={(props) => (
                                     <Link
                                         {...props}
-                                        to="/"
+                                        to="/profile"
                                         className="text-sm font-semibold text-white/70"
                                     >
-                                        Organization
+                                        Profile
                                     </Link>
                                 )}
                             />
                         </BreadcrumbItem>
-                        {appName ? (
-                            <>
-                                <BreadcrumbSeparator />
-                                <BreadcrumbItem>
-                                    <BreadcrumbLink
-                                        render={(props) => (
-                                            <Link
-                                                {...props}
-                                                to={`/apps/${app}`}
-                                                className="text-sm font-semibold text-white/70"
-                                            >
-                                                {appName}
-                                            </Link>
-                                        )}
-                                    />
-                                </BreadcrumbItem>
-                            </>
-                        ) : null}
                     </>
-                )}
+                ) : null}
             </BreadcrumbList>
         </UIBreadcrumb>
     );

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -7,7 +7,6 @@ import {
     Layers,
     Settings,
     Sparkles,
-    User,
     Users,
     Wrench,
 } from 'lucide-react';
@@ -29,11 +28,6 @@ const defaultAppTabs: NavigationTab[] = [
     { value: 'overview', label: 'Overview', path: '', icon: FileText },
     { value: 'data', label: 'Data', path: 'data', icon: FileText },
     { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
-];
-
-const accountTabs: NavigationTab[] = [
-    { value: 'profile', label: 'Profile', path: 'profile', icon: User },
-    { value: 'viavai', label: 'ViaVai', path: 'viavai', icon: Sparkles },
 ];
 
 const appTabsByName: Record<string, NavigationTab[]> = {
@@ -93,17 +87,14 @@ export type TabsConfig = {
 };
 
 export function getTabsConfig({
-    section,
+    section: _section,
     app,
 }: {
     section: 'account' | 'organization';
     app?: string;
 }): TabsConfig {
     const appTabs = app ? (appTabsByName[app] ?? defaultAppTabs) : null;
-    const tabs =
-        section === 'organization'
-            ? (appTabs ?? organizationTabs)
-            : accountTabs;
+    const tabs = appTabs ?? organizationTabs;
     const basePathSuffix = app ? `apps/${app}` : undefined;
 
     return { tabs, basePathSuffix };


### PR DESCRIPTION
### Motivation
- The UI should always present the Organization navigation (`Apps`, `People`, `Settings`) and remove the separate `Dashboard` entry from the user dropdown so profile pages keep the organization-level tabs visible.

### Description
- Removed the `Dashboard` item from the user dropdown and simplified imports in `web/src/components/Profile.tsx` so the dropdown only contains `Profile` and sign in/out actions (removed `Building2`/`Dashboard`).
- Made the top navigation always use the organization tab set by changing `Layout` to call `getTabsConfig({ section: 'organization', app })` and simplified `getTabsConfig` in `web/src/lib/navigation.ts` to prefer app-specific tabs or fall back to organization tabs (removed account-specific `accountTabs`).
- Simplified breadcrumb behavior in `web/src/components/breadcrumb.tsx` to always start with `Organization` and show `Profile` as the secondary crumb when on `/profile` routes.
- Updated formatting across the `web` workspace with `bun run format`.

### Testing
- Ran `bun run format` in the `web/` workspace, which completed successfully.
- Attempted a production build with `bun run build`, which failed due to unrelated pre-existing TypeScript issues in shared UI files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`).
- Ran the dev server with `bun run dev --host 0.0.0.0 --port 4173` and performed a manual visual check and captured a screenshot to verify that organization tabs remain visible on the profile page (dev run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949c15fba88323810d33a1a719296b)