### PR TITLE
Fix organization tab navigation to use root-level routes

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -32,7 +32,7 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
         ? normalizedSuffix
             ? `/${normalizedSuffix}`
             : '/'
-        : '/';
+        : '';
 
     const activeTabConfig = getActiveTabConfig({
         tabs,


### PR DESCRIPTION
### Motivation
- Ensure organization-level tabs navigate to top-level routes like `/apps` and `/people` instead of being treated as nested paths, which caused incorrect navigation from the Apps page.

### Description
- Change default `basePath` in `web/src/Layout.tsx` from `'/'` to `''` so tab target paths resolve as root-level routes when no `:app` param is present.

### Testing
- Ran `cd web && bun run format` (succeeded).
- Ran `cd web && bun run build` (failed due to unrelated TypeScript issues in other UI components, not caused by this change).
- Started the dev server and captured a screenshot of the `/apps` route to verify the route renders (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949e5741008323bb9a7cb47f40883a)