### PR TITLE
Keep Apps tab selected when viewing /profile

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,4 +1,10 @@
-import { Link, Outlet, useNavigate, useParams } from 'react-router';
+import {
+    Link,
+    Outlet,
+    useLocation,
+    useNavigate,
+    useParams,
+} from 'react-router';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { UserProfile } from '@/components/Profile';
@@ -25,6 +31,7 @@ export default function Layout() {
 
 export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
     const { app } = useParams();
+    const location = useLocation();
     const navigate = useNavigate();
 
     const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
@@ -39,7 +46,9 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
         locationPath: location.pathname,
         basePath,
     });
-    const activeTab = activeTabConfig?.value ?? tabs[0]?.value ?? 'overview';
+    const activeTab = location.pathname.startsWith('/profile')
+        ? 'apps'
+        : (activeTabConfig?.value ?? tabs[0]?.value ?? 'overview');
 
     return (
         <div className="min-h-screen text-white">


### PR DESCRIPTION
### Motivation
- Ensure the top navigation retains the organization-level "Apps" tab as active when the user is viewing the profile route so the header reflects the organization context.

### Description
- Updated the navigation logic to read the current pathname via `useLocation` and added a `/profile` pathname override that forces the active tab to `'apps'` while preserving the existing tab-matching behavior for other routes.
- Modified file: `web/src/Layout.tsx`.

### Testing
- Ran `bun run format`, which completed successfully.
- Ran `bun run build`, which failed due to pre-existing TypeScript issues in unrelated files (e.g. `src/components/ui/resizable.tsx` and missing `@/hooks/use-mobile`), indicating the change itself does not introduce new build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a07ca7588323b2dfd93cfb68b8f7)