### PR TITLE
Add /login endpoint and conditional GitHub OAuth registration

### DIFF
--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -5,17 +5,22 @@ from authlib.integrations.starlette_client import OAuth
 
 
 oauth = OAuth()
-oauth.register(
-    name='github',
-    client_id=os.getenv('GITHUB_CLIENT_ID'),
-    client_secret=os.getenv('GITHUB_CLIENT_SECRET'),
-    access_token_url='https://github.com/login/oauth/access_token',
-    authorize_url='https://github.com/login/oauth/authorize',
-    api_base_url='https://api.github.com/',
-    userinfo_endpoint='https://api.github.com/user',
-    client_kwargs={'scope': 'read:user user:email'},
-    redirect_uri='https://api.swissgpu.ch/auth/github',
-)
+AVAILABLE_AUTH_METHODS: list[str] = []
+
+
+if os.getenv('GITHUB_CLIENT_ID') and os.getenv('GITHUB_CLIENT_SECRET'):
+    oauth.register(
+        name='github',
+        client_id=os.getenv('GITHUB_CLIENT_ID'),
+        client_secret=os.getenv('GITHUB_CLIENT_SECRET'),
+        access_token_url='https://github.com/login/oauth/access_token',
+        authorize_url='https://github.com/login/oauth/authorize',
+        api_base_url='https://api.github.com/',
+        userinfo_endpoint='https://api.github.com/user',
+        client_kwargs={'scope': 'read:user user:email'},
+        redirect_uri='https://api.swissgpu.ch/auth/github',
+    )
+    AVAILABLE_AUTH_METHODS.append('github')
 
 
 async def authuser(request: Request) -> db.User:

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,7 +1,7 @@
 import src.db as db
 from typing import cast
-from fastapi import Request
-from src.auth import oauth
+from fastapi import Request, HTTPException
+from src.auth import oauth, AVAILABLE_AUTH_METHODS
 from src.router import router
 from fastapi.responses import RedirectResponse
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
@@ -10,8 +10,16 @@ from authlib.integrations.starlette_client.apps import StarletteOAuth2App
 URL = 'http://localhost:5173'
 
 
+@router.get('/login')
+async def login_methods():
+    return {'methods': AVAILABLE_AUTH_METHODS}
+
+
 @router.get('/login/github')
 async def login_github(request: Request):
+    if 'github' not in AVAILABLE_AUTH_METHODS:
+        raise HTTPException(404, 'Authentication method not available')
+
     github = cast(StarletteOAuth2App, oauth.create_client('github'))
 
     return await github.authorize_redirect(
@@ -22,6 +30,9 @@ async def login_github(request: Request):
 
 @router.get('/auth/github')
 async def auth_github(request: Request):
+    if 'github' not in AVAILABLE_AUTH_METHODS:
+        raise HTTPException(404, 'Authentication method not available')
+
     github = cast(StarletteOAuth2App, oauth.create_client('github'))
 
     token = await github.authorize_access_token(request)


### PR DESCRIPTION
### Motivation
- Expose which authentication providers are available to the frontend via an API endpoint.  
- Avoid registering OAuth providers when required environment variables are missing to prevent runtime errors.  
- Fail fast with a clear `404` when accessing provider routes that are not configured.

### Description
- Introduced `AVAILABLE_AUTH_METHODS: list[str]` and register the GitHub provider only when both `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are present in the environment in `api/src/auth.py`.  
- Added `GET /login` in `api/src/routes/auth.py` that returns `{'methods': AVAILABLE_AUTH_METHODS}`.  
- Guarded `GET /login/github` and `GET /auth/github` to raise `HTTPException(404)` when `'github'` is not in `AVAILABLE_AUTH_METHODS` to prevent attempts to use an unconfigured provider.

### Testing
- Compiled the API sources with `cd api && python -m compileall src` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a14769bc8323aa67a88f9a3129d6)