### PR TITLE
sdk: add root endpoint returning app metadata

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -13,6 +13,14 @@ class LongLink(Router, Cron):
         self.settings = Settings()
         super().__init__()
 
+        @self.get("/")
+        async def get_app_information():
+            return {
+                "name": self.title,
+                "description": self.description,
+                "version": self.version,
+            }
+
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
             return
@@ -64,11 +72,17 @@ class LongLink(Router, Cron):
             headers = [(b"content-type", b"application/json")]
             body_bytes = response_body.encode()
         else:
-            headers = [(b"content-type", b"text/plain")]
-            if isinstance(body, bytes):
-                body_bytes = body
+            if isinstance(body, dict):
+                import json
+
+                headers = [(b"content-type", b"application/json")]
+                body_bytes = json.dumps(body).encode()
             else:
-                body_bytes = str(body).encode()
+                headers = [(b"content-type", b"text/plain")]
+                if isinstance(body, bytes):
+                    body_bytes = body
+                else:
+                    body_bytes = str(body).encode()
 
         await send({
             "type": "http.response.start",

--- a/sdk/tests/app/test_app.py
+++ b/sdk/tests/app/test_app.py
@@ -1,0 +1,70 @@
+import asyncio
+import json
+import sys
+import types
+import unittest
+
+
+if "pydantic_settings" not in sys.modules:
+    pydantic_settings = types.ModuleType("pydantic_settings")
+
+    class BaseSettings:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def SettingsConfigDict(**kwargs):
+        return kwargs
+
+    pydantic_settings.BaseSettings = BaseSettings
+    pydantic_settings.SettingsConfigDict = SettingsConfigDict
+    sys.modules["pydantic_settings"] = pydantic_settings
+
+from longlink.app import LongLink
+
+
+class TestLongLinkApp(unittest.TestCase):
+    def test_root_returns_app_information_as_json(self):
+        app = LongLink(
+            title="Demo App",
+            description="Demo description",
+            version="1.2.3",
+        )
+        messages = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            messages.append(message)
+
+        asyncio.run(
+            app(
+                {
+                    "type": "http",
+                    "method": "GET",
+                    "path": "/",
+                    "query_string": b"",
+                },
+                receive,
+                send,
+            )
+        )
+
+        self.assertEqual(messages[0]["type"], "http.response.start")
+        self.assertEqual(messages[0]["status"], 200)
+        self.assertIn((b"content-type", b"application/json"), messages[0]["headers"])
+
+        self.assertEqual(messages[1]["type"], "http.response.body")
+        self.assertEqual(
+            json.loads(messages[1]["body"]),
+            {
+                "name": "Demo App",
+                "description": "Demo description",
+                "version": "1.2.3",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a simple default `GET /` endpoint for SDK apps that exposes the app's basic metadata (`name`, `description`, `version`).
- Ensure handlers that return plain Python `dict` objects are serialized as JSON with the correct `application/json` content type.

### Description

- Added a default route in `LongLink` registered at `@self.get("/")` that returns a dict with `name`, `description`, and `version` (file: `sdk/longlink/app.py`).
- Updated the ASGI response serialization to return `application/json` when a handler returns a `dict` (file: `sdk/longlink/app.py`).
- Added unit tests exercising the ASGI call path for `GET /` and validating the status, `content-type`, and JSON payload, including a small test shim for `pydantic_settings` to avoid an external dependency in the test environment (files: `sdk/tests/app/test_app.py`, `sdk/tests/app/__init__.py`).

### Testing

- Running `cd sdk && python -m unittest discover -s tests` initially produced an import error for `pydantic_settings` which prevented tests from running.
- After adding a test shim for `pydantic_settings`, `cd sdk && python -m unittest discover -s tests` completed successfully with `Ran 4 tests` and `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a1f9146c8323a7b6306a6f819d8a)