### PR TITLE
web: fetch available auth methods on login and disable provider buttons

### DIFF
--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -1,16 +1,21 @@
 import { Chrome, Github, Layers } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { getApiBaseUrl } from '@/lib/api';
+import { apiFetch, getApiBaseUrl } from '@/lib/api';
 import { useUser } from '@/hooks/use-user';
+
+type LoginMethodsResponse = {
+    methods?: string[];
+};
 
 export default function Login() {
     const location = useLocation();
     const navigate = useNavigate();
     const { user, isLoading } = useUser();
     const apiBaseUrl = getApiBaseUrl();
+    const [availableMethods, setAvailableMethods] = useState<string[]>([]);
 
     const getDefaultReturnTo = () => {
         const referrer = document.referrer;
@@ -47,6 +52,32 @@ export default function Login() {
         }
     }, [isLoading, navigate, returnTo, user]);
 
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadLoginMethods = async () => {
+            try {
+                const data = await apiFetch<LoginMethodsResponse>('/login');
+                if (isMounted) {
+                    setAvailableMethods(data.methods ?? []);
+                }
+            } catch {
+                if (isMounted) {
+                    setAvailableMethods([]);
+                }
+            }
+        };
+
+        loadLoginMethods();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    const hasGoogleMethod = availableMethods.includes('google');
+    const hasGithubMethod = availableMethods.includes('github');
+
     const handleGithubLogin = () => {
         window.location.href = `${apiBaseUrl}/login/github`;
     };
@@ -66,13 +97,17 @@ export default function Login() {
                     </div>
 
                     <div className="grid gap-3">
-                        <Button className="h-11 gap-2 bg-white text-slate-900 hover:bg-white/90">
+                        <Button
+                            className="h-11 gap-2 bg-white text-slate-900 hover:bg-white/90"
+                            disabled={!hasGoogleMethod}
+                        >
                             <Chrome className="h-4 w-4" />
                             Login with Google
                         </Button>
                         <Button
                             variant="outline"
                             className="h-11 gap-2"
+                            disabled={!hasGithubMethod}
                             onClick={handleGithubLogin}
                         >
                             <Github className="h-4 w-4" />


### PR DESCRIPTION
### Motivation
- The login page should reflect which OAuth providers the backend exposes so users are only offered working options.
- Centralize backend-driven UI behavior by querying the API rather than hard-coding available providers.

### Description
- Added a call to `GET /login` via `apiFetch` in `web/src/pages/user/Login.tsx` to retrieve available authentication methods and store them in component state. 
- Introduced a `LoginMethodsResponse` type and `useState`/`useEffect` logic to load methods and guard updates when the component unmounts. 
- Wired availability checks into the UI by using the `disabled` prop on provider buttons so Google and GitHub buttons are disabled when not returned by the API, while preserving the existing GitHub redirect flow to `/login/github`.

### Testing
- Ran `bun run format` in `web` which completed successfully. 
- Ran `bun run build` in `web` which failed due to pre-existing TypeScript issues unrelated to this change (errors in `src/components/ui/*`).
- Launched the dev server with `vite` and executed a Playwright script to load `/login` and capture a screenshot, which produced `browser:/tmp/codex_browser_invocations/f887afb93cd48215/artifacts/artifacts/login-auth-methods.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a2f1ad488323b9a656051dd5767d)