### PR TITLE
Add SDK page routes with metadata and root page listing

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -19,6 +19,7 @@ class LongLink(Router, Cron):
                 "name": self.title,
                 "description": self.description,
                 "version": self.version,
+                "pages": self.pages(),
             }
 
     async def __call__(self, scope, receive, send):
@@ -51,8 +52,28 @@ class LongLink(Router, Cron):
         else:
             body = await handler()
 
+        is_page_handler = any(route.handler is handler for route in self._pages)
+
         return_type = get_type_hints(handler).get("return")
-        if return_type and isinstance(return_type, type) and issubclass(return_type, BaseModel):
+        if is_page_handler:
+            from longlink.ui import Page
+            import json
+
+            if return_type is not Page or not isinstance(body, Page):
+                await send({
+                    "type": "http.response.start",
+                    "status": 500,
+                    "headers": [(b"content-type", b"text/plain")],
+                })
+                await send({
+                    "type": "http.response.body",
+                    "body": b"Invalid response type. Page routes must return longlink.ui.Page.",
+                })
+                return
+
+            headers = [(b"content-type", b"application/json")]
+            body_bytes = json.dumps(list(body)).encode()
+        elif return_type and isinstance(return_type, type) and issubclass(return_type, BaseModel):
             if not isinstance(body, return_type):
                 await send({
                     "type": "http.response.start",

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Callable, Awaitable, Any
-from .route import Route
+from .route import Route, PageRoute
+from longlink.ui import Page
 
 
 Handler = Callable[..., Awaitable[Any]]
@@ -9,15 +10,27 @@ Handler = Callable[..., Awaitable[Any]]
 class Router:
     def __init__(self) -> None:
         self._routes: list[Route] = []
+        self._pages: list[PageRoute] = []
 
     def register(self, router: "Router") -> None:
         self._routes.extend(router._routes)
+        self._pages.extend(router._pages)
 
     def _route(self, method: str, path: str):
         def decorator(func: Handler) -> Handler:
             self._routes.append(Route(method.upper(), path, func))
             return func
         return decorator
+
+    def page(self, path: str, name: str, icon: str):
+        def decorator(func: Handler) -> Handler:
+            self._pages.append(PageRoute(path, func, name=name, icon=icon))
+            self._routes.append(self._pages[-1])
+            return func
+        return decorator
+
+    def pages(self) -> list[dict[str, str]]:
+        return [{"path": page.template, "name": page.name, "icon": page.icon} for page in self._pages]
 
     def match(self, method: str, path: str, query_string: str = "") -> tuple[Handler | None, dict[str, Any]]:
         full_path = path
@@ -59,7 +72,6 @@ class Router:
     def delete(self, path: str): return self._route("DELETE", path)
 
 
-
 if __name__ == "__main__":
     router = Router()
 
@@ -67,7 +79,12 @@ if __name__ == "__main__":
     async def get_user_posts(user_id: str, filter: str = "", sort_order: str = "asc"):
         return {"user_id": user_id, "filter": filter, "sort": sort_order}
 
+    @router.page("/settings", name="Settings", icon="settings")
+    async def settings_page() -> Page:
+        return Page()
+
     fn, params = router.match("GET", "/users/admin/posts", query_string="filter=any&sort=desc")
     assert fn is not None, "Handler not found for registered route"
     assert fn.__name__ == "get_user_posts", "Handler function name does not match expected"
     assert params == {"user_id": "admin", "filter": "any", "sort_order": "desc"}
+    assert router.pages() == [{"path": "/settings", "name": "Settings", "icon": "settings"}]

--- a/sdk/longlink/router/route.py
+++ b/sdk/longlink/router/route.py
@@ -63,3 +63,10 @@ class Route:
                 values[param_name] = query[query_key][0]
 
         return values
+
+
+class PageRoute(Route):
+    def __init__(self, template: str, handler: Handler, name: str, icon: str):
+        super().__init__("GET", template, handler)
+        self.name = name
+        self.icon = icon

--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -4,8 +4,10 @@
 
 from src.app import app
 from src.routes.sample import router as sample_router
+from src.pages.settings import router as settings_router
 
 app.register(sample_router)
+app.register(settings_router)
 
 
 if __name__ == '__main__':

--- a/sdk/sample/src/pages/settings.py
+++ b/sdk/sample/src/pages/settings.py
@@ -1,41 +1,48 @@
-from longlink import Page
+from longlink import Router, Page
 
 
-page = Page()
+router = Router()
 
-page.hero(
-    title="Settings",
-    subtitle="Manage your app preferences and account defaults.",
-)
 
-profile_tab, notifications_tab, security_tab = page.tabs([
-    "Profile",
-    "Notifications",
-    "Security",
-])
+@router.page("/settings", name="Settings", icon="settings")
+async def settings_page() -> Page:
+    page = Page()
 
-profile_tab.input(
-    label="Display name",
-    placeholder="Jane Doe",
-    description="This name will be visible to other users.",
-    submit="Save profile",
-)
-profile_tab.input(
-    label="Timezone",
-    placeholder="UTC",
-    description="Used for scheduling and activity timestamps.",
-)
+    page.hero(
+        title="Settings",
+        subtitle="Manage your app preferences and account defaults.",
+    )
 
-notifications_tab.input(
-    label="Email notifications",
-    placeholder="Enabled / Disabled",
-    description="Choose whether updates are sent to your email.",
-    submit="Save notifications",
-)
+    profile_tab, notifications_tab, security_tab = page.tabs([
+        "Profile",
+        "Notifications",
+        "Security",
+    ])
 
-security_tab.input(
-    label="Two-factor authentication",
-    placeholder="Enabled / Disabled",
-    description="Add an extra layer of security to your account.",
-)
-security_tab.button("Update security settings", variant="secondary")
+    profile_tab.input(
+        label="Display name",
+        placeholder="Jane Doe",
+        description="This name will be visible to other users.",
+        submit="Save profile",
+    )
+    profile_tab.input(
+        label="Timezone",
+        placeholder="UTC",
+        description="Used for scheduling and activity timestamps.",
+    )
+
+    notifications_tab.input(
+        label="Email notifications",
+        placeholder="Enabled / Disabled",
+        description="Choose whether updates are sent to your email.",
+        submit="Save notifications",
+    )
+
+    security_tab.input(
+        label="Two-factor authentication",
+        placeholder="Enabled / Disabled",
+        description="Add an extra layer of security to your account.",
+    )
+    security_tab.button("Update security settings", variant="secondary")
+
+    return page


### PR DESCRIPTION
### Motivation
- Allow apps to declare UI pages in the SDK router so pages can be discovered by the platform and served as strict `Page` responses. 
- Provide metadata (`name`, `icon`, and `path`) for each page so the web frontend can render navigation and app listings.

### Description
- Added a `PageRoute` type to `sdk/longlink/router/route.py` to store page-specific metadata (`name` and `icon`) while keeping normal route matching behavior. 
- Extended `Router` (`sdk/longlink/router/__init__.py`) with `page(path, name, icon)` decorator, internal `_pages` tracking, `pages()` helper that returns the list of registered pages, and register/merge support for pages. 
- Updated `LongLink` (`sdk/longlink/app.py`) to include `pages` in the root app info (`GET /`) and to enforce that routes registered via `Router.page` strictly declare `-> Page` and return a `longlink.ui.Page` instance; page handlers are serialized to JSON by converting the `Page` to a list of components. 
- Updated the sample app to expose a settings page using `@router.page("/settings", name="Settings", icon="settings")` in `sdk/sample/src/pages/settings.py` and registered that router in `sdk/sample/main.py`.

### Testing
- Ran bytecode compilation with `python -m compileall sdk/longlink sdk/sample/src sdk/sample/main.py`, which succeeded. 
- Performed a runtime smoke attempt to register and print pages via a short Python snippet, which failed due to a missing environment dependency (`pydantic_settings`) unrelated to the page routing changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a43dac488323b26274bcab647370)