### PR TITLE
Prevent duplicate sample page registration on reload

### DIFF
--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -6,8 +6,11 @@ from src.app import app
 from src.routes.sample import router as sample_router
 from src.pages.settings import router as settings_router
 
-app.register(sample_router)
-app.register(settings_router)
+
+if not getattr(app, "_sample_routes_registered", False):
+    app.register(sample_router)
+    app.register(settings_router)
+    app._sample_routes_registered = True
 
 
 if __name__ == '__main__':
@@ -22,4 +25,3 @@ if __name__ == '__main__':
         reload=True,
         access_log=False,
     )
-


### PR DESCRIPTION
### Motivation
- The sample app registered its routers on every import, causing the same page (`/settings`) to appear twice in the app metadata when the module was reloaded (e.g. during dev reloads). 

### Description
- Make router registration idempotent by guarding registration in `sdk/sample/main.py` with a module-level flag `app._sample_routes_registered` so `sample_router` and `settings_router` are only registered once.

### Testing
- Ran import/reload checks using `python - <<'PY' ...` from the repository root and from `sdk/sample`, and both automated checks failed due to environment issues: the root run failed with `ModuleNotFoundError: No module named 'src'`, and the `sdk/sample` run failed due to a missing dependency `pydantic_settings`, so functional verification could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c32ae6388323a98397fb7e96fc6e)