### PR TITLE
Require URL for app creation in API database layer

### DIFF
--- a/api/src/db/README.md
+++ b/api/src/db/README.md
@@ -21,7 +21,7 @@ Import the database layer once and use the service instances:
 import src.db as db
 
 user = await db.users.get(1)
-app = await db.apps.create('Acme')
+app = await db.apps.create('Acme', 'https://acme.example.com')
 ```
 
 ## Adding new models

--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -11,5 +11,6 @@ class App(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
+    url: Mapped[str] = mapped_column(String(255), nullable=False)
 
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -3,12 +3,12 @@ from src.db.session import get_session
 
 
 class AppsService:
-    async def create(self, name: str) -> App:
+    async def create(self, name: str, url: str) -> App:
         """Add a new app to the database."""
 
         Session = await get_session()
         async with Session() as session:
-            app = App(name=name)
+            app = App(name=name, url=url)
             session.add(app)
             await session.commit()
             await session.refresh(app)


### PR DESCRIPTION
### Motivation

- Ensure every application record stores its external address by making the app URL a required field in the database.

### Description

- Added a required `url` column to the `App` SQLAlchemy model as `url: Mapped[str] = mapped_column(String(255), nullable=False)` in `api/src/db/models/apps.py`.
- Updated `AppsService.create` to accept a `url` parameter and persist it when creating an `App` in `api/src/db/services/apps.py`.
- Updated the database layer usage example to call `db.apps.create(name, url)` in `api/src/db/README.md`.

### Testing

- Compiled the API package with `python -m compileall api/src`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c4cddf7c83239f5d343925f4a740)