### PR TITLE
api: register sample app in __main__ startup

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -38,10 +38,18 @@ app.include_router(router)
 
 
 if __name__ == '__main__':
+    import asyncio
     import uvicorn
     from dotenv import load_dotenv
+
+    import src.db as db
+
+    async def register_sample_app() -> None:
+        await db.apps.create('sample', 'http://localhost:1707')
+
     load_dotenv('.env.sample')
     load_dotenv('.env', override=True)
+    asyncio.run(register_sample_app())
 
     uvicorn.run(
         'main:app',


### PR DESCRIPTION
### Motivation
- Ensure a sample app record exists when running the API directly so local development and proxy routes can target an app backend at `http://localhost:1707`.

### Description
- Add an async helper in `api/main.py` that imports `src.db` and calls `db.apps.create('sample', 'http://localhost:1707')`, then run it with `asyncio.run(register_sample_app())` before launching `uvicorn`.

### Testing
- Ran `python -m py_compile api/main.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c857592c8323a5f23e29aedc992e)