### PR TITLE
web: remove unused react-table type declaration file

### DIFF
--- a/web/src/types/react-table.d.ts
+++ b/web/src/types/react-table.d.ts
@@ -1,8 +1,0 @@
-import '@tanstack/react-table';
-
-declare module '@tanstack/react-table' {
-    interface ColumnMeta<TData, TValue> {
-        align?: 'left' | 'center' | 'right';
-        _type?: [TData, TValue];
-    }
-}


### PR DESCRIPTION
### Motivation
- Remove an unused module augmentation for `@tanstack/react-table` because the app narrows `columnDef.meta` locally and the declaration is no longer necessary.

### Description
- Deleted `web/src/types/react-table.d.ts` and implicitly removed the now-empty `web/src/types` folder to eliminate redundant type augmentation.

### Testing
- Ran `bun run format` in `web`, which completed successfully.
- Attempted `bun run build` in `web`, which failed due to pre-existing unrelated TypeScript issues in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, and a missing import `@/hooks/use-mobile`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c8a1257c8323979eebd001ce6c72)