### PR TITLE
web: require auth for all routes and remove legacy home links

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { Toaster } from '@/components/ui/sonner';
 import { ThemeProvider } from '@/components/theme';
 import { Navigate, RouterProvider, createBrowserRouter } from 'react-router';
@@ -15,14 +16,14 @@ import SettingsPage from '@/pages/org/Settings';
 import Apps from '@/pages/org/Apps';
 import ViaVai from '@/pages/org/ViaVai';
 
+const withAuth = (element: ReactElement) => (
+    <RequireAuth>{element}</RequireAuth>
+);
+
 const router = createBrowserRouter([
     {
         path: '/',
-        element: (
-            <RequireAuth>
-                <Layout />
-            </RequireAuth>
-        ),
+        element: withAuth(<Layout />),
         children: [
             { index: true, element: <Navigate to="/apps" replace /> },
             { path: 'apps', element: <Apps /> },
@@ -38,47 +39,23 @@ const router = createBrowserRouter([
     { path: '/login', element: <Login /> },
     {
         path: '/profile',
-        element: (
-            <RequireAuth>
-                <Layout />
-            </RequireAuth>
-        ),
+        element: withAuth(<Layout />),
         children: [{ index: true, element: <Profile /> }],
     },
     {
         path: '/organizations',
-        element: <Navigate to="/" replace />,
+        element: withAuth(<Navigate to="/" replace />),
     },
     {
         path: '/organization',
-        element: <Navigate to="/" replace />,
-    },
-    {
-        path: '/home',
-        element: <Navigate to="/" replace />,
-    },
-    {
-        path: '/home/privacy',
-        element: <Navigate to="/" replace />,
-    },
-    {
-        path: '/home/tos',
-        element: <Navigate to="/" replace />,
-    },
-    {
-        path: '/home/impressum',
-        element: <Navigate to="/" replace />,
+        element: withAuth(<Navigate to="/" replace />),
     },
     {
         path: '/viavai',
-        element: (
-            <RequireAuth>
-                <Layout />
-            </RequireAuth>
-        ),
+        element: withAuth(<Layout />),
         children: [{ index: true, element: <ViaVai /> }],
     },
-    { path: '*', element: <NotFound /> },
+    { path: '*', element: withAuth(<NotFound />) },
 ]);
 
 export default function App() {


### PR DESCRIPTION
### Motivation
- Ensure all pages except the login page are protected by authentication so the app enforces auth consistently across routes.
- Remove legacy `/home` pages (including `privacy`, `tos`, `impressum`) from the route surface and navigation.

### Description
- Added a small helper `withAuth` in `web/src/App.tsx` to wrap route elements with `RequireAuth` for consistency.
- Replaced the previous ad-hoc `RequireAuth` wrappers by using `withAuth` for the root layout, profile, `viavai`, redirect-only routes (`/organizations`, `/organization`) and the wildcard route so they now require auth.
- Removed the legacy `/home`, `/home/privacy`, `/home/tos`, and `/home/impressum` routes from the router so those pages no longer appear in navigation or routing.
- Kept `'/login'` as the only public route.

### Testing
- Ran code formatting with `bun run format`, which completed successfully.
- Ran `bun run build` to validate the app, which failed due to pre-existing TypeScript issues unrelated to the route changes (errors observed in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, and `src/components/ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c8f2d77083238e7dbb670ff79b5a)