### PR TITLE
Add endpoint to list registered app names

### DIFF
--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -1,8 +1,21 @@
+from typing import List
+
+from sqlalchemy import select
+
 from src.db.models import App
 from src.db.session import get_session
 
 
 class AppsService:
+    async def list_names(self) -> List[str]:
+        """Return all registered app names."""
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(App.name)
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
     async def create(self, name: str, url: str) -> App:
         """Add a new app to the database."""
 

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -2,6 +2,8 @@ import httpx
 from fastapi import Request, Response, HTTPException
 from src.router import router
 
+import src.db as db
+
 APP_BACKEND_URL = "http://localhost:1707"
 
 ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
@@ -66,6 +68,12 @@ async def proxy_request(req: Request, app_id: str, full_path: str = "") -> Respo
             status_code=502,
             detail=f"Could not reach app backend: {exc}",
         )
+
+
+
+@router.get('/apps')
+async def list_apps() -> list[str]:
+    return await db.apps.list_names()
 
 
 # This shall return the root configs of the APP, suche as the name, the tabs, ecc


### PR DESCRIPTION
### Motivation
- Provide a simple API to discover which apps are registered in the platform by returning their names. 

### Description
- Added `AppsService.list_names` in `src/db/services/apps.py` to query and return all app names using `select(App.name)`.
- Added a `GET /apps` route in `src/routes/apps.py` that returns `db.apps.list_names()` and imported `src.db` into the module.
- Left existing `/apps/{app_id}` proxy routes unchanged so app proxy behaviour is preserved.

### Testing
- Ran `cd api && python -m compileall src` and the code compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c95d59708323aaf45efb23f2c3e8)