### PR TITLE
Add app creation API and useApps hook

### DIFF
--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from sqlalchemy import select
 
 from src.db.models import App
@@ -7,17 +5,17 @@ from src.db.session import get_session
 
 
 class AppsService:
-    async def list_names(self) -> List[str]:
-        """Return all registered app names."""
+    async def list(self) -> list[App]:
+        '''Return all registered apps.'''
 
         Session = await get_session()
         async with Session() as session:
-            statement = select(App.name)
+            statement = select(App)
             result = await session.execute(statement)
             return list(result.scalars().all())
 
     async def create(self, name: str, url: str) -> App:
-        """Add a new app to the database."""
+        '''Add a new app to the database.'''
 
         Session = await get_session()
         async with Session() as session:

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -1,40 +1,38 @@
 import httpx
-from fastapi import Request, Response, HTTPException
-from src.router import router
+from fastapi import HTTPException, Request, Response
 
 import src.db as db
+from src.router import router
+from src.types import AppCreate, AppResponse
 
-APP_BACKEND_URL = "http://localhost:1707"
+APP_BACKEND_URL = 'http://localhost:1707'
 
-ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
 
 EXCLUDED_REQUEST_HEADERS = {
-    "host",
-    "content-length",
-    "accept-encoding",
-    "connection",
+    'host',
+    'content-length',
+    'accept-encoding',
+    'connection',
 }
 
 EXCLUDED_RESPONSE_HEADERS = {
-    "content-length",
-    "transfer-encoding",
-    "content-encoding",
-    "connection",
+    'content-length',
+    'transfer-encoding',
+    'content-encoding',
+    'connection',
 }
 
-# ✅ Single shared async client (connection pooled)
 client = httpx.AsyncClient(
     base_url=APP_BACKEND_URL,
     timeout=30.0,
 )
 
 
-async def proxy_request(req: Request, app_id: str, full_path: str = "") -> Response:
-    path = f"{app_id}"
+async def proxy_request(req: Request, app_id: str, full_path: str = '') -> Response:
+    path = f'{app_id}'
     if full_path:
-        path += f"/{full_path}"
-
-    print(path)
+        path += f'/{full_path}'
 
     headers = {
         k: v
@@ -66,22 +64,41 @@ async def proxy_request(req: Request, app_id: str, full_path: str = "") -> Respo
     except httpx.RequestError as exc:
         raise HTTPException(
             status_code=502,
-            detail=f"Could not reach app backend: {exc}",
+            detail=f'Could not reach app backend: {exc}',
         )
 
 
-
 @router.get('/apps')
-async def list_apps() -> list[str]:
-    return await db.apps.list_names()
+async def list_apps() -> list[AppResponse]:
+    apps = await db.apps.list()
+    return [
+        AppResponse(
+            id=app.id,
+            name=app.name,
+            url=app.url,
+        )
+        for app in apps
+    ]
 
 
-# This shall return the root configs of the APP, suche as the name, the tabs, ecc
-@router.api_route("/apps/{app_id}", methods=ALLOWED_METHODS)
+@router.post('/apps')
+async def create_app(payload: AppCreate) -> AppResponse:
+    app = await db.apps.create(
+        name=payload.name,
+        url=payload.url,
+    )
+    return AppResponse(
+        id=app.id,
+        name=app.name,
+        url=app.url,
+    )
+
+
+@router.api_route('/apps/{app_id}', methods=ALLOWED_METHODS)
 async def proxy_root(req: Request, app_id: str):
     return await proxy_request(req, app_id)
 
 
-@router.api_route("/apps/{app_id}/{full_path:path}", methods=ALLOWED_METHODS)
+@router.api_route('/apps/{app_id}/{full_path:path}', methods=ALLOWED_METHODS)
 async def proxy_path(req: Request, app_id: str, full_path: str):
     return await proxy_request(req, app_id, full_path)

--- a/api/src/types/__init__.py
+++ b/api/src/types/__init__.py
@@ -1,2 +1,3 @@
+from .apps import AppCreate, AppResponse
 from .lists.countries import CountryCode
 from .users import UserUpdate

--- a/api/src/types/apps.py
+++ b/api/src/types/apps.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class AppCreate(BaseModel):
+    name: str
+    url: str
+
+
+class AppResponse(BaseModel):
+    id: int
+    name: str
+    url: str

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { apiFetch } from '@/lib/api';
+
+export type App = {
+    id: number;
+    name: string;
+    url: string;
+};
+
+type CreateAppPayload = {
+    name: string;
+    url: string;
+};
+
+type UseAppsResult = {
+    apps: App[];
+    isLoading: boolean;
+    error: string | null;
+    refreshApps: () => Promise<void>;
+    createApp: (payload: CreateAppPayload) => Promise<App>;
+};
+
+export function useApps(): UseAppsResult {
+    const [apps, setApps] = useState<App[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const refreshApps = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const response = await apiFetch<App[]>('/apps');
+            setApps(response);
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : 'Failed to load apps'
+            );
+            setApps([]);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    const createApp = useCallback(async (payload: CreateAppPayload) => {
+        const app = await apiFetch<App>('/apps', {
+            method: 'POST',
+            body: payload,
+        });
+        setApps((previousApps) => [...previousApps, app]);
+        return app;
+    }, []);
+
+    useEffect(() => {
+        void refreshApps();
+    }, [refreshApps]);
+
+    return useMemo(
+        () => ({
+            apps,
+            isLoading,
+            error,
+            refreshApps,
+            createApp,
+        }),
+        [apps, isLoading, error, refreshApps, createApp]
+    );
+}

--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -1,4 +1,5 @@
 import { Plus, Sparkles } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
@@ -8,8 +9,33 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Input } from '@/components/ui/input';
+import { useApps } from '@/hooks/use-apps';
 
 export default function Apps() {
+    const { apps, isLoading, error, createApp } = useApps();
+    const [name, setName] = useState('');
+    const [url, setUrl] = useState('');
+    const [isCreating, setIsCreating] = useState(false);
+
+    const onCreateApp = async () => {
+        if (!name.trim() || !url.trim()) {
+            return;
+        }
+
+        try {
+            setIsCreating(true);
+            await createApp({
+                name: name.trim(),
+                url: url.trim(),
+            });
+            setName('');
+            setUrl('');
+        } finally {
+            setIsCreating(false);
+        }
+    };
+
     return (
         <div className="space-y-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -21,29 +47,70 @@ export default function Apps() {
                         <h1 className="text-lg font-semibold text-white">
                             Apps
                         </h1>
-                        <p className="text-sm text-white/60">0 apps</p>
+                        <p className="text-sm text-white/60">
+                            {apps.length} apps
+                        </p>
                     </div>
                 </div>
-                <Button variant="outline">
-                    <Plus className="h-4 w-4" />
-                    New App
-                </Button>
             </div>
 
-            <Card className="p-10 text-center">
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <Sparkles />
-                        </EmptyMedia>
-                        <EmptyTitle>No Apps Yet</EmptyTitle>
-                        <EmptyDescription>
-                            You haven&apos;t added any apps yet. Get started by
-                            creating your first app.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
+            <Card className="space-y-3 p-4">
+                <p className="text-sm text-white/60">Create a new app</p>
+                <div className="grid gap-3 md:grid-cols-3">
+                    <Input
+                        placeholder="App name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                    />
+                    <Input
+                        placeholder="http://localhost:1707/my-app"
+                        value={url}
+                        onChange={(event) => setUrl(event.target.value)}
+                    />
+                    <Button
+                        variant="outline"
+                        onClick={() => void onCreateApp()}
+                        disabled={isCreating}
+                    >
+                        <Plus className="h-4 w-4" />
+                        New App
+                    </Button>
+                </div>
             </Card>
+
+            {isLoading ? (
+                <Card className="p-10 text-center text-white/60">
+                    Loading apps...
+                </Card>
+            ) : error ? (
+                <Card className="p-10 text-center text-red-300">{error}</Card>
+            ) : apps.length === 0 ? (
+                <Card className="p-10 text-center">
+                    <Empty>
+                        <EmptyHeader>
+                            <EmptyMedia variant="icon">
+                                <Sparkles />
+                            </EmptyMedia>
+                            <EmptyTitle>No Apps Yet</EmptyTitle>
+                            <EmptyDescription>
+                                You haven&apos;t added any apps yet. Get started
+                                by creating your first app.
+                            </EmptyDescription>
+                        </EmptyHeader>
+                    </Empty>
+                </Card>
+            ) : (
+                <div className="grid gap-3">
+                    {apps.map((app) => (
+                        <Card key={app.id} className="space-y-1 p-4">
+                            <h2 className="font-medium text-white">
+                                {app.name}
+                            </h2>
+                            <p className="text-sm text-white/60">{app.url}</p>
+                        </Card>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Provide a complete flow to register and display external apps by exposing API endpoints and a frontend hook so the UI can list and create apps. 

### Description
- Add typed API models `AppCreate` and `AppResponse` in `api/src/types/apps.py` and export them from `api/src/types/__init__.py`.
- Update the apps DB service to return full `App` records via `AppsService.list()` in `api/src/db/services/apps.py` and keep `create()` for persistence.
- Implement `GET /apps` to return full app objects and `POST /apps` to create new apps in `api/src/routes/apps.py` using the new types.
- Add a `useApps` hook in `web/src/hooks/use-apps.ts` exposing `apps`, `isLoading`, `error`, `refreshApps`, and `createApp`, and wire it into the organization Apps page `web/src/pages/org/Apps.tsx` to render live data and a create-app form.

### Testing
- Ran `python -m compileall api/src` and the Python sources compiled successfully.
- Ran `bun run format` in `web` and code was formatted successfully.
- `bun run build` in `web` currently fails due to pre-existing TypeScript issues in unrelated components (`resizable.tsx`, `scroll-area.tsx`) and a missing local hook (`@/hooks/use-mobile`).
- Attempting to start the API with `uvicorn` failed due to a missing runtime dependency (`pydantic_settings`), preventing a full end-to-end runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cb1be83083238a3e1f2c6b7fa82d)