### PR TITLE
Use settings.DATABASE_URL in DB session initialization

### DIFF
--- a/api/src/db/session.py
+++ b/api/src/db/session.py
@@ -1,5 +1,5 @@
-import os
 from src.db.models import Base
+from src.settings import settings
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 
@@ -14,15 +14,15 @@ async def get_session() -> async_sessionmaker[AsyncSession]:
     if Session is not None:
         return Session
 
-    dburl = os.environ["DBURL"]
+    dburl = settings.DATABASE_URL
 
     engine_kwargs = {
-        "pool_pre_ping": True,
-        "pool_recycle": 20,
+        'pool_pre_ping': True,
+        'pool_recycle': 20,
     }
 
-    if not dburl.startswith("sqlite+"):
-        engine_kwargs["pool_use_lifo"] = True
+    if not dburl.startswith('sqlite+'):
+        engine_kwargs['pool_use_lifo'] = True
 
     _engine = create_async_engine(dburl, **engine_kwargs)
 
@@ -33,7 +33,7 @@ async def get_session() -> async_sessionmaker[AsyncSession]:
     Session = async_sessionmaker(_engine, expire_on_commit=False)
 
     # Auto-create tables for SQLite only
-    if dburl.startswith("sqlite+"):
+    if dburl.startswith('sqlite+'):
         async with _engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 


### PR DESCRIPTION
### Motivation
- Prevent `KeyError: 'DBURL'` and align DB URL resolution with the app's settings model by using the central `settings.DATABASE_URL` instead of reading `os.environ['DBURL']` directly.

### Description
- Replaced the direct environment lookup in `api/src/db/session.py` with `from src.settings import settings` and use `settings.DATABASE_URL`, and adjusted string quoting to single quotes for consistency; session/engine behavior is otherwise unchanged.

### Testing
- Compiled the module with `python -m compileall api/src/db/session.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d25a8aac832395bf5ed2d36b3b23)