### PR TITLE
Avoid duplicate sample app registration

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -44,7 +44,10 @@ if __name__ == '__main__':
     import src.db as db
 
     async def register_sample_app() -> None:
-        await db.apps.create('sample', 'http://localhost:1707')
+        apps = await db.apps.list()
+        sample_exists = any(app.name == 'sample' for app in apps)
+        if not sample_exists:
+            await db.apps.create('sample', 'http://localhost:1707')
 
     asyncio.run(register_sample_app())
 


### PR DESCRIPTION
### Motivation
- Prevent inserting a duplicate `sample` app on repeated local starts by creating it only when it is not already present in the database.

### Description
- In `api/main.py`, `register_sample_app()` now calls `db.apps.list()`, checks for an existing app with `name == 'sample'`, and only calls `db.apps.create('sample', 'http://localhost:1707')` if it does not exist.

### Testing
- Ran `python -m py_compile api/main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69959cc881b88323863eef170741ac90)