### PR TITLE
Make app cards navigate to /apps/<app_name>

### DIFF
--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -1,5 +1,6 @@
 import { Plus, Sparkles } from 'lucide-react';
 import { useState } from 'react';
+import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
@@ -102,12 +103,16 @@ export default function Apps() {
             ) : (
                 <div className="grid gap-3">
                     {apps.map((app) => (
-                        <Card key={app.id} className="space-y-1 p-4">
-                            <h2 className="font-medium text-white">
-                                {app.name}
-                            </h2>
-                            <p className="text-sm text-white/60">{app.url}</p>
-                        </Card>
+                        <Link key={app.id} to={`/apps/${app.name}`}>
+                            <Card className="space-y-1 p-4 transition hover:bg-white/5">
+                                <h2 className="font-medium text-white">
+                                    {app.name}
+                                </h2>
+                                <p className="text-sm text-white/60">
+                                    {app.url}
+                                </p>
+                            </Card>
+                        </Link>
                     ))}
                 </div>
             )}


### PR DESCRIPTION
### Motivation
- Make the Apps list entries clickable so selecting an app opens its dedicated route at `/apps/<app_name>`.

### Description
- Import `Link` from `react-router` and wrap each app `Card` in `<Link to={`/apps/${app.name}`}>` so clicking a card navigates to the app route.
- Preserve existing `Card` layout and add a subtle `transition hover:bg-white/5` class to indicate clickability.
- No changes to API hooks or backend behavior were made.

### Testing
- Ran `bun run format` inside `web` which completed successfully.
- Ran `bun run build` inside `web` which failed due to pre-existing TypeScript errors unrelated to this change (errors reported in `resizable.tsx`, `scroll-area.tsx`, and `sidebar.tsx`).
- Executed an automated Playwright screenshot attempt which failed because Chromium crashed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69959e81ef808323b1e51590925c0f28)