### PR TITLE
Build app tabs from /apps/:app metadata pages

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -6,13 +6,20 @@ import {
     useParams,
 } from 'react-router';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { UserProfile } from '@/components/Profile';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useData } from '@/hooks/use-data';
 import {
     getActiveTabConfig,
+    getAppTabsFromPages,
     getTabsConfig,
     NavigationIcon,
+    type AppNavigationPage,
 } from '@/lib/navigation';
+
+type AppMetadata = {
+    pages?: AppNavigationPage[];
+};
 
 type NavigationProps = {
     tabs: ReturnType<typeof getTabsConfig>['tabs'];
@@ -21,9 +28,17 @@ type NavigationProps = {
 
 export default function Layout() {
     const { app } = useParams();
+    const appMetadataEndpoint = app ? `/apps/${app}` : null;
+
+    const { data: appMetadata } = useData<AppMetadata>(appMetadataEndpoint);
+    const appTabs = app
+        ? getAppTabsFromPages(appMetadata?.pages ?? [])
+        : undefined;
+
     const { tabs, basePathSuffix } = getTabsConfig({
         section: 'organization',
         app,
+        appTabs,
     });
 
     return <Navigation tabs={tabs} basePathSuffix={basePathSuffix} />;

--- a/web/src/hooks/use-data.ts
+++ b/web/src/hooks/use-data.ts
@@ -9,7 +9,7 @@ type UseDataResult<T> = {
     refresh: () => Promise<void>;
 };
 
-export function useData<T>(endpoint: string): UseDataResult<T> {
+export function useData<T>(endpoint: string | null): UseDataResult<T> {
     const [data, setData] = useState<T | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -19,13 +19,20 @@ export function useData<T>(endpoint: string): UseDataResult<T> {
         setError(null);
 
         try {
+            if (!endpoint) {
+                setData(null);
+                return;
+            }
+
             const response = await apiFetch<T>(endpoint);
             setData(response);
         } catch (err) {
             setError(
                 err instanceof Error
                     ? err.message
-                    : `Failed to load ${endpoint}`
+                    : endpoint
+                      ? `Failed to load ${endpoint}`
+                      : 'Failed to load data'
             );
             setData(null);
         } finally {

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -1,14 +1,11 @@
 import type { LucideIcon } from 'lucide-react';
 import {
     BarChart3,
-    Boxes,
     FileText,
     FolderKanban,
-    Layers,
     Settings,
     Sparkles,
     Users,
-    Wrench,
 } from 'lucide-react';
 
 export type NavigationTab = {
@@ -31,56 +28,47 @@ const defaultAppTabs: NavigationTab[] = [
     { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
 ];
 
-const appTabsByName: Record<string, NavigationTab[]> = {
-    viavai: [
-        { value: 'overview', label: 'Overview', path: '', icon: FileText },
-        {
-            value: 'automations',
-            label: 'Automations',
-            path: 'automations',
-            icon: Sparkles,
-        },
-        {
-            value: 'integrations',
-            label: 'Integrations',
-            path: 'integrations',
-            icon: Boxes,
-        },
-        {
-            value: 'settings',
-            label: 'Settings',
-            path: 'settings',
-            icon: Settings,
-        },
-    ],
-    atlas: [
-        { value: 'overview', label: 'Overview', path: '', icon: FileText },
-        { value: 'models', label: 'Models', path: 'models', icon: Layers },
-        { value: 'reports', label: 'Reports', path: 'reports', icon: FileText },
-        {
-            value: 'settings',
-            label: 'Settings',
-            path: 'settings',
-            icon: Settings,
-        },
-    ],
-    pulse: [
-        { value: 'overview', label: 'Overview', path: '', icon: FileText },
-        {
-            value: 'streams',
-            label: 'Streams',
-            path: 'streams',
-            icon: Sparkles,
-        },
-        { value: 'alerts', label: 'Alerts', path: 'alerts', icon: Wrench },
-        {
-            value: 'settings',
-            label: 'Settings',
-            path: 'settings',
-            icon: Settings,
-        },
-    ],
+export type AppNavigationPage = {
+    path: string;
+    name: string;
+    icon?: string;
 };
+
+const pageIconMap: Record<string, LucideIcon> = {
+    settings: Settings,
+};
+
+const normalizeTabPath = (path: string) => path.replace(/^\/+|\/+$/g, '');
+
+const getTabValue = ({ path, name }: { path: string; name: string }) => {
+    if (path.length > 0) {
+        return path;
+    }
+
+    return name.toLowerCase().replace(/\s+/g, '-');
+};
+
+export function getAppTabsFromPages(
+    pages: AppNavigationPage[]
+): NavigationTab[] {
+    if (pages.length === 0) {
+        return defaultAppTabs;
+    }
+
+    return pages.map((page) => {
+        const path = normalizeTabPath(page.path);
+        const icon = page.icon
+            ? (pageIconMap[page.icon] ?? FileText)
+            : FileText;
+
+        return {
+            value: getTabValue({ path, name: page.name }),
+            label: page.name,
+            path,
+            icon,
+        };
+    });
+}
 
 export type TabsConfig = {
     tabs: NavigationTab[];
@@ -90,12 +78,13 @@ export type TabsConfig = {
 export function getTabsConfig({
     section: _section,
     app,
+    appTabs,
 }: {
     section: 'account' | 'organization';
     app?: string;
+    appTabs?: NavigationTab[];
 }): TabsConfig {
-    const appTabs = app ? (appTabsByName[app] ?? defaultAppTabs) : null;
-    const tabs = appTabs ?? organizationTabs;
+    const tabs = app ? (appTabs ?? defaultAppTabs) : organizationTabs;
     const basePathSuffix = app ? `apps/${app}` : undefined;
 
     return { tabs, basePathSuffix };


### PR DESCRIPTION
### Motivation
- Make app navigation dynamic by using the backend-provided app metadata (the `pages` array from `GET /apps/:app`) so an app like `sample` can render only the tabs declared by the backend (e.g. a single Settings tab). 
- Remove the previous hardcoded per-app tab matrix and derive tabs from page definitions to keep frontend navigation in sync with app metadata.

### Description
- Added `AppNavigationPage` and `getAppTabsFromPages` to `web/src/lib/navigation.ts` to map backend `pages` entries into `NavigationTab` entries with normalized paths and a small icon map. 
- Updated `getTabsConfig` to accept caller-supplied `appTabs` so app-level tabs can be injected dynamically instead of picking from hardcoded sets. 
- Updated `web/src/Layout.tsx` to fetch app metadata via `useData` for `GET /apps/:app` and pass the derived tabs into the navigation config. 
- Made `useData` accept a nullable endpoint (`string | null`) in `web/src/hooks/use-data.ts` so shared layout routes that do not need app metadata can skip fetching safely.

### Testing
- Ran `bun run format` in the `web` package and it completed successfully. 
- Ran `bun run build` in the `web` package and it failed due to unrelated existing TypeScript errors in other UI files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`). 
- Started the dev server and executed an automated Playwright script that mocked `GET /apps/sample` to return a payload with a single `Settings` page, navigated to `http://localhost:4173/apps/sample`, and captured a screenshot showing only the Settings tab (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a3de84188323ac55af9910582b42)