### PR TITLE
Show a single loading tab while app navigation metadata loads

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react';
 import {
     Link,
     Outlet,
@@ -24,15 +25,26 @@ type AppMetadata = {
 type NavigationProps = {
     tabs: ReturnType<typeof getTabsConfig>['tabs'];
     basePathSuffix?: string;
+    isTabsLoading?: boolean;
 };
 
 export default function Layout() {
     const { app } = useParams();
     const appMetadataEndpoint = app ? `/apps/${app}` : null;
 
-    const { data: appMetadata } = useData<AppMetadata>(appMetadataEndpoint);
+    const { data: appMetadata, isLoading: isAppMetadataLoading } =
+        useData<AppMetadata>(appMetadataEndpoint);
     const appTabs = app
-        ? getAppTabsFromPages(appMetadata?.pages ?? [])
+        ? isAppMetadataLoading
+            ? [
+                  {
+                      value: 'loading',
+                      label: 'Loading',
+                      path: '',
+                      icon: Loader2,
+                  },
+              ]
+            : getAppTabsFromPages(appMetadata?.pages ?? [])
         : undefined;
 
     const { tabs, basePathSuffix } = getTabsConfig({
@@ -41,10 +53,20 @@ export default function Layout() {
         appTabs,
     });
 
-    return <Navigation tabs={tabs} basePathSuffix={basePathSuffix} />;
+    return (
+        <Navigation
+            tabs={tabs}
+            basePathSuffix={basePathSuffix}
+            isTabsLoading={Boolean(app && isAppMetadataLoading)}
+        />
+    );
 }
 
-export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
+export function Navigation({
+    tabs,
+    basePathSuffix,
+    isTabsLoading,
+}: NavigationProps) {
     const { app } = useParams();
     const location = useLocation();
     const navigate = useNavigate();
@@ -61,9 +83,11 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
         locationPath: location.pathname,
         basePath,
     });
-    const activeTab = location.pathname.startsWith('/profile')
-        ? 'apps'
-        : (activeTabConfig?.value ?? tabs[0]?.value ?? 'overview');
+    const activeTab = isTabsLoading
+        ? 'loading'
+        : location.pathname.startsWith('/profile')
+          ? 'apps'
+          : (activeTabConfig?.value ?? tabs[0]?.value ?? 'overview');
 
     return (
         <div className="min-h-screen text-white">
@@ -88,6 +112,9 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                     <Tabs
                         value={activeTab}
                         onValueChange={(value) => {
+                            if (isTabsLoading) {
+                                return;
+                            }
                             const nextTab = tabs.find(
                                 (tab) => tab.value === value
                             );
@@ -111,9 +138,12 @@ export function Navigation({ tabs, basePathSuffix }: NavigationProps) {
                                     <TabsTrigger
                                         key={tab.value}
                                         value={tab.value}
+                                        disabled={isTabsLoading}
                                         className="cursor-pointer"
                                     >
-                                        <Icon className="h-4 w-4" />
+                                        <Icon
+                                            className={`h-4 w-4 ${tab.value === 'loading' ? 'animate-spin' : ''}`}
+                                        />
                                         {tab.label}
                                     </TabsTrigger>
                                 );


### PR DESCRIPTION
### Motivation
- Prevent the full app tab list from flashing before app metadata is loaded and provide a clear, single loading state when navigating to `apps/:app/*` routes.
- Avoid accidental navigation to stale or default tabs while the app-specific tab configuration is still being fetched.

### Description
- Extract `isLoading` from `useData` for app metadata and, when loading, set `appTabs` to a single temporary tab `{ value: 'loading', label: 'Loading', icon: Loader2 }` in `web/src/Layout.tsx`.
- Pass an `isTabsLoading` flag into the `Navigation` component and select the `'loading'` tab while the metadata request is in-flight.
- Disable tab switching during loading and render a spinning icon for the loading tab to provide visual feedback.
- Add `Loader2` import from `lucide-react` and update tab rendering to apply a spinner style when `tab.value === 'loading'`.

### Testing
- Ran formatting with `bun run format`, which succeeded.
- Linted the modified file with `bunx eslint src/Layout.tsx`, which completed without errors.
- Started the dev server and executed an automated Playwright script to simulate a delayed `/apps/:app` metadata response and capture a screenshot of the loading tab, which produced the expected loading UI snapshot.
- Attempted `bun run build`, which failed due to unrelated pre-existing TypeScript issues in other UI files and did not block verification of the loading-tab behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a55dee0c8323acb3d5b9ce553531)