### PR TITLE
Fix Apps header icon and text alignment

### DIFF
--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -45,8 +45,8 @@ export default function Apps() {
 
     return (
         <div className="space-y-6">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="flex items-start gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
                     <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/30">
                         <Sparkles className="h-5 w-5" />
                     </div>


### PR DESCRIPTION
### Motivation
- Vertically align the Sparkles icon with the Apps title/subtitle block on the Apps page to fix a visual misalignment.

### Description
- Update `web/src/pages/org/Apps.tsx` by replacing `items-start` with `items-center` on the header wrapper and inner row so the icon and text are centered vertically, and run `bun run format` before committing.

### Testing
- Ran `bun run format` in `web` which succeeded; ran `bun run build` in `web` which failed due to pre-existing TypeScript issues unrelated to this change; generated an automated Playwright screenshot of the Apps page which confirmed the visual alignment change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a95f6ec48323b8f5748ed09ba718)