### PR TITLE
web: add reusable Icon resolver component

### DIFF
--- a/web/src/components/Icon.tsx
+++ b/web/src/components/Icon.tsx
@@ -1,0 +1,66 @@
+import * as LucideIcons from 'lucide-react';
+import {
+    AppWindow,
+    Box,
+    FileText,
+    FolderKanban,
+    Settings,
+    Table2,
+    type LucideIcon,
+    type LucideProps,
+} from 'lucide-react';
+
+type IconProps = LucideProps & {
+    name?: string | null;
+    fallback?: LucideIcon;
+};
+
+const iconAliasMap: Record<string, LucideIcon> = {
+    app: AppWindow,
+    apps: FolderKanban,
+    file: FileText,
+    settings: Settings,
+    table: Table2,
+    tabs: FolderKanban,
+};
+
+function normalizeIconName(name: string): string {
+    return name.trim().toLowerCase();
+}
+
+function toPascalCase(value: string): string {
+    return value
+        .split(/[^a-zA-Z0-9]+/)
+        .filter((part) => part.length > 0)
+        .map((part) => part[0].toUpperCase() + part.slice(1).toLowerCase())
+        .join('');
+}
+
+export function getIconByName(
+    name?: string | null,
+    fallback: LucideIcon = Box
+): LucideIcon {
+    if (!name) {
+        return fallback;
+    }
+
+    const normalizedName = normalizeIconName(name);
+    const aliasedIcon = iconAliasMap[normalizedName];
+
+    if (aliasedIcon) {
+        return aliasedIcon;
+    }
+
+    const iconExport =
+        LucideIcons[toPascalCase(normalizedName) as keyof typeof LucideIcons];
+
+    return typeof iconExport === 'function'
+        ? (iconExport as LucideIcon)
+        : fallback;
+}
+
+export function Icon({ name, fallback = Box, ...props }: IconProps) {
+    const ResolvedIcon = getIconByName(name, fallback);
+
+    return <ResolvedIcon {...props} />;
+}

--- a/web/src/components/viavai/Menu.tsx
+++ b/web/src/components/viavai/Menu.tsx
@@ -8,7 +8,9 @@ import {
     type ReactNode,
 } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { AppWindow, Box, FolderKanban, Table2 } from 'lucide-react';
+import { AppWindow } from 'lucide-react';
+
+import { getIconByName } from '@/components/Icon';
 
 import {
     Menu as BaseMenu,
@@ -73,11 +75,6 @@ function getDefaultActiveValue(
     return firstSection.subSections[0]?.id ?? firstSection.id;
 }
 
-const iconByName: Record<string, LucideIcon> = {
-    table: Table2,
-    tabs: FolderKanban,
-};
-
 function resolveSectionTitle(props: ParsedMenuSectionProps): string {
     return props.title ?? props.props?.title ?? 'Section';
 }
@@ -89,7 +86,7 @@ function resolveSectionIcon(props: ParsedMenuSectionProps): LucideIcon {
         return AppWindow;
     }
 
-    return iconByName[iconName] ?? Box;
+    return getIconByName(iconName, AppWindow);
 }
 
 function resolveSubSectionTitle(

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -8,6 +8,8 @@ import {
     Users,
 } from 'lucide-react';
 
+import { getIconByName } from '@/components/Icon';
+
 export type NavigationTab = {
     value: string;
     label: string;
@@ -26,10 +28,6 @@ export type AppNavigationPage = {
     path: string;
     name: string;
     icon?: string;
-};
-
-const pageIconMap: Record<string, LucideIcon> = {
-    settings: Settings,
 };
 
 const normalizeTabPath = (path: string) => path.replace(/^\/+|\/+$/g, '');
@@ -51,9 +49,7 @@ export function getAppTabsFromPages(
 
     return pages.map((page) => {
         const path = normalizeTabPath(page.path);
-        const icon = page.icon
-            ? (pageIconMap[page.icon] ?? FileText)
-            : FileText;
+        const icon = getIconByName(page.icon, FileText);
 
         return {
             value: getTabValue({ path, name: page.name }),


### PR DESCRIPTION
### Motivation
- Provide a single, reusable way to resolve string icon names to Lucide icons so UI code can accept string-based icon identifiers and avoid duplicated mapping logic.
- Centralize aliasing, normalization and fallback behavior for icons to keep icon resolution consistent across components.

### Description
- Added `web/src/components/Icon.tsx` which implements `getIconByName(name, fallback)` and an `Icon` component that resolves aliases, normalizes names, converts to PascalCase and looks up icons from `lucide-react` with a fallback when not found.
- Replaced the local `iconByName` logic in `web/src/components/viavai/Menu.tsx` to use `getIconByName` for section icons.
- Updated `web/src/lib/navigation.ts` to call `getIconByName(page.icon, FileText)` when building app tab icons and imported the resolver from the new component.

### Testing
- Ran `bun run format` which executed Prettier and reformatted/added the new file without errors.
- Attempted `bun run build` (executes `tsc -b && vite build`) which failed due to unrelated existing TypeScript errors in other UI files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`) and not because of the icon resolver changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995aa434f7483238b70e59ebb5f713f)