### PR TITLE
Use lucide dynamic icon import map in web Icon component

### DIFF
--- a/web/src/components/Icon.tsx
+++ b/web/src/components/Icon.tsx
@@ -1,24 +1,20 @@
 import React, { Suspense } from 'react';
-import type { LucideProps, LucideIcon } from 'lucide-react';
+import dynamicIconImports from 'lucide-react/dynamicIconImports';
+import type { LucideIcon, LucideProps } from 'lucide-react';
 
 type IconModule = {
     default: LucideIcon;
 };
 
-// Load all icon importers
-const iconImporters = import.meta.glob<IconModule>(
-    '/node_modules/lucide-react/dist/esm/icons/*.js'
-);
+const iconImporters = dynamicIconImports as Record<
+    string,
+    () => Promise<IconModule>
+>;
 
-// Build lazy components ONCE (module scope)
 const lazyIcons: Record<string, React.LazyExoticComponent<LucideIcon>> = {};
 
-for (const path in iconImporters) {
-    const match = path.match(/icons\/(.*)\.js$/);
-    if (!match) continue;
-
-    const iconName = match[1]; // kebab-case
-    lazyIcons[iconName] = React.lazy(iconImporters[path]);
+for (const [iconName, importer] of Object.entries(iconImporters)) {
+    lazyIcons[iconName] = React.lazy(importer);
 }
 
 function toKebabCase(value: string): string {
@@ -33,15 +29,10 @@ type IconProps = LucideProps & {
     fallback?: string;
 };
 
-export function Icon({
-    name,
-    fallback = 'box',
-    ...props
-}: IconProps) {
+export function Icon({ name, fallback = 'box', ...props }: IconProps) {
     const iconName = toKebabCase(name ?? fallback);
 
-    const Component =
-        lazyIcons[iconName] ?? lazyIcons[toKebabCase(fallback)];
+    const Component = lazyIcons[iconName] ?? lazyIcons[toKebabCase(fallback)];
 
     return (
         <Suspense fallback={null}>


### PR DESCRIPTION
### Motivation
- Replace fragile Vite-specific `import.meta.glob` lookup against `node_modules` with the officially provided Lucide dynamic import map to make icon loading more robust and compatible with the library.

### Description
- Import `dynamicIconImports` from `lucide-react/dynamicIconImports` and use it as the icon importer map in `web/src/components/Icon.tsx`.
- Build a `lazyIcons` registry by iterating `Object.entries(iconImporters)` and creating `React.lazy` components for each importer to preserve on-demand loading.
- Preserve the existing kebab-case name normalization (`toKebabCase`) and fallback resolution so current usage and behavior remain unchanged.

### Testing
- Ran `bun run format` in `web/` which completed successfully and formatted the changed file.
- Ran `bun run build` in `web/` which failed due to pre-existing TypeScript errors in unrelated files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, and `src/components/ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b9306ad8832390df6fff10b5f064)