### PR TITLE
web: render hero icon in Hero component

### DIFF
--- a/web/src/components/viavai/Hero.tsx
+++ b/web/src/components/viavai/Hero.tsx
@@ -1,18 +1,27 @@
 import type { ReactNode } from 'react';
 import Button from '@/components/viavai/Button';
+import { Icon } from '@/components/viavai/Icon';
 
 type HeroProps = {
     title: string;
     subtitle?: string | null;
     action?: string | null;
+    icon?: string | null;
     children?: ReactNode;
 };
 
-export function Hero({ title, subtitle, action, children }: HeroProps) {
+export function Hero({ title, subtitle, action, icon, children }: HeroProps) {
     return (
         <div className="flex items-start justify-between gap-4">
             <div>
-                <h2 className="text-lg font-semibold text-white">{title}</h2>
+                <div className="flex items-center gap-2">
+                    {icon ? (
+                        <Icon name={icon} className="h-5 w-5 text-white" />
+                    ) : null}
+                    <h2 className="text-lg font-semibold text-white">
+                        {title}
+                    </h2>
+                </div>
                 {subtitle ? (
                     <p className="text-sm text-white/60">{subtitle}</p>
                 ) : null}


### PR DESCRIPTION
### Motivation
- Allow pages and schema-driven renderers to supply an icon name string to the hero so the UI can show a leading icon next to the title using the shared icon system.

### Description
- Add an optional `icon?: string | null` prop to `Hero` and import/use the shared `Icon` component to render the icon inline with the title in `web/src/components/viavai/Hero.tsx`, leaving subtitle and action behavior unchanged.

### Testing
- `bun run format` (from `web/`) succeeded.
- `bun run build` (from `web/`) was run and failed due to pre-existing TypeScript issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c99b405883239d7fd7c3e4c10cd5)