### PR TITLE
Fix ViaVai page endpoint resolution for app tabs

### DIFF
--- a/web/src/pages/org/ViaVai.tsx
+++ b/web/src/pages/org/ViaVai.tsx
@@ -1,10 +1,39 @@
 import Render, { type RenderNodeSchema } from '@/components/Render';
 import { useData } from '@/hooks/use-data';
+import { type AppNavigationPage } from '@/lib/navigation';
+import { useMemo } from 'react';
 import { useParams } from 'react-router';
 
+type AppMetadata = {
+    pages?: AppNavigationPage[];
+};
+
+const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
+
 export default function ViaVai() {
-    const { app } = useParams();
-    const pageEndpoint = app ? `/apps/${app}/page` : null;
+    const { app, '*': wildcardPath } = useParams();
+    const normalizedRoutePath = normalizePath(wildcardPath ?? '');
+
+    const { data: appMetadata, isLoading: isAppMetadataLoading } =
+        useData<AppMetadata>(
+            app && normalizedRoutePath.length === 0 ? `/apps/${app}` : null
+        );
+
+    const fallbackPagePath = useMemo(() => {
+        if (!appMetadata?.pages || appMetadata.pages.length === 0) {
+            return '';
+        }
+
+        return normalizePath(appMetadata.pages[0]?.path ?? '');
+    }, [appMetadata?.pages]);
+
+    const activePagePath = normalizedRoutePath || fallbackPagePath;
+    const pageEndpoint = app
+        ? activePagePath.length > 0
+            ? `/apps/${app}/${activePagePath}`
+            : null
+        : null;
+
     const { data, isLoading, error } = useData<unknown>(pageEndpoint);
 
     const samplePageData = Array.isArray(data)
@@ -15,8 +44,12 @@ export default function ViaVai() {
         return <div>{error}</div>;
     }
 
-    if (isLoading) {
+    if (isAppMetadataLoading || isLoading) {
         return <div>Loading...</div>;
+    }
+
+    if (!pageEndpoint) {
+        return <div>No pages configured for this app.</div>;
     }
 
     if (data !== null && !Array.isArray(data)) {


### PR DESCRIPTION
### Motivation
- The ViaVai page was always requesting a hardcoded `/apps/:app/page` endpoint which prevented loading app tabs that expose different page endpoints.
- The intent is to request the actual page endpoint corresponding to the selected app tab or fallback to the app's first configured page when visiting the app root.

### Description
- Reworked `web/src/pages/org/ViaVai.tsx` to read the wildcard route segment (`/apps/:app/*`) via `useParams` and normalize it with `normalizePath`.
- When the route has no page segment the component now fetches app metadata (`/apps/:app`) and uses the first configured page path as a fallback via `useMemo`.
- The page endpoint is now computed as `/apps/:app/<page-path>` and requested with `useData`, and a friendly empty state is shown when an app has no configured pages.
- Added minimal type support for `AppNavigationPage` and adjusted loading/error handling to await app metadata when needed.

### Testing
- Ran `bun run format` in `web` and it completed successfully.
- Attempted `bun run build` in `web` and it failed due to pre-existing TypeScript errors unrelated to this change (errors in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, and `src/components/ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ca522384832395d034fa4c438d53)