### PR TITLE
Move app creation UI into Apps hero modal

### DIFF
--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -5,6 +5,12 @@ import Hero from '@/components/viavai/Hero';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     Empty,
     EmptyDescription,
     EmptyHeader,
@@ -50,34 +56,42 @@ export default function Apps() {
                 title="Apps"
                 subtitle={`${apps.length} apps`}
                 icon="sparkles"
-            />
+                action="Create New App"
+            >
+                <DialogContent className="sm:max-w-3xl">
+                    <DialogHeader>
+                        <DialogTitle>Create a new app</DialogTitle>
+                        <DialogDescription>
+                            Add a name and URL to register your app.
+                        </DialogDescription>
+                    </DialogHeader>
 
-            <Card className="space-y-3 p-4">
-                <p className="text-sm text-white/60">Create a new app</p>
-                <div className="grid gap-3 md:grid-cols-3">
-                    <Input
-                        placeholder="App name"
-                        value={name}
-                        onChange={(event) => setName(event.target.value)}
-                    />
-                    <Input
-                        placeholder="http://localhost:1707/my-app"
-                        value={url}
-                        onChange={(event) => setUrl(event.target.value)}
-                    />
-                    <Button
-                        variant="outline"
-                        onClick={() => void onCreateApp()}
-                        disabled={isCreating}
-                    >
-                        <Plus className="h-4 w-4" />
-                        New App
-                    </Button>
-                </div>
-                {createError ? (
-                    <p className="text-sm text-red-300">{createError}</p>
-                ) : null}
-            </Card>
+                    <div className="grid gap-3 md:grid-cols-3">
+                        <Input
+                            placeholder="App name"
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                        />
+                        <Input
+                            placeholder="http://localhost:1707/my-app"
+                            value={url}
+                            onChange={(event) => setUrl(event.target.value)}
+                        />
+                        <Button
+                            variant="outline"
+                            onClick={() => void onCreateApp()}
+                            disabled={isCreating}
+                        >
+                            <Plus className="h-4 w-4" />
+                            New App
+                        </Button>
+                    </div>
+
+                    {createError ? (
+                        <p className="text-sm text-red-300">{createError}</p>
+                    ) : null}
+                </DialogContent>
+            </Hero>
 
             {isLoading ? (
                 <Card className="p-10 text-center text-white/60">


### PR DESCRIPTION
### Motivation
- Consolidate the app creation UX by surfacing the create form inside the Apps page hero modal instead of an inline card so users can open the flow from the hero action button.
- Preserve existing create logic and error handling while improving discoverability and consistency with other hero actions.

### Description
- Added `action="Create New App"` to the `Hero` in `web/src/pages/org/Apps.tsx` and moved the create inputs and submit `Button` into the `Hero` children so they render inside the hero modal.
- Wrapped the form with `DialogContent`, `DialogHeader`, `DialogTitle`, and `DialogDescription` from `@/components/ui/dialog` to provide a proper modal layout and explanatory copy.
- Removed the previous inline `Card` that contained the create form while keeping the existing `onCreateApp` logic and error message rendering intact.
- Form layout and inputs (`Input` placeholders, submit `Button`, and `Plus` icon) remain unchanged visually and behaviorally, only their container moved into the modal.

### Testing
- Ran `bun run format` in `web` which completed successfully.
- Ran `bun run build` in `web` which failed due to pre-existing TypeScript errors in unrelated UI files and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962c4e62c08323b225fa8d4c7c639c)