### PR TITLE
Add users management endpoint and frontend useUsers hook

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,7 @@ app.add_middleware(
 import src.routes.apps
 import src.routes.auth
 import src.routes.user
+import src.routes.users
 
 app.include_router(router)
 

--- a/api/src/db/services/users.py
+++ b/api/src/db/services/users.py
@@ -4,6 +4,15 @@ from src.db.session import get_session
 
 
 class UsersService:
+    async def list(self) -> list[User]:
+        '''Return all users in the database.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(User)
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
     async def create(
         self,
         name: str,

--- a/api/src/models/users.py
+++ b/api/src/models/users.py
@@ -5,3 +5,11 @@ class UserUpdate(BaseModel):
     name: str | None = None
     email: EmailStr | None = None
     avatar: str | None = None
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+    email: EmailStr
+    avatar: str | None = None
+    oauth_github_id: int | None = None

--- a/api/src/routes/users.py
+++ b/api/src/routes/users.py
@@ -1,0 +1,20 @@
+import src.db as db
+from fastapi import Depends
+from src.auth import authuser
+from src.models.users import UserResponse
+from src.router import router
+
+
+@router.get('/users')
+async def list_users(_: db.User = Depends(authuser)) -> list[UserResponse]:
+    users = await db.users.list()
+    return [
+        UserResponse(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            avatar=user.avatar,
+            oauth_github_id=user.oauth_github_id,
+        )
+        for user in users
+    ]

--- a/web/src/hooks/use-users.ts
+++ b/web/src/hooks/use-users.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { apiFetch } from '@/lib/api';
+
+export type ManagedUser = {
+    id: number;
+    name: string;
+    email: string;
+    avatar?: string | null;
+    oauth_github_id?: number | null;
+};
+
+type UseUsersResult = {
+    users: ManagedUser[];
+    isLoading: boolean;
+    error: string | null;
+    refreshUsers: () => Promise<void>;
+};
+
+export function useUsers(): UseUsersResult {
+    const [users, setUsers] = useState<ManagedUser[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const refreshUsers = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const response = await apiFetch<ManagedUser[]>('/users', {
+                credentials: 'include',
+            });
+            setUsers(response);
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : 'Failed to load users'
+            );
+            setUsers([]);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void refreshUsers();
+    }, [refreshUsers]);
+
+    return useMemo(
+        () => ({
+            users,
+            isLoading,
+            error,
+            refreshUsers,
+        }),
+        [users, isLoading, error, refreshUsers]
+    );
+}

--- a/web/src/pages/org/People.tsx
+++ b/web/src/pages/org/People.tsx
@@ -1,5 +1,6 @@
 import { Plus, Users } from 'lucide-react';
 import Hero from '@/components/viavai/Hero';
+import Table, { type ApiTableColumn } from '@/components/viavai/Table';
 import { Card } from '@/components/ui/card';
 import {
     Empty,
@@ -8,33 +9,61 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { useUsers } from '@/hooks/use-users';
+
+const columns: ApiTableColumn[] = [
+    {
+        key: 'name',
+        label: 'Name',
+        cell: '{name}',
+    },
+    {
+        key: 'email',
+        label: 'Email',
+        cell: '{email}',
+    },
+];
 
 export default function People() {
+    const { users, isLoading, error } = useUsers();
+
     return (
         <div className="space-y-6">
             <Hero
                 title="People"
-                subtitle="0 people"
+                subtitle={`${users.length} people`}
                 icon="users"
                 action="Add Person"
             >
                 <Plus className="h-4 w-4" />
             </Hero>
 
-            <Card className="p-10 text-center">
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <Users className="h-5 w-5" />
-                        </EmptyMedia>
-                        <EmptyTitle>No People Yet</EmptyTitle>
-                        <EmptyDescription>
-                            Invite teammates and collaborators to start working
-                            together.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
-            </Card>
+            {isLoading ? (
+                <Card className="p-10 text-center text-muted-foreground">
+                    Loading people...
+                </Card>
+            ) : error ? (
+                <Card className="p-10 text-center text-destructive">
+                    {error}
+                </Card>
+            ) : users.length === 0 ? (
+                <Card className="p-10 text-center">
+                    <Empty>
+                        <EmptyHeader>
+                            <EmptyMedia variant="icon">
+                                <Users className="h-5 w-5" />
+                            </EmptyMedia>
+                            <EmptyTitle>No People Yet</EmptyTitle>
+                            <EmptyDescription>
+                                Invite teammates and collaborators to start
+                                working together.
+                            </EmptyDescription>
+                        </EmptyHeader>
+                    </Empty>
+                </Card>
+            ) : (
+                <Table data={users} columns={columns} />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
### Motivation

- Expose a users listing endpoint so the frontend can manage and display organization users on the People page.

### Description

- Add `UsersService.list` to return all users and a `UserResponse` Pydantic model to shape API responses in the backend.
- Add an authenticated `GET /users` route (`api/src/routes/users.py`) that returns the list of users using `UsersService.list` and `UserResponse`.
- Register the new users route in the FastAPI startup (`api/main.py`).
- Add a frontend `useUsers` hook that calls `apiFetch('/users')` and update the People page to use `useUsers` and render loading, error, empty, and table states.

### Testing

- Ran `python -m compileall api/src api/main.py` which completed successfully for the Python backend files.
- Ran `bun run format` inside `web/` which completed successfully.
- Ran `bun run build` inside `web/` which failed due to pre-existing TypeScript issues in unrelated UI files and not related to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965e1e84c08323884b9f0f6944854c)