### PR TITLE
Remove ViaVai org tab and fix Settings Hero action/dialog

### DIFF
--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -4,7 +4,6 @@ import {
     FileText,
     FolderKanban,
     Settings,
-    Sparkles,
     Users,
 } from 'lucide-react';
 
@@ -19,7 +18,6 @@ export type NavigationTab = {
 
 const organizationTabs: NavigationTab[] = [
     { value: 'apps', label: 'Apps', path: 'apps', icon: FolderKanban },
-    { value: 'viavai', label: 'ViaVai', path: 'viavai', icon: Sparkles },
     { value: 'people', label: 'People', path: 'people', icon: Users },
     { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
 ];

--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -1,4 +1,4 @@
-import { Plus, Settings } from 'lucide-react';
+import { Settings } from 'lucide-react';
 import Hero from '@/components/viavai/Hero';
 import { Card } from '@/components/ui/card';
 import {
@@ -17,9 +17,7 @@ export default function SettingsPage() {
                 subtitle="Organization settings"
                 icon="settings"
                 action="New Setting"
-            >
-                <Plus className="h-4 w-4" />
-            </Hero>
+            />
 
             <Card className="p-10 text-center">
                 <Empty>


### PR DESCRIPTION
### Motivation
- Remove the organization-level `ViaVai` tab from the main navigation because it was unused and inconsistent with the app routes.
- Fix the Settings page hero action so it behaves like the Apps page and does not render a stray `+`/empty dialog.

### Description
- Removed the `viavai` entry from `organizationTabs` in `web/src/lib/navigation.ts`.
- Updated `web/src/pages/org/Settings.tsx` to stop passing the `<Plus />` child into `Hero` and rely on the `action` prop only, aligning the behavior with `Apps`.
- These changes prevent the hero button from opening an empty dialog and align UI patterns across organization pages.

### Testing
- Ran `bun run format` in `web/` which completed successfully.
- Ran `bun run build` in `web/` which failed due to unrelated TypeScript issues in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, and `src/components/ui/sidebar.tsx` (these are pre-existing and not caused by this change).
- No automated tests were added or modified per project guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699663a74a2c8323874ece92cc3f0f1e)