### PR TITLE
Fix People page: stack email under name and correct Add Person button

### DIFF
--- a/web/src/pages/org/People.tsx
+++ b/web/src/pages/org/People.tsx
@@ -1,4 +1,4 @@
-import { Plus, Users } from 'lucide-react';
+import { Users } from 'lucide-react';
 import Hero from '@/components/viavai/Hero';
 import Table, { type ApiTableColumn } from '@/components/viavai/Table';
 import { Card } from '@/components/ui/card';
@@ -15,12 +15,7 @@ const columns: ApiTableColumn[] = [
     {
         key: 'name',
         label: 'Name',
-        cell: '{name}',
-    },
-    {
-        key: 'email',
-        label: 'Email',
-        cell: '{email}',
+        cell: ['{name}', '{email}'],
     },
 ];
 
@@ -34,9 +29,7 @@ export default function People() {
                 subtitle={`${users.length} people`}
                 icon="users"
                 action="Add Person"
-            >
-                <Plus className="h-4 w-4" />
-            </Hero>
+            />
 
             {isLoading ? (
                 <Card className="p-10 text-center text-muted-foreground">


### PR DESCRIPTION
### Motivation
- Ensure the People page header action renders the `Add Person` button correctly and avoid an extra icon being shown. 
- Display the user e-mail under the name in the same table column for a cleaner, stacked layout.

### Description
- Removed the extra `Plus` icon child from the `Hero` action so the `Add Person` button is rendered as intended and no stray icon appears. 
- Updated the People table `columns` to combine name and email into a single column using a multiline cell template (`cell: ['{name}', '{email}']`) and removed the separate Email column. 
- Adjustments are limited to `web/src/pages/org/People.tsx` and rely on the existing `Table` renderer which supports multiline cells.

### Testing
- Ran formatter with `bun run format` and the workspace was formatted successfully. 
- Attempted `bun run build`, which failed due to pre-existing TypeScript issues unrelated to these changes (errors in `src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, and a missing `@/hooks/use-mobile`). 
- Launched the dev server and verified the UI by navigating to `/people` and capturing a screenshot with mocked API responses to confirm the `Add Person` button and stacked name/email layout rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699666c1f01c8323a94ccb917081d753)