### PR TITLE
Add menu sections and subsections to sample settings

### DIFF
--- a/sdk/sample/src/pages/settings.py
+++ b/sdk/sample/src/pages/settings.py
@@ -43,4 +43,37 @@ async def settings_page() -> Page:
     )
     security_tab.button("Update security settings", variant="secondary")
 
+    settings_menu = page.menu()
+
+    account_section = settings_menu.section("Account")
+    account_profile = account_section.section("Profile")
+    account_profile.input(
+        label="Public handle",
+        placeholder="@janedoe",
+        description="Displayed in mentions and activity feeds.",
+    )
+
+    account_preferences = account_section.section("Preferences")
+    account_preferences.input(
+        label="Language",
+        placeholder="English",
+        description="Set the default language for your workspace.",
+    )
+
+    team_section = settings_menu.section("Team")
+    members_subsection = team_section.section("Members")
+    members_subsection.input(
+        label="Default role",
+        placeholder="Member",
+        description="Applied when inviting new team members.",
+    )
+
+    access_subsection = team_section.section("Access")
+    access_subsection.input(
+        label="Session timeout",
+        placeholder="8 hours",
+        description="Automatically sign out inactive users.",
+        submit="Save team settings",
+    )
+
     return page


### PR DESCRIPTION
### Motivation
- Provide a sample that demonstrates the hierarchical `menu` API so app authors can see top-level sections and nested subsections in the settings page.
- Improve the sample app coverage for UI primitives by showing subsection-level inputs and submit actions.

### Description
- Added a `menu` block to `sdk/sample/src/pages/settings.py` by calling `settings_menu = page.menu()` and attaching it to the page.
- Created two top-level sections via `settings_menu.section("Account")` and `settings_menu.section("Team")` and added nested subsections using `section.section("...")`.
- Added example input fields to subsections (`Public handle`, `Language`, `Default role`, `Session timeout`) and a submit label on the team access subsection.
- No changes to existing tabs or components besides appending the new menu structure to the same page.

### Testing
- Ran `python -m compileall sdk/sample/src/pages/settings.py` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966673ca8c83239258be87c2c0da11)