### PR TITLE
web: render /apps using shared table layout

### DIFF
--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -1,7 +1,7 @@
 import { Plus, Sparkles } from 'lucide-react';
 import { useState } from 'react';
-import { Link } from 'react-router';
 import Hero from '@/components/longlink/Hero';
+import Table, { type ApiTableColumn } from '@/components/longlink/Table';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
@@ -19,6 +19,19 @@ import {
 } from '@/components/ui/empty';
 import { Input } from '@/components/ui/input';
 import { useApps } from '@/hooks/use-apps';
+
+const columns: ApiTableColumn[] = [
+    {
+        key: 'name',
+        label: 'Name',
+        cell: '{name}',
+    },
+    {
+        key: 'url',
+        label: 'URL',
+        cell: '{url}',
+    },
+];
 
 export default function Apps() {
     const { apps, isLoading, error, createApp } = useApps();
@@ -115,20 +128,7 @@ export default function Apps() {
                     </Empty>
                 </Card>
             ) : (
-                <div className="grid gap-3">
-                    {apps.map((app) => (
-                        <Link key={app.id} to={`/apps/${app.name}`}>
-                            <Card className="space-y-1 p-4 transition hover:bg-white/5">
-                                <h2 className="font-medium text-white">
-                                    {app.name}
-                                </h2>
-                                <p className="text-sm text-white/60">
-                                    {app.url}
-                                </p>
-                            </Card>
-                        </Link>
-                    ))}
-                </div>
+                <Table data={apps} columns={columns} />
             )}
         </div>
     );


### PR DESCRIPTION
### Motivation
- Align the `/apps` listing with the `/people` page by using the same table-based presentation to improve consistency and reuse the shared table component.

### Description
- Import the shared `Table` component and `ApiTableColumn` type and define explicit `columns` for `Name` and `URL`.
- Replace the previous card-per-app mapping UI with a single `<Table data={apps} columns={columns} />` render path for the non-empty state.
- Remove the now-unused `Link`-based list rendering and simplify the page to rely on the reusable table renderer.

### Testing
- Ran `cd web && bun run format` which completed successfully.
- Ran `cd web && bun run build` which failed due to pre-existing TypeScript issues in unrelated files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`).
- Launched the dev server with `cd web && bun run dev` and Vite reported the app ready locally, and an automated Playwright screenshot attempt failed due to a browser crash (SIGSEGV) unrelated to the UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fe8b73dc83238580ac442e6e1bb4)