### PR TITLE
Refactor web data layer to TanStack Query hooks

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import { Toaster } from '@/components/ui/sonner';
 import { ThemeProvider } from '@/components/theme';
 import { Navigate, RouterProvider, createBrowserRouter } from 'react-router';
+import { useIsFetching, useIsMutating } from '@tanstack/react-query';
 import Layout from '@/Layout';
 import { RequireAuth } from '@/components/Auth';
 
@@ -44,9 +45,26 @@ const router = createBrowserRouter([
     { path: '*', element: withAuth(<NotFound />) },
 ]);
 
+function GlobalLoader() {
+    const isFetching = useIsFetching();
+    const isMutating = useIsMutating();
+    const isLoading = isFetching > 0 || isMutating > 0;
+
+    if (!isLoading) {
+        return null;
+    }
+
+    return (
+        <div className="fixed left-0 top-0 z-50 h-1 w-full overflow-hidden bg-transparent">
+            <div className="h-full w-full animate-pulse bg-blue-500/80" />
+        </div>
+    );
+}
+
 export default function App() {
     return (
         <ThemeProvider>
+            <GlobalLoader />
             <RouterProvider router={router} />
             <Toaster />
         </ThemeProvider>

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -17,7 +17,7 @@ import {
     EmptyTitle,
 } from '@/components/ui/empty';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useData } from '@/hooks/use-data';
+import { useApiData } from '@/hooks/use-data';
 import {
     getActiveTabConfig,
     getAppTabsFromPages,
@@ -42,7 +42,7 @@ export default function Layout() {
     const appMetadataEndpoint = app ? `/apps/${app}` : null;
 
     const { data: appMetadata, isLoading: isAppMetadataLoading } =
-        useData<AppMetadata>(appMetadataEndpoint);
+        useApiData<AppMetadata>(appMetadataEndpoint);
     const appTabs = app
         ? isAppMetadataLoading
             ? [

--- a/web/src/components/Auth.tsx
+++ b/web/src/components/Auth.tsx
@@ -4,7 +4,7 @@ import { useUser } from '@/hooks/use-user';
 
 export function RequireAuth({ children }: { children: ReactElement }) {
     const location = useLocation();
-    const { user, isLoading } = useUser();
+    const { data: user, isLoading } = useUser();
 
     if (isLoading) {
         return null;

--- a/web/src/components/Profile.tsx
+++ b/web/src/components/Profile.tsx
@@ -10,11 +10,12 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { useUser } from '@/hooks/use-user';
+import { useSignOut, useUser } from '@/hooks/use-user';
 
 export function UserProfile() {
     const navigate = useNavigate();
-    const { user, signOut } = useUser();
+    const { data: user } = useUser();
+    const { mutateAsync: signOut } = useSignOut();
     const username = user?.name ?? 'Guest';
     const fullName = user?.email ?? 'Not signed in';
     const avatarUrl = user?.avatar ?? '';

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiFetch } from '@/lib/api';
 
@@ -13,57 +13,24 @@ type CreateAppPayload = {
     url: string;
 };
 
-type UseAppsResult = {
-    apps: App[];
-    isLoading: boolean;
-    error: string | null;
-    refreshApps: () => Promise<void>;
-    createApp: (payload: CreateAppPayload) => Promise<App>;
-};
+export function useApps() {
+    return useQuery({
+        queryKey: ['apps'],
+        queryFn: () => apiFetch<App[]>('/apps'),
+    });
+}
 
-export function useApps(): UseAppsResult {
-    const [apps, setApps] = useState<App[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+export function useCreateApp() {
+    const queryClient = useQueryClient();
 
-    const refreshApps = useCallback(async () => {
-        setIsLoading(true);
-        setError(null);
-
-        try {
-            const response = await apiFetch<App[]>('/apps');
-            setApps(response);
-        } catch (err) {
-            setError(
-                err instanceof Error ? err.message : 'Failed to load apps'
-            );
-            setApps([]);
-        } finally {
-            setIsLoading(false);
-        }
-    }, []);
-
-    const createApp = useCallback(async (payload: CreateAppPayload) => {
-        const app = await apiFetch<App>('/apps', {
-            method: 'POST',
-            body: payload,
-        });
-        setApps((previousApps) => [...previousApps, app]);
-        return app;
-    }, []);
-
-    useEffect(() => {
-        void refreshApps();
-    }, [refreshApps]);
-
-    return useMemo(
-        () => ({
-            apps,
-            isLoading,
-            error,
-            refreshApps,
-            createApp,
-        }),
-        [apps, isLoading, error, refreshApps, createApp]
-    );
+    return useMutation({
+        mutationFn: (payload: CreateAppPayload) =>
+            apiFetch<App>('/apps', {
+                method: 'POST',
+                body: payload,
+            }),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['apps'] });
+        },
+    });
 }

--- a/web/src/hooks/use-data.ts
+++ b/web/src/hooks/use-data.ts
@@ -1,56 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { apiFetch } from '@/lib/api';
 
-type UseDataResult<T> = {
-    data: T | null;
-    isLoading: boolean;
-    error: string | null;
-    refresh: () => Promise<void>;
-};
-
-export function useData<T>(endpoint: string | null): UseDataResult<T> {
-    const [data, setData] = useState<T | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-
-    const refresh = useCallback(async () => {
-        setIsLoading(true);
-        setError(null);
-
-        try {
-            if (!endpoint) {
-                setData(null);
-                return;
-            }
-
-            const response = await apiFetch<T>(endpoint);
-            setData(response);
-        } catch (err) {
-            setError(
-                err instanceof Error
-                    ? err.message
-                    : endpoint
-                      ? `Failed to load ${endpoint}`
-                      : 'Failed to load data'
-            );
-            setData(null);
-        } finally {
-            setIsLoading(false);
-        }
-    }, [endpoint]);
-
-    useEffect(() => {
-        void refresh();
-    }, [refresh]);
-
-    return useMemo(
-        () => ({
-            data,
-            isLoading,
-            error,
-            refresh,
-        }),
-        [data, isLoading, error, refresh]
-    );
+export function useApiData<T>(endpoint: string | null) {
+    return useQuery({
+        queryKey: ['api', endpoint],
+        queryFn: () => apiFetch<T>(endpoint!),
+        enabled: Boolean(endpoint),
+    });
 }

--- a/web/src/hooks/use-user.tsx
+++ b/web/src/hooks/use-user.tsx
@@ -1,11 +1,5 @@
-import {
-    createContext,
-    useCallback,
-    useContext,
-    useEffect,
-    useMemo,
-    useState,
-} from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiFetch } from '@/lib/api';
 
 export type User = {
@@ -17,71 +11,27 @@ export type User = {
     date_creation?: string;
 };
 
-type UserContextValue = {
-    user: User | null;
-    isLoading: boolean;
-    refreshUser: () => Promise<void>;
-    signOut: () => Promise<void>;
-};
-
-const UserContext = createContext<UserContextValue | null>(null);
-
-export function UserProvider({ children }: { children: React.ReactNode }) {
-    const [user, setUser] = useState<User | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-
-    const fetchUser = useCallback(async () => {
-        try {
-            const response = await apiFetch<User>('/user', {
+export function useUser() {
+    return useQuery({
+        queryKey: ['user'],
+        queryFn: () =>
+            apiFetch<User>('/user', {
                 credentials: 'include',
-            });
-            setUser(response);
-        } catch {
-            setUser(null);
-        } finally {
-            setIsLoading(false);
-        }
-    }, []);
-
-    const refreshUser = useCallback(async () => {
-        setIsLoading(true);
-        await fetchUser();
-    }, [fetchUser]);
-
-    const signOut = useCallback(async () => {
-        try {
-            await apiFetch('/logout', {
-                method: 'GET',
-                credentials: 'include',
-            });
-        } finally {
-            setUser(null);
-        }
-    }, []);
-
-    useEffect(() => {
-        void fetchUser();
-    }, [fetchUser]);
-
-    const value = useMemo(
-        () => ({
-            user,
-            isLoading,
-            refreshUser,
-            signOut,
-        }),
-        [isLoading, refreshUser, signOut, user]
-    );
-
-    return (
-        <UserContext.Provider value={value}>{children}</UserContext.Provider>
-    );
+            }),
+    });
 }
 
-export function useUser() {
-    const context = useContext(UserContext);
-    if (!context) {
-        throw new Error('useUser must be used within a UserProvider.');
-    }
-    return context;
+export function useSignOut() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: () =>
+            apiFetch('/logout', {
+                method: 'GET',
+                credentials: 'include',
+            }),
+        onSuccess: () => {
+            queryClient.setQueryData(['user'], null);
+        },
+    });
 }

--- a/web/src/lib/react-query.ts
+++ b/web/src/lib/react-query.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            staleTime: 60_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+        },
+    },
+});

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,14 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import './index.css';
 import App from './App.tsx';
-import { UserProvider } from '@/hooks/use-user';
+import { queryClient } from '@/lib/react-query';
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
-        <UserProvider>
+        <QueryClientProvider client={queryClient}>
             <App />
-        </UserProvider>
+        </QueryClientProvider>
     </StrictMode>
 );

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -4,10 +4,9 @@ import { Card, CardContent } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button';
 import { useUser } from '@/hooks/use-user';
 
-
 export default function NotFound() {
     const location = useLocation();
-    const { user } = useUser();
+    const { data: user } = useUser();
     const primaryLink = user ? '/' : '/';
     const primaryLabel = user ? 'Back to dashboard' : 'Back to home';
 

--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -18,7 +18,7 @@ import {
     EmptyTitle,
 } from '@/components/ui/empty';
 import { Input } from '@/components/ui/input';
-import { useApps } from '@/hooks/use-apps';
+import { useApps, useCreateApp } from '@/hooks/use-apps';
 
 const columns: ApiTableColumn[] = [
     {
@@ -34,10 +34,10 @@ const columns: ApiTableColumn[] = [
 ];
 
 export default function Apps() {
-    const { apps, isLoading, error, createApp } = useApps();
+    const { data: apps = [], isLoading, error } = useApps();
+    const { mutateAsync: createApp, isPending } = useCreateApp();
     const [name, setName] = useState('');
     const [url, setUrl] = useState('');
-    const [isCreating, setIsCreating] = useState(false);
     const [createError, setCreateError] = useState<string | null>(null);
 
     const onCreateApp = async () => {
@@ -46,7 +46,6 @@ export default function Apps() {
         }
 
         try {
-            setIsCreating(true);
             setCreateError(null);
             await createApp({
                 name: name.trim(),
@@ -58,8 +57,6 @@ export default function Apps() {
             setCreateError(
                 err instanceof Error ? err.message : 'Failed to create app'
             );
-        } finally {
-            setIsCreating(false);
         }
     };
 
@@ -93,7 +90,7 @@ export default function Apps() {
                         <Button
                             variant="outline"
                             onClick={() => void onCreateApp()}
-                            disabled={isCreating}
+                            disabled={isPending}
                         >
                             <Plus className="h-4 w-4" />
                             New App

--- a/web/src/pages/org/Longlink.tsx
+++ b/web/src/pages/org/Longlink.tsx
@@ -1,5 +1,5 @@
 import Render, { type RenderNodeSchema } from '@/components/Render';
-import { useData } from '@/hooks/use-data';
+import { useApiData } from '@/hooks/use-data';
 import { type AppNavigationPage } from '@/lib/navigation';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
@@ -15,7 +15,7 @@ export default function Longlink() {
     const normalizedRoutePath = normalizePath(wildcardPath ?? '');
 
     const { data: appMetadata, isLoading: isAppMetadataLoading } =
-        useData<AppMetadata>(
+        useApiData<AppMetadata>(
             app && normalizedRoutePath.length === 0 ? `/apps/${app}` : null
         );
 
@@ -34,7 +34,7 @@ export default function Longlink() {
             : null
         : null;
 
-    const { data, isLoading, error } = useData<unknown>(pageEndpoint);
+    const { data, isLoading, error } = useApiData<unknown>(pageEndpoint);
 
     const samplePageData = Array.isArray(data)
         ? (data as RenderNodeSchema[])

--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -13,7 +13,7 @@ type LoginMethodsResponse = {
 export default function Login() {
     const location = useLocation();
     const navigate = useNavigate();
-    const { user, isLoading } = useUser();
+    const { data: user, isLoading } = useUser();
     const apiBaseUrl = getApiBaseUrl();
     const [availableMethods, setAvailableMethods] = useState<string[]>([]);
 

--- a/web/src/pages/user/Profile.tsx
+++ b/web/src/pages/user/Profile.tsx
@@ -36,7 +36,7 @@ const menuItems: Array<{ id: SectionId; label: string; icon: typeof User }> = [
 ];
 
 export default function Profile() {
-    const { user } = useUser();
+    const { data: user } = useUser();
     const [activeSection, setActiveSection] = useState<SectionId>('profile');
     const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
### Motivation
- Move the web app from manual state/effect patterns and a custom `UserProvider` to TanStack React Query to centralize caching, invalidation, and reduce boilerplate.
- Provide a root `QueryClient` with sane defaults to control refetching and retries across the app.
- Replace ad-hoc fetch hooks with query/mutation patterns so UI components consume `data`/status directly and mutations automatically update cache.
- Surface global network activity with a lightweight top loading indicator driven by React Query fetch/mutate state.

### Description
- Added a root query client at `web/src/lib/react-query.ts` and wrapped the app with `QueryClientProvider` in `web/src/main.tsx`.
- Replaced the state/effect `useApps` implementation with `useQuery(['apps'])` and added `useCreateApp` using `useMutation` that invalidates `['apps']` on success in `web/src/hooks/use-apps.ts`.
- Replaced the generic `useData` hook with `useApiData(endpoint)` based on `useQuery` in `web/src/hooks/use-data.ts` and updated consumers in `web/src/Layout.tsx` and `web/src/pages/org/Longlink.tsx`.
- Replaced the `UserProvider` context with query-based `useUser` and mutation-based `useSignOut` in `web/src/hooks/use-user.tsx` and updated all consumers to use `data: user` and the sign-out mutation (`web/src/components/Profile.tsx`, `web/src/components/Auth.tsx`, `web/src/pages/user/Login.tsx`, `web/src/pages/user/Profile.tsx`, `web/src/pages/NotFound.tsx`).
- Added a `GlobalLoader` to `web/src/App.tsx` using `useIsFetching` and `useIsMutating` to render a top loading bar during active queries/mutations.
- Updated the Apps page to consume `data`, `isLoading`, `error` and `isPending` from the new hooks and removed manual refresh/set-state logic (`web/src/pages/org/Apps.tsx`).

### Testing
- Ran formatting with `bun run format` successfully.
- Attempted build with `bun run build`, which failed due to environment dependency resolution (network registry downloads failed during `bun install` with HTTP 403) and some unrelated TypeScript issues present in UI files, so a full build could not be validated in this environment.
- `bun install` also failed in this environment due to HTTP 403 while fetching `@tanstack/react-query` and `@tanstack/query-core` packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69970082f2c483239d58820989f1c647)