### PR TITLE
Harden settings scope rules and uniqueness semantics

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -1,9 +1,9 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-
 from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from src.db.models import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -18,7 +18,7 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = None
+target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -27,7 +27,7 @@ target_metadata = None
 
 
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
+    '''Run migrations in 'offline' mode.
 
     This configures the context with just a URL
     and not an Engine, though an Engine is acceptable
@@ -37,13 +37,13 @@ def run_migrations_offline() -> None:
     Calls to context.execute() here emit the given string to the
     script output.
 
-    """
-    url = config.get_main_option("sqlalchemy.url")
+    '''
+    url = config.get_main_option('sqlalchemy.url')
     context.configure(
         url=url,
         target_metadata=target_metadata,
         literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
+        dialect_opts={'paramstyle': 'named'},
     )
 
     with context.begin_transaction():
@@ -51,22 +51,20 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+    '''Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
     and associate a connection with the context.
 
-    """
+    '''
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
+        prefix='sqlalchemy.',
         poolclass=pool.NullPool,
     )
 
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
+        context.configure(connection=connection, target_metadata=target_metadata)
 
         with context.begin_transaction():
             context.run_migrations()

--- a/api/alembic/versions/20260219_01_add_settings_table.py
+++ b/api/alembic/versions/20260219_01_add_settings_table.py
@@ -1,0 +1,48 @@
+'''add settings table
+
+Revision ID: 20260219_01
+Revises:
+Create Date: 2026-02-19 00:00:00.000000
+'''
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20260219_01'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'settings',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('scope', sa.String(length=16), nullable=False),
+        sa.Column('key', sa.String(length=128), nullable=False),
+        sa.Column('value', sa.Text(), nullable=False),
+        sa.Column('app_id', sa.Integer(), nullable=True),
+        sa.Column('date_creation', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.CheckConstraint("scope IN ('org', 'app')", name='ck_settings_scope'),
+        sa.CheckConstraint(
+            "(scope = 'org' AND app_id IS NULL) OR (scope = 'app' AND app_id IS NOT NULL)",
+            name='ck_settings_scope_app_id',
+        ),
+        sa.ForeignKeyConstraint(['app_id'], ['apps.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'uq_settings_scope_key_app_id_norm',
+        'settings',
+        ['scope', 'key', sa.text('coalesce(app_id, 0)')],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('uq_settings_scope_key_app_id_norm', table_name='settings')
+    op.drop_table('settings')

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,5 +1,6 @@
-from .models import App, User
-from .services import AppsService, UsersService
+from .models import App, Setting, User
+from .services import AppsService, SettingsService, UsersService
 
 apps = AppsService()
+settings = SettingsService()
 users = UsersService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -1,4 +1,5 @@
 # Import all models here to ensure they are registered with Base
 from .__base__ import Base
 from .apps import App
+from .settings import Setting
 from .users import User

--- a/api/src/db/models/settings.py
+++ b/api/src/db/models/settings.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text, func, text
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class Setting(Base):
+    '''Represent a platform setting at org or app scope.'''
+
+    __tablename__ = 'settings'
+    __table_args__ = (
+        CheckConstraint("scope IN ('org', 'app')", name='ck_settings_scope'),
+        CheckConstraint(
+            "(scope = 'org' AND app_id IS NULL) OR (scope = 'app' AND app_id IS NOT NULL)",
+            name='ck_settings_scope_app_id',
+        ),
+        Index('uq_settings_scope_key_app_id_norm', 'scope', 'key', text('coalesce(app_id, 0)'), unique=True),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    scope: Mapped[str] = mapped_column(String(16), nullable=False)
+    key: Mapped[str] = mapped_column(String(128), nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+    app_id: Mapped[int | None] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=True)
+
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -1,2 +1,3 @@
 from .apps import AppsService
+from .settings import SettingsService
 from .users import UsersService

--- a/api/src/db/services/settings.py
+++ b/api/src/db/services/settings.py
@@ -1,0 +1,71 @@
+from sqlalchemy import select
+from src.db.models import Setting
+from src.db.session import get_session
+
+
+class SettingsService:
+    @staticmethod
+    def _normalize_scope(scope: str, app_id: int | None) -> tuple[str, int | None]:
+        if scope not in {'org', 'app'}:
+            raise ValueError('Invalid setting scope. Expected "org" or "app".')
+
+        if scope == 'app' and app_id is None:
+            raise ValueError('app_id is required for app-scoped settings.')
+
+        if scope == 'org':
+            return scope, None
+
+        return scope, app_id
+
+    async def list(self, *, scope: str, app_id: int | None = None) -> list[Setting]:
+        '''Return all settings for the selected scope.'''
+
+        scope, app_id = self._normalize_scope(scope, app_id)
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Setting).where(Setting.scope == scope)
+            if scope == 'app':
+                statement = statement.where(Setting.app_id == app_id)
+            else:
+                statement = statement.where(Setting.app_id.is_(None))
+
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
+    async def get(self, key: str, *, scope: str, app_id: int | None = None) -> Setting | None:
+        '''Return a setting by key and scope.'''
+
+        scope, app_id = self._normalize_scope(scope, app_id)
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Setting).where(Setting.scope == scope, Setting.key == key)
+            if scope == 'app':
+                statement = statement.where(Setting.app_id == app_id)
+            else:
+                statement = statement.where(Setting.app_id.is_(None))
+
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def set(self, key: str, value: str, *, scope: str, app_id: int | None = None) -> Setting:
+        '''Create or update a setting by key and scope.'''
+
+        scope, app_id = self._normalize_scope(scope, app_id)
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Setting).where(Setting.scope == scope, Setting.key == key, Setting.app_id == app_id)
+            result = await session.execute(statement)
+            setting = result.scalar_one_or_none()
+
+            if setting is None:
+                setting = Setting(scope=scope, key=key, value=value, app_id=app_id)
+                session.add(setting)
+            else:
+                setting.value = value
+
+            await session.commit()
+            await session.refresh(setting)
+            return setting


### PR DESCRIPTION
### Motivation

- Provide a robust settings store that supports both organization (`org`) and application (`app`) scopes while preventing invalid scope/app_id combinations and duplicate keys across scopes.
- Enforce core invariants at the database level to avoid subtle application-level race conditions and make migrations autogeneration reliable.

### Description

- Add `Setting` model (`api/src/db/models/settings.py`) with `scope`, `key`, `value`, optional `app_id`, `date_creation`, DB `CHECK` constraints to restrict `scope` to `org|app` and to require `app_id` presence/absence per scope, and a normalized unique index `coalesce(app_id, 0)` to ensure uniqueness across nullable `app_id` values.
- Implement `SettingsService` (`api/src/db/services/settings.py`) with centralized validation via `_normalize_scope(...)` and consistent `list`, `get`, and `set` behaviors for `org` and `app` scopes.
- Add an Alembic revision (`api/alembic/versions/20260219_01_add_settings_table.py`) that creates/drops the `settings` table with the same check constraints and normalized unique index.
- Wire the new model and service into the package by exporting `Setting` in `api/src/db/models/__init__.py`, `SettingsService` in `api/src/db/services/__init__.py`, instantiating `settings` in `api/src/db/__init__.py`, and enable Alembic autogeneration by setting `target_metadata = Base.metadata` in `api/alembic/env.py`.

### Testing

- Ran `python -m compileall src alembic` from `api/` and compilation completed successfully with no syntax errors.
- No migrations were executed locally per instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975a2229d08323bfd1cde1912613ac)