### PR TITLE
Support SDK-provided table columns passed as child nodes

### DIFF
--- a/web/src/components/longlink/Table.tsx
+++ b/web/src/components/longlink/Table.tsx
@@ -1,3 +1,5 @@
+import { Children, isValidElement, type ReactNode } from 'react';
+
 import {
     type ColumnDef,
     flexRender,
@@ -37,6 +39,7 @@ type TableProps<T extends object> = {
     data: T[];
     columns?: ApiTableColumn[];
     schema?: TableSchemaConfig;
+    children?: ReactNode;
 };
 
 const textAlignClasses: Record<TableAlign, string> = {
@@ -92,12 +95,48 @@ function buildColumns<T extends object>(
     });
 }
 
+function normalizeChildColumns(children?: ReactNode): ApiTableColumn[] {
+    return Children.toArray(children)
+        .filter(isValidElement)
+        .reduce<ApiTableColumn[]>((acc, child) => {
+            const childProps = child.props as
+                | (Partial<ApiTableColumn> & {
+                      props?: Partial<ApiTableColumn>;
+                  })
+                | undefined;
+
+            if (!childProps) {
+                return acc;
+            }
+
+            const column = {
+                ...(childProps.props ?? {}),
+                ...childProps,
+            };
+
+            if (!column.key || !column.cell) {
+                return acc;
+            }
+
+            acc.push({
+                key: column.key,
+                label: column.label,
+                align: column.align,
+                cell: column.cell,
+            });
+
+            return acc;
+        }, []);
+}
+
 export function Table<T extends object>({
     columns,
     schema,
     data,
+    children,
 }: TableProps<T>) {
-    const resolvedColumns = columns ?? schema?.schema.columns ?? [];
+    const resolvedColumns =
+        columns ?? schema?.schema.columns ?? normalizeChildColumns(children);
 
     const table = useReactTable({
         data,


### PR DESCRIPTION
### Motivation

- The SDK serializes table column definitions as child nodes (under `children`) rather than exposing them via the `columns` prop or `schema.schema.columns`, which caused the table to not render columns. 

### Description

- Added `children?: ReactNode` to `TableProps` and imported `Children` and `isValidElement` to enable parsing of JSX child nodes. 
- Implemented `normalizeChildColumns(children?: ReactNode): ApiTableColumn[]` to extract column metadata (including nested `props`) and convert valid child entries into `ApiTableColumn`. 
- Used the normalized child columns as a fallback: `columns ?? schema?.schema.columns ?? normalizeChildColumns(children)`. 
- Changed only `web/src/components/longlink/Table.tsx` to keep existing behavior for explicit `columns` and `schema` unchanged.

### Testing

- Ran `bun run format` in `web`, which completed successfully. 
- Ran `bun run build` in `web`, which still fails due to unrelated TypeScript issues in other files, while the new table-related type errors introduced earlier are resolved and the component now supports SDK-driven child columns.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975ef095248323aedbd06ef0bc9e12)