### PR TITLE
Add settings GET/PUT endpoints (global scope) and fix SettingsService

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,6 +34,7 @@ import src.routes.auth
 import src.routes.user
 import src.routes.users
 import src.routes.sample
+import src.routes.settings
 
 app.include_router(router)
 

--- a/api/src/db/services/settings.py
+++ b/api/src/db/services/settings.py
@@ -1,4 +1,5 @@
 from sqlalchemy import select
+
 from src.db.models import Setting
 from src.db.session import get_session
 
@@ -8,35 +9,43 @@ class SettingsService:
         '''Return all settings for the selected scope.'''
         Session = await get_session()
         async with Session() as session:
-            statement = statement.where(Setting.app_id.is_(None))
+            statement = select(Setting)
+            if app_id is None:
+                statement = statement.where(Setting.app_id.is_(None))
+            else:
+                statement = statement.where(Setting.app_id == app_id)
 
             result = await session.execute(statement)
             return list(result.scalars().all())
 
     async def get(self, key: str, *, app_id: int | None = None) -> Setting | None:
         '''Return a setting by key and scope.'''
-
         Session = await get_session()
         async with Session() as session:
-            if app_id:
-                statement = statement.where(Setting.app_id == app_id)
-            else:
+            statement = select(Setting).where(Setting.key == key)
+            if app_id is None:
                 statement = statement.where(Setting.app_id.is_(None))
+            else:
+                statement = statement.where(Setting.app_id == app_id)
 
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def set(self, key: str, value: str, *,app_id: int | None = None) -> Setting:
+    async def set(self, key: str, value: str, *, app_id: int | None = None) -> Setting:
         '''Create or update a setting by key and scope.'''
-  
         Session = await get_session()
         async with Session() as session:
-            statement = select(Setting).where(Setting.scope == scope, Setting.key == key, Setting.app_id == app_id)
+            statement = select(Setting).where(Setting.key == key)
+            if app_id is None:
+                statement = statement.where(Setting.app_id.is_(None))
+            else:
+                statement = statement.where(Setting.app_id == app_id)
+
             result = await session.execute(statement)
             setting = result.scalar_one_or_none()
 
             if setting is None:
-                setting = Setting(scope=scope, key=key, value=value, app_id=app_id)
+                setting = Setting(key=key, value=value, app_id=app_id)
                 session.add(setting)
             else:
                 setting.value = value

--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -1,3 +1,4 @@
 from .apps import AppCreate, AppResponse
 from .lists.countries import CountryCode
 from .users import UserUpdate
+from .settings import SettingSet, SettingResponse

--- a/api/src/models/settings.py
+++ b/api/src/models/settings.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class SettingSet(BaseModel):
+    value: str
+
+
+class SettingResponse(BaseModel):
+    key: str
+    value: str
+    app_id: int | None = None

--- a/api/src/routes/settings.py
+++ b/api/src/routes/settings.py
@@ -1,0 +1,28 @@
+from fastapi import HTTPException
+
+import src.db as db
+from src.models.settings import SettingResponse, SettingSet
+from src.router import router
+
+
+@router.get('/settings/{key}')
+async def get_setting(key: str) -> SettingResponse:
+    setting = await db.settings.get(key, app_id=None)
+    if setting is None:
+        raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
+
+    return SettingResponse(
+        key=setting.key,
+        value=setting.value,
+        app_id=setting.app_id,
+    )
+
+
+@router.put('/settings/{key}')
+async def set_setting(key: str, payload: SettingSet) -> SettingResponse:
+    setting = await db.settings.set(key, payload.value, app_id=None)
+    return SettingResponse(
+        key=setting.key,
+        value=setting.value,
+        app_id=setting.app_id,
+    )


### PR DESCRIPTION
### Motivation
- Expose a simple HTTP API to read and update platform settings by key so other components can query and modify configuration.
- For now handle settings at global scope only by forcing `app_id=None` as requested.

### Description
- Added `GET /settings/{key}` and `PUT /settings/{key}` endpoints that return and set a setting respectively and always call the DB service with `app_id=None` (`api/src/routes/settings.py`).
- Added Pydantic models `SettingSet` and `SettingResponse` to represent request and response payloads (`api/src/models/settings.py`) and exported them via `src.models` (`api/src/models/__init__.py`).
- Fixed `SettingsService` SQLAlchemy statements in `list`, `get`, and `set` to correctly build queries by `key` and `app_id`, and to properly create or update rows (`api/src/db/services/settings.py`).
- Registered the new settings route module so the endpoints are included at app startup (`api/main.py`).

### Testing
- Compiled the updated package with `python -m compileall api/main.py api/src`, which succeeded without syntax errors.
- No additional automated tests were added per repository instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979957a4f48323b37f89b1f997d61c)