### PR TITLE
Refactor table component into dedicated table modules

### DIFF
--- a/web/src/components/longlink/Table.tsx
+++ b/web/src/components/longlink/Table.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
-    type ColumnDef,
     type SortingState,
     flexRender,
     getCoreRowModel,
@@ -15,17 +14,15 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
-import { apiFetch } from '@/lib/api';
+import {
+    buildColumns,
+    textAlignClasses,
+    type ApiTableColumn,
+    type TableAlign,
+} from '@/components/table/buildColumns';
+import { useApiTable } from '@/components/table/useApiTable';
 
-export type TableAlign = 'left' | 'center' | 'right';
-
-export type ApiTableColumn = {
-    key: string;
-    label?: string;
-    align?: TableAlign;
-    value: string;
-    detail?: string;
-};
+export type { ApiTableColumn, TableAlign };
 
 export type TableSchema = {
     columns: ApiTableColumn[];
@@ -43,72 +40,11 @@ type TableProps = {
     pageSize?: number;
 };
 
-type TableResponse =
-    | Record<string, unknown>[]
-    | {
-          data?: Record<string, unknown>[];
-          total?: number;
-      };
-
-const textAlignClasses: Record<TableAlign, string> = {
-    left: 'text-left',
-    center: 'text-center',
-    right: 'text-right',
-};
-
-function resolvePath(data: unknown, path: string): unknown {
-    return path
-        .split('.')
-        .reduce<unknown>(
-            (acc, key) => (acc as Record<string, unknown>)?.[key],
-            data
-        );
-}
-
-function renderTemplate(template: string, data: unknown): string {
-    return template.replace(/\{([^}]+)\}/g, (_, path) => {
-        const value = resolvePath(data, path.trim());
-        return value == null ? '' : String(value);
-    });
-}
-
-function buildColumns<T extends object>(
-    columns: ApiTableColumn[]
-): ColumnDef<T>[] {
-    return columns.map((column) => {
-        const align = column.align ?? 'left';
-
-        return {
-            id: column.key,
-            header: column.label ?? column.key,
-            enableSorting: true,
-            meta: { align },
-            cell: ({ row }) => (
-                <div className={`leading-tight ${textAlignClasses[align]}`}>
-                    <div className="text-sm font-medium">
-                        {renderTemplate(column.value, row.original)}
-                    </div>
-
-                    {column.detail ? (
-                        <div className="text-xs text-muted-foreground">
-                            {renderTemplate(column.detail, row.original)}
-                        </div>
-                    ) : null}
-                </div>
-            ),
-        };
-    });
-}
-
 export function Table<T extends object>({
     endpoint,
     schema,
     pageSize = 10,
 }: TableProps) {
-    const [data, setData] = useState<T[]>([]);
-    const [total, setTotal] = useState(0);
-    const [loading, setLoading] = useState(false);
-
     const [pagination, setPagination] = useState({
         pageIndex: 0,
         pageSize,
@@ -116,27 +52,11 @@ export function Table<T extends object>({
 
     const [sorting, setSorting] = useState<SortingState>([]);
 
-    useEffect(() => {
-        const fetchData = async () => {
-            setLoading(true);
-
-            try {
-                const response = await apiFetch<TableResponse>(endpoint);
-
-                if (Array.isArray(response)) {
-                    setData(response as T[]);
-                    setTotal(response.length);
-                } else {
-                    setData((response.data ?? []) as T[]);
-                    setTotal(response.total ?? response.data?.length ?? 0);
-                }
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        void fetchData();
-    }, [endpoint, pagination, sorting]);
+    const { data, total, loading } = useApiTable<T>({
+        endpoint,
+        pagination,
+        sorting,
+    });
 
     const columns = useMemo(
         () => buildColumns<T>(schema?.schema?.columns ?? []),

--- a/web/src/components/table/buildColumns.tsx
+++ b/web/src/components/table/buildColumns.tsx
@@ -1,0 +1,61 @@
+import { type ColumnDef } from '@tanstack/react-table';
+
+export type TableAlign = 'left' | 'center' | 'right';
+
+export type ApiTableColumn = {
+    key: string;
+    label?: string;
+    align?: TableAlign;
+    value: string;
+    detail?: string;
+};
+
+export const textAlignClasses: Record<TableAlign, string> = {
+    left: 'text-left',
+    center: 'text-center',
+    right: 'text-right',
+};
+
+function resolvePath(data: unknown, path: string): unknown {
+    return path
+        .split('.')
+        .reduce<unknown>(
+            (acc, key) => (acc as Record<string, unknown>)?.[key],
+            data
+        );
+}
+
+function renderTemplate(template: string, data: unknown): string {
+    return template.replace(/\{([^}]+)\}/g, (_, path) => {
+        const value = resolvePath(data, path.trim());
+        return value == null ? '' : String(value);
+    });
+}
+
+export function buildColumns<T extends object>(
+    columns: ApiTableColumn[]
+): ColumnDef<T>[] {
+    return columns.map((column) => {
+        const align = column.align ?? 'left';
+
+        return {
+            id: column.key,
+            header: column.label ?? column.key,
+            enableSorting: true,
+            meta: { align },
+            cell: ({ row }) => (
+                <div className={`leading-tight ${textAlignClasses[align]}`}>
+                    <div className="text-sm font-medium">
+                        {renderTemplate(column.value, row.original)}
+                    </div>
+
+                    {column.detail ? (
+                        <div className="text-xs text-muted-foreground">
+                            {renderTemplate(column.detail, row.original)}
+                        </div>
+                    ) : null}
+                </div>
+            ),
+        };
+    });
+}

--- a/web/src/components/table/useApiTable.ts
+++ b/web/src/components/table/useApiTable.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { type PaginationState, type SortingState } from '@tanstack/react-table';
+
+import { apiFetch } from '@/lib/api';
+
+type TableResponse =
+    | Record<string, unknown>[]
+    | {
+          data?: Record<string, unknown>[];
+          total?: number;
+      };
+
+type UseApiTableParams = {
+    endpoint: string;
+    pagination: PaginationState;
+    sorting: SortingState;
+};
+
+export function useApiTable<T extends object>({
+    endpoint,
+    pagination,
+    sorting,
+}: UseApiTableParams) {
+    const [data, setData] = useState<T[]>([]);
+    const [total, setTotal] = useState(0);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setLoading(true);
+
+            try {
+                const response = await apiFetch<TableResponse>(endpoint);
+
+                if (Array.isArray(response)) {
+                    setData(response as T[]);
+                    setTotal(response.length);
+                } else {
+                    setData((response.data ?? []) as T[]);
+                    setTotal(response.total ?? response.data?.length ?? 0);
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchData();
+    }, [endpoint, pagination, sorting]);
+
+    return {
+        data,
+        total,
+        loading,
+    };
+}


### PR DESCRIPTION
### Motivation

- Reduce duplication and separate concerns by moving table column construction and API fetching logic out of the large `Table` component.

### Description

- Added a new `web/src/components/table/buildColumns.tsx` that contains `ApiTableColumn`/`TableAlign` types, alignment mapping, template resolution, and `buildColumns` to produce TanStack `ColumnDef` objects.
- Added a new `web/src/components/table/useApiTable.ts` hook that encapsulates `apiFetch` logic and returns `data`, `total`, and `loading` based on `endpoint`, `pagination`, and `sorting`.
- Updated `web/src/components/longlink/Table.tsx` to consume `buildColumns` and `useApiTable` and re-export `ApiTableColumn`/`TableAlign` for compatibility with existing imports.

### Testing

- Ran code formatting with `bun run format` / `bunx prettier --write` on modified files, which completed successfully.
- Attempted a full web build with `bun run build`, which failed due to pre-existing TypeScript errors in unrelated files (for example `src/components/ui/resizable.tsx` and `src/components/ui/sidebar.tsx`).
- Confirmed the refactor preserves the previous `Table` rendering and pagination behavior in local inspection of the component code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979fa47918832388ea7ba6848e848a)