### PR TITLE
Hash app tokens and add app authentication helper

### DIFF
--- a/api/alembic/versions/20260219_02_add_app_token_hash.py
+++ b/api/alembic/versions/20260219_02_add_app_token_hash.py
@@ -1,0 +1,40 @@
+'''add app token hash
+
+Revision ID: 20260219_02
+Revises: 20260219_01
+Create Date: 2026-02-19 00:10:00.000000
+'''
+
+import hashlib
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20260219_02'
+down_revision: Union[str, None] = '20260219_01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('apps', sa.Column('token_hash', sa.String(length=64), nullable=True))
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.text('SELECT id, url FROM apps')).fetchall()
+    for row in rows:
+        token_hash = hashlib.sha256(str(row.url).encode('utf-8')).hexdigest()
+        connection.execute(
+            sa.text('UPDATE apps SET token_hash = :token_hash WHERE id = :id'),
+            {'id': row.id, 'token_hash': token_hash},
+        )
+
+    op.alter_column('apps', 'token_hash', nullable=False)
+    op.create_unique_constraint('uq_apps_token_hash', 'apps', ['token_hash'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_apps_token_hash', 'apps', type_='unique')
+    op.drop_column('apps', 'token_hash')

--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -1,6 +1,6 @@
 import src.db as db
-from fastapi import HTTPException, Request
 from authlib.integrations.starlette_client import OAuth
+from fastapi import HTTPException, Request
 from src.envs import settings
 
 """
@@ -48,3 +48,20 @@ async def authuser(request: Request) -> db.User:
     if not user:
         raise HTTPException(401, 'Not authenticated')
     return user
+
+
+async def authapp(request: Request) -> db.App:
+    auth_header = request.headers.get('authorization')
+    token = request.headers.get('x-app-token')
+
+    if auth_header and auth_header.lower().startswith('bearer '):
+        token = auth_header[7:].strip()
+
+    if not token:
+        raise HTTPException(401, 'Missing app token')
+
+    app = await db.apps.get_by_token(token)
+    if app is None:
+        raise HTTPException(401, 'Invalid app token')
+
+    return app

--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -12,5 +12,6 @@ class App(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     url: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
 
     date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from sqlalchemy import select
 
 from src.db.models import App
@@ -14,7 +16,6 @@ class AppsService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
-
     async def get_by_name(self, name: str) -> App | None:
         '''Return a registered app by name.'''
 
@@ -24,10 +25,23 @@ class AppsService:
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def create(self, name: str, url: str) -> App:
+    async def get_by_token(self, token: str) -> App | None:
+        '''Return a registered app by token.'''
+
+        Session = await get_session()
+        token_hash = hashlib.sha256(token.encode('utf-8')).hexdigest()
+
+        async with Session() as session:
+            statement = select(App).where(App.token_hash == token_hash)
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def create(self, name: str, url: str, token: str) -> App:
         '''Add a new app to the database.'''
 
         Session = await get_session()
+        token_hash = hashlib.sha256(token.encode('utf-8')).hexdigest()
+
         async with Session() as session:
             statement = select(App).where(App.url == url)
             result = await session.execute(statement)
@@ -35,7 +49,13 @@ class AppsService:
             if existing_app is not None:
                 raise ValueError('App URL already exists')
 
-            app = App(name=name, url=url)
+            token_statement = select(App).where(App.token_hash == token_hash)
+            token_result = await session.execute(token_statement)
+            existing_token = token_result.scalar_one_or_none()
+            if existing_token is not None:
+                raise ValueError('App token already exists')
+
+            app = App(name=name, url=url, token_hash=token_hash)
             session.add(app)
             await session.commit()
             await session.refresh(app)

--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class AppCreate(BaseModel):
     name: str
     url: str
+    token: str
 
 
 class AppResponse(BaseModel):

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -90,6 +90,7 @@ async def create_app(payload: AppCreate) -> AppResponse:
         app = await db.apps.create(
             name=payload.name,
             url=payload.url,
+            token=payload.token,
         )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc


### PR DESCRIPTION
### Motivation
- App registrations require a secret token and storing that token in plaintext is insecure, so tokens should be persisted hashed. 
- The API must be able to authenticate requests coming from registered apps, using the provided token. 
- Existing data must be migrated to the new hashed format and uniqueness enforced to prevent token collisions.

### Description
- Add a `token_hash` column to the `App` model and persist tokens as SHA-256 hashes (`api/src/db/models/apps.py`).
- Update `AppsService` to accept a `token` on creation, hash it, enforce uniqueness of the hash, and provide `get_by_token` lookup by hashed token (`api/src/db/services/apps.py`).
- Require `token` in the app creation schema and pass it through the `/apps` route during creation (`api/src/models/apps.py` and `api/src/routes/apps.py`).
- Add `authapp` helper in `src/auth.py` that accepts `Authorization: Bearer <token>` or `X-App-Token` headers and resolves the app via the hashed token lookup.
- Add an Alembic migration that adds the `token_hash` column, backfills existing rows by deriving a deterministic SHA-256 hash from the `url` for existing rows, marks the column non-nullable, and creates a unique constraint (`api/alembic/versions/20260219_02_add_app_token_hash.py`).

### Testing
- Ran `python -m compileall src alembic/versions/20260219_02_add_app_token_hash.py` (from `api/`), which compiled the application modules and the new migration without errors.
- No automated unit tests were added as part of this change; only the compilation check above was executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a05f456c83239a1b94a5feafb1fc)