### PR TITLE
feat(web): support rich table cell schema with links

### DIFF
--- a/web/src/components/table/buildColumns.tsx
+++ b/web/src/components/table/buildColumns.tsx
@@ -2,12 +2,19 @@ import { type ColumnDef } from '@tanstack/react-table';
 
 export type TableAlign = 'left' | 'center' | 'right';
 
+export type ApiTableCell = {
+    value: string;
+    bold?: boolean;
+    link?: string;
+};
+
 export type ApiTableColumn = {
     key: string;
     label?: string;
     align?: TableAlign;
-    value: string;
-    detail?: string;
+    value?: string;
+    detail?: string | ApiTableCell;
+    content?: ApiTableCell;
 };
 
 export const textAlignClasses: Record<TableAlign, string> = {
@@ -32,6 +39,45 @@ function renderTemplate(template: string, data: unknown): string {
     });
 }
 
+function resolveCell(
+    legacyValue: string | undefined,
+    cell: ApiTableCell | string | undefined,
+    row: unknown
+): ApiTableCell | undefined {
+    const resolvedCell = cell ?? legacyValue;
+
+    if (!resolvedCell) {
+        return undefined;
+    }
+
+    if (typeof resolvedCell === 'string') {
+        return { value: renderTemplate(resolvedCell, row) };
+    }
+
+    return {
+        ...resolvedCell,
+        value: renderTemplate(resolvedCell.value, row),
+        link: resolvedCell.link
+            ? renderTemplate(resolvedCell.link, row)
+            : undefined,
+    };
+}
+
+function renderCellRow(cell: ApiTableCell, fallbackBold = false) {
+    const className = (cell.bold ?? fallbackBold) ? 'font-medium' : '';
+    const content = <span className={className}>{cell.value}</span>;
+
+    if (!cell.link) {
+        return content;
+    }
+
+    return (
+        <a className="hover:underline" href={cell.link}>
+            {content}
+        </a>
+    );
+}
+
 export function buildColumns<T extends object>(
     columns: ApiTableColumn[]
 ): ColumnDef<T>[] {
@@ -43,19 +89,34 @@ export function buildColumns<T extends object>(
             header: column.label ?? column.key,
             enableSorting: true,
             meta: { align },
-            cell: ({ row }) => (
-                <div className={`leading-tight ${textAlignClasses[align]}`}>
-                    <div className="text-sm font-medium">
-                        {renderTemplate(column.value, row.original)}
-                    </div>
+            cell: ({ row }) => {
+                const content = resolveCell(
+                    column.value,
+                    column.content,
+                    row.original
+                );
+                const detail = resolveCell(
+                    undefined,
+                    column.detail,
+                    row.original
+                );
 
-                    {column.detail ? (
-                        <div className="text-xs text-muted-foreground">
-                            {renderTemplate(column.detail, row.original)}
-                        </div>
-                    ) : null}
-                </div>
-            ),
+                return (
+                    <div className={`leading-tight ${textAlignClasses[align]}`}>
+                        {content ? (
+                            <div className="text-sm">
+                                {renderCellRow(content, true)}
+                            </div>
+                        ) : null}
+
+                        {detail ? (
+                            <div className="text-xs text-muted-foreground">
+                                {renderCellRow(detail)}
+                            </div>
+                        ) : null}
+                    </div>
+                );
+            },
         };
     });
 }


### PR DESCRIPTION
### Motivation
- Enable table columns to render richer cell content (text, bold styling, and links) driven by API-provided schema instead of only plain template strings.
- Keep backward compatibility with the existing `{...}` template-string format so older schemas still work.

### Description
- Added a new `ApiTableCell` type (`value`, `bold?`, `link?`) and extended `ApiTableColumn` to accept `content` and `detail` as rich cell objects or legacy strings.
- Implemented `resolveCell` to normalize legacy template strings and new cell objects while performing template interpolation for both text and link URLs.
- Implemented `renderCellRow` to render bold styling and optional anchor links for cell values.
- Updated `buildColumns` to use the new resolution/rendering logic so primary and detail rows can be independently rendered with links and bold control.

### Testing
- Ran `bun run format` in `web` (succeeded).
- Ran `bun run build` in `web` which failed due to unrelated pre-existing TypeScript errors in other files and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997aed7fe2883238ed055855dbfa38b)