### PR TITLE
Fix apps page crash when query returns Error object

### DIFF
--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -44,6 +44,8 @@ export default function Apps() {
     const [name, setName] = useState('');
     const [url, setUrl] = useState('');
     const [createError, setCreateError] = useState<string | null>(null);
+    const loadErrorMessage =
+        error instanceof Error ? error.message : 'Failed to load apps';
 
     const onCreateApp = async () => {
         if (!name.trim() || !url.trim()) {
@@ -113,7 +115,9 @@ export default function Apps() {
                     Loading apps...
                 </Card>
             ) : error ? (
-                <Card className="p-10 text-center text-red-300">{error}</Card>
+                <Card className="p-10 text-center text-red-300">
+                    {loadErrorMessage}
+                </Card>
             ) : apps.length === 0 ? (
                 <Card className="p-10 text-center">
                     <Empty>


### PR DESCRIPTION
### Motivation
- Prevent the runtime crash "Objects are not valid as a React child" that occurred when the React Query `error` value (an `Error` object) was rendered directly in the Apps page.

### Description
- Normalize the query error on the Apps page by adding `loadErrorMessage` and rendering that string instead of the raw `error` object in `web/src/pages/org/Apps.tsx`.

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bun run build` which failed due to pre-existing unrelated TypeScript errors in other files (e.g. `resizable.tsx`, `scroll-area.tsx`, `sidebar.tsx`, `Longlink.tsx`, and `People.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b059a9f08323a5f729f7001d14d8)