### PR TITLE
Render app names as links to /apps/{name}

### DIFF
--- a/web/src/pages/org/Apps.tsx
+++ b/web/src/pages/org/Apps.tsx
@@ -27,7 +27,10 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
             {
                 key: 'name',
                 label: 'Name',
-                value: '{name}',
+                content: {
+                    value: '{name}',
+                    link: '/apps/{name}',
+                },
             },
             {
                 key: 'url',


### PR DESCRIPTION
### Motivation

- Make app entries (for example `sample`) clickable so users can navigate to the app details page at `/apps/{name}`.

### Description

- Updated the Apps table schema in `web/src/pages/org/Apps.tsx` to use a `content` cell for the `Name` column that supplies both `value: '{name}'` and `link: '/apps/{name}'` so the table renders the name as an anchor.
- This leverages the existing table column rendering which wraps cell content in an `<a>` when a `link` is provided.

### Testing

- Ran the repository formatter via `bun run format` in the `web` folder and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986200d0248323926968a55b57f4a6)