### PR TITLE
Resolve circular import between Dialog and Hero in SDK UI

### DIFF
--- a/sdk/longlink/ui/dialog.py
+++ b/sdk/longlink/ui/dialog.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass, field
 
 
 # Importing components that can be used in a Page
-from .hero import Hero
 from .input import Input
 
 
@@ -13,7 +12,9 @@ class Dialog(Component):
     cancel: str = 'Cancel'
     _components: list[Component] = field(default_factory=list)
 
-    def hero(self, title: str, subtitle: str | None = None) -> Hero:
+    def hero(self, title: str, subtitle: str | None = None) -> 'Hero':
+        from .hero import Hero
+
         hero = Hero(title=title, subtitle=subtitle)
         self._components.append(hero)
         return hero


### PR DESCRIPTION
### Motivation
- Prevent `ImportError` caused by the circular import between `sdk/longlink/ui/dialog.py` and `sdk/longlink/ui/hero.py` when the SDK UI modules are imported.

### Description
- Remove the module-level `from .hero import Hero` and change `Dialog.hero(...)` to use a forward-reference return type (`'Hero'`) while performing a local import of `Hero` inside the method to defer import and break the cycle.

### Testing
- Ran `python -m py_compile sdk/longlink/ui/dialog.py` which succeeded; running `python sdk/sample/main.py` progressed past the original circular import but then failed later due to a missing environment dependency (`pydantic_settings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998646176748323a907bb2fc0a00ab6)