### PR TITLE
Add app-specific env secrets database layer

### DIFF
--- a/api/alembic/versions/20260220_01_add_envs_table.py
+++ b/api/alembic/versions/20260220_01_add_envs_table.py
@@ -1,0 +1,36 @@
+'''add envs table
+
+Revision ID: 20260220_01
+Revises: 20260219_02
+Create Date: 2026-02-20 00:10:00.000000
+'''
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20260220_01'
+down_revision: Union[str, None] = '20260219_02'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'envs',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('key', sa.String(length=128), nullable=False),
+        sa.Column('value', sa.Text(), nullable=False),
+        sa.Column('app_id', sa.Integer(), nullable=False),
+        sa.Column('date_creation', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.ForeignKeyConstraint(['app_id'], ['apps.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('app_id', 'key', name='uq_envs_app_id_key'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('envs')

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,6 +1,7 @@
-from .models import App, Setting, User
-from .services import AppsService, SettingsService, UsersService
+from .models import App, Env, Setting, User
+from .services import AppsService, EnvsService, SettingsService, UsersService
 
 apps = AppsService()
+envs = EnvsService()
 settings = SettingsService()
 users = UsersService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -1,5 +1,6 @@
 # Import all models here to ensure they are registered with Base
 from .__base__ import Base
 from .apps import App
+from .envs import Env
 from .settings import Setting
 from .users import User

--- a/api/src/db/models/envs.py
+++ b/api/src/db/models/envs.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class Env(Base):
+    '''Represent an application secret environment variable.'''
+    __tablename__ = 'envs'
+    __table_args__ = (UniqueConstraint('app_id', 'key', name='uq_envs_app_id_key'),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    key: Mapped[str] = mapped_column(String(128), nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+    app_id: Mapped[int] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=False)
+
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -1,3 +1,4 @@
 from .apps import AppsService
+from .envs import EnvsService
 from .settings import SettingsService
 from .users import UsersService

--- a/api/src/db/services/envs.py
+++ b/api/src/db/services/envs.py
@@ -1,0 +1,40 @@
+from sqlalchemy import select
+
+from src.db.models import Env
+from src.db.session import get_session
+
+
+class EnvsService:
+    async def list(self, app_id: int) -> list[Env]:
+        '''Return all env secrets for an app.'''
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Env).where(Env.app_id == app_id)
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
+    async def get(self, key: str, app_id: int) -> Env | None:
+        '''Return an env secret by key and app scope.'''
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Env).where(Env.key == key, Env.app_id == app_id)
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def set(self, key: str, value: str, app_id: int) -> Env:
+        '''Create or update an env secret by key and app scope.'''
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Env).where(Env.key == key, Env.app_id == app_id)
+            result = await session.execute(statement)
+            env = result.scalar_one_or_none()
+
+            if env is None:
+                env = Env(key=key, value=value, app_id=app_id)
+                session.add(env)
+            else:
+                env.value = value
+
+            await session.commit()
+            await session.refresh(env)
+            return env


### PR DESCRIPTION
### Motivation

- Store application-specific secret values separately from global `settings` so secrets are not exposed by the `/settings` endpoint.

### Description

- Add a new `Env` ORM model mapped to the `envs` table to hold app-scoped secrets with `app_id` FK, `value`, `key`, `date_creation`, and a unique constraint on `(app_id, key)` in `src/db/models/envs.py`.
- Implement `EnvsService` with `list`, `get`, and `set` methods scoped by `app_id` in `src/db/services/envs.py` to manage secrets programmatically.
- Wire the model and service into the DB aggregation modules by updating `src/db/models/__init__.py`, `src/db/services/__init__.py`, and `src/db/__init__.py` and expose an `envs` service instance.
- Add an Alembic migration `alembic/versions/20260220_01_add_envs_table.py` to create/drop the `envs` table with CASCADE FK and the `(app_id, key)` unique constraint.

### Testing

- Ran `python -m compileall src alembic/versions/20260220_01_add_envs_table.py` to ensure code compiles successfully, and it completed without errors.
- Verified repository state with `git status` and the last commit via `git log --oneline -1`, confirming the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986589341483238e8c7bd0a039473c)