### PR TITLE
Align SDK table column API with current web table schema

### DIFF
--- a/sdk/longlink/ui/table.py
+++ b/sdk/longlink/ui/table.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypeAlias, overload
+from typing import Literal, TypeAlias, overload, TypedDict
 from dataclasses import dataclass, field
 from .__root__ import Component
 
@@ -7,11 +7,17 @@ Alignments: TypeAlias = Literal['left', 'center', 'right']
 
 
 # Import Components
-from .link import Link 
+from .link import Link
+
+
+class TableCell(TypedDict, total=False):
+    value: str
+    bold: bool
+    link: str
 
 
 """
-The Table component is tricky. 
+The Table component is tricky.
 
 On the frontend, it uses Shadcn and @tanstack/react-table
 https://tanstack.com/table/latest
@@ -19,36 +25,62 @@ However on the backend it shall behave on it's own, with the data linked to a en
 This has to be managed by the table itself without the need to reload the page.
 """
 
+
 class Column(Component):
     key: str
     label: str
     align: Alignments = 'left'
-    value: str = ''   # First row in the cell
-    detail: str = ''  # Second row in the cell
+    content: str | TableCell = ''
+    detail: str | TableCell = ''
 
-    def __init__(self, key: str, label: str, value: str | Link = '', detail: str | Link= '', align: Alignments = 'left',) -> None:
+    def __init__(
+        self,
+        key: str,
+        label: str,
+        content: str | Link | TableCell = '',
+        detail: str | Link | TableCell = '',
+        align: Alignments = 'left',
+    ) -> None:
         self.key = key
         self.label = label
         self.align = align
-        self.value = str(value)
-        self.detail = str(detail)
+        self.content = self._normalize_cell(content)
+        self.detail = self._normalize_cell(detail)
+
+    def _normalize_cell(self, cell: str | Link | TableCell) -> str | TableCell:
+        if isinstance(cell, dict):
+            payload: TableCell = {'value': str(cell.get('value', ''))}
+            if 'bold' in cell:
+                payload['bold'] = bool(cell['bold'])
+            if 'link' in cell:
+                payload['link'] = str(cell['link'])
+            return payload
+
+        if isinstance(cell, Link):
+            return {'value': cell.text, 'link': cell.url}
+
+        return str(cell)
 
     def __iter__(self):
-        yield 'type', 'column'
-        yield 'props', {
+        props: dict[str, str | TableCell] = {
             'key': self.key,
             'label': self.label,
             'align': self.align,
-            'value': self.value,
-            'detail': self.detail,
+            'content': self.content,
         }
+
+        if self.detail:
+            props['detail'] = self.detail
+
+        yield 'type', 'column'
+        yield 'props', props
         yield 'children', []
 
 
 @dataclass
 class Table(Component):
     """LongLink Table component
-    
+
     The table is a bit special, because it is designed to work with an endpoint
     that returns the table data as a list of dicts.
     The table therefore shall support automatic filtering based on the endpoint query parameters,
@@ -61,31 +93,37 @@ class Table(Component):
     def column(self, key: Column) -> Column: ...
 
     @overload
-    def column(self, 
-        key: str, 
-        label: str | None = None, 
-        value: str | Link = '',
-        detail: str | Link = '',
-        align: Alignments = 'left'
+    def column(
+        self,
+        key: str,
+        label: str | None = None,
+        content: str | Link | TableCell = '',
+        detail: str | Link | TableCell = '',
+        align: Alignments = 'left',
     ) -> Column: ...
 
     def column(
         self,
         key: str | Column,
         label: str | None = None,
-        value: str | Link = '',
-        detail: str | Link = '',
-        align: Alignments = 'left'
+        content: str | Link | TableCell = '',
+        detail: str | Link | TableCell = '',
+        align: Alignments = 'left',
     ) -> Column:
         if isinstance(key, Column):
             column = key
         else:
             label = label or key.capitalize()
-            column = Column(key=key, label=label,  value=value, detail=detail, align=align,)
+            column = Column(
+                key=key,
+                label=label,
+                content=content,
+                detail=detail,
+                align=align,
+            )
 
         self._children.append(column)
         return column
-
 
     def __iter__(self):
         yield 'type', 'table'

--- a/sdk/sample/src/pages/table.py
+++ b/sdk/sample/src/pages/table.py
@@ -37,21 +37,21 @@ async def table_page() -> Page:
         ]
     )
 
-    projects_table.column('name', label='Project', cell='{name}')
-    projects_table.column('owner', label='Owner', cell='{owner}')
-    projects_table.column('status', label='Status', cell='{status}')
-    col = projects_table.column('budget', label='Budget', cell='{budget}', align='right')
+    projects_table.column('name', label='Project', content='{name}')
+    projects_table.column('owner', label='Owner', content='{owner}')
+    projects_table.column('status', label='Status', content='{status}')
+    projects_table.column('budget', label='Budget', content='{budget}', align='right')
 
     return page
 
 
-# cell='link({name}, /projects/{id})'
-# cell='badge({status})'
-# cell='badge({status}, color={status_color})'
-# cell='bold({name})'
-# cell='italic({name})'
-# cell='code({name})'
-# cell='tag({status})'
-# cell='tag({status}, color={status_color})'
-# cell='avatar({owner})'
-# cell='avatar({owner}, size=32)'
+# content='link({name}, /projects/{id})'
+# content='badge({status})'
+# content='badge({status}, color={status_color})'
+# content='bold({name})'
+# content='italic({name})'
+# content='code({name})'
+# content='tag({status})'
+# content='tag({status}, color={status_color})'
+# content='avatar({owner})'
+# content='avatar({owner}, size=32)'


### PR DESCRIPTION
### Motivation
- The web table renderer now expects a `content` payload (with richer object support) for primary cell data instead of the legacy `cell`/`value` mapping. 
- SDK-generated page schemas must produce the shape the frontend consumes to avoid runtime mismatches. 
- Update the SDK so the serialized column props match `web/src/components/table/buildColumns.tsx` and `web` pages.

### Description
- Changed `sdk/longlink/ui/table.py` to introduce a `TableCell` `TypedDict` and replace the legacy `value` field with `content` and richer typed payload support (`value`, optional `bold`, optional `link`).
- Implemented `_normalize_cell` in `Column` to accept `str`, `Link`, or dict-like payloads and serialize them into the `content`/`detail` shapes the frontend expects.
- Updated `Table.column` overloads and implementation to accept `content: str | Link | TableCell` (instead of `cell`/`value`) and to construct `Column` instances with `content`/`detail`.
- Updated the sample page `sdk/sample/src/pages/table.py` to use `content=...` in column definitions and adjusted in-file helper comments accordingly.

### Testing
- Ran `python -m py_compile sdk/longlink/ui/table.py sdk/sample/src/pages/table.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998676819f483238f71ed5237ed3e90)