### PR TITLE
Fix API services to match updated DB model fields

### DIFF
--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -1,5 +1,3 @@
-import hashlib
-
 from sqlalchemy import select
 
 from src.db.models import App
@@ -29,10 +27,8 @@ class AppsService:
         '''Return a registered app by token.'''
 
         Session = await get_session()
-        token_hash = hashlib.sha256(token.encode('utf-8')).hexdigest()
-
         async with Session() as session:
-            statement = select(App).where(App.token_hash == token_hash)
+            statement = select(App).where(App.token == token)
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
@@ -40,7 +36,6 @@ class AppsService:
         '''Add a new app to the database.'''
 
         Session = await get_session()
-        token_hash = hashlib.sha256(token.encode('utf-8')).hexdigest()
 
         async with Session() as session:
             statement = select(App).where(App.url == url)
@@ -49,13 +44,13 @@ class AppsService:
             if existing_app is not None:
                 raise ValueError('App URL already exists')
 
-            token_statement = select(App).where(App.token_hash == token_hash)
+            token_statement = select(App).where(App.token == token)
             token_result = await session.execute(token_statement)
             existing_token = token_result.scalar_one_or_none()
             if existing_token is not None:
                 raise ValueError('App token already exists')
 
-            app = App(name=name, url=url, token_hash=token_hash)
+            app = App(name=name, url=url, token=token)
             session.add(app)
             await session.commit()
             await session.refresh(app)

--- a/api/src/db/services/envs.py
+++ b/api/src/db/services/envs.py
@@ -9,7 +9,7 @@ class EnvsService:
         '''Return all env secrets for an app.'''
         Session = await get_session()
         async with Session() as session:
-            statement = select(Env).where(Env.app_id == app_id)
+            statement = select(Env).where(Env.appid == app_id)
             result = await session.execute(statement)
             return list(result.scalars().all())
 
@@ -17,7 +17,7 @@ class EnvsService:
         '''Return an env secret by key and app scope.'''
         Session = await get_session()
         async with Session() as session:
-            statement = select(Env).where(Env.key == key, Env.app_id == app_id)
+            statement = select(Env).where(Env.key == key, Env.appid == app_id)
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
@@ -25,12 +25,12 @@ class EnvsService:
         '''Create or update an env secret by key and app scope.'''
         Session = await get_session()
         async with Session() as session:
-            statement = select(Env).where(Env.key == key, Env.app_id == app_id)
+            statement = select(Env).where(Env.key == key, Env.appid == app_id)
             result = await session.execute(statement)
             env = result.scalar_one_or_none()
 
             if env is None:
-                env = Env(key=key, value=value, app_id=app_id)
+                env = Env(key=key, value=value, appid=app_id)
                 session.add(env)
             else:
                 env.value = value

--- a/api/src/db/services/settings.py
+++ b/api/src/db/services/settings.py
@@ -11,9 +11,9 @@ class SettingsService:
         async with Session() as session:
             statement = select(Setting)
             if app_id is None:
-                statement = statement.where(Setting.app_id.is_(None))
+                statement = statement.where(Setting.appid.is_(None))
             else:
-                statement = statement.where(Setting.app_id == app_id)
+                statement = statement.where(Setting.appid == app_id)
 
             result = await session.execute(statement)
             return list(result.scalars().all())
@@ -24,9 +24,9 @@ class SettingsService:
         async with Session() as session:
             statement = select(Setting).where(Setting.key == key)
             if app_id is None:
-                statement = statement.where(Setting.app_id.is_(None))
+                statement = statement.where(Setting.appid.is_(None))
             else:
-                statement = statement.where(Setting.app_id == app_id)
+                statement = statement.where(Setting.appid == app_id)
 
             result = await session.execute(statement)
             return result.scalar_one_or_none()
@@ -37,15 +37,15 @@ class SettingsService:
         async with Session() as session:
             statement = select(Setting).where(Setting.key == key)
             if app_id is None:
-                statement = statement.where(Setting.app_id.is_(None))
+                statement = statement.where(Setting.appid.is_(None))
             else:
-                statement = statement.where(Setting.app_id == app_id)
+                statement = statement.where(Setting.appid == app_id)
 
             result = await session.execute(statement)
             setting = result.scalar_one_or_none()
 
             if setting is None:
-                setting = Setting(key=key, value=value, app_id=app_id)
+                setting = Setting(key=key, value=value, appid=app_id)
                 session.add(setting)
             else:
                 setting.value = value

--- a/api/src/routes/settings.py
+++ b/api/src/routes/settings.py
@@ -14,7 +14,7 @@ async def get_setting(key: str) -> SettingResponse:
     return SettingResponse(
         key=setting.key,
         value=setting.value,
-        app_id=setting.app_id,
+        app_id=setting.appid,
     )
 
 
@@ -24,5 +24,5 @@ async def set_setting(key: str, payload: SettingSet) -> SettingResponse:
     return SettingResponse(
         key=setting.key,
         value=setting.value,
-        app_id=setting.app_id,
+        app_id=setting.appid,
     )


### PR DESCRIPTION
### Motivation
- Database models were updated: `App` now exposes `token` (no hash), and `Env`/`Setting` renamed their foreign key from `app_id` to `appid`, so services and routes must be adjusted to remain functional.

### Description
- Updated `AppsService` to use `App.token` for lookups and persistence and removed the `hashlib` token-hashing logic.
- Updated `EnvsService` to query and create using `Env.appid` while keeping the public method signature (`app_id`) unchanged.
- Updated `SettingsService` to query and create using `Setting.appid` (including global-scope checks with `Setting.appid.is_(None)`).
- Updated the settings route to map `setting.appid` into the response `app_id` field.

### Testing
- Ran `cd api && python -m compileall src` which completed successfully without compilation errors.
- Confirmed the modified modules import and compile across `src` with no runtime syntax issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699873829e8c83238b7e356ad41d326a)