### PR TITLE
Align longlink web renderer with SDK UI component schemas

### DIFF
--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -6,7 +6,7 @@ import Hero from '@/components/longlink/Hero';
 import Input from '@/components/longlink/Input';
 import Menu, { MenuSection, MenuSubSection } from '@/components/longlink/Menu';
 import Separator from '@/components/longlink/Separator';
-import Table from '@/components/longlink/Table';
+import Table, { type ApiTableColumn } from '@/components/longlink/Table';
 import Tabs, { Tab } from '@/components/longlink/Tabs';
 
 const registry = {
@@ -108,6 +108,37 @@ function Render({ type, props, children }: RenderNodeSchema) {
                     );
                 })}
             </Menu>
+        );
+    }
+
+    if (type === 'table') {
+        const columns: ApiTableColumn[] = resolvedChildren
+            .filter((child) => child.type === 'column')
+            .map((child) => ({
+                key: String(child.props?.key ?? ''),
+                label:
+                    child.props?.label == null
+                        ? undefined
+                        : String(child.props.label),
+                align:
+                    child.props?.align == null
+                        ? undefined
+                        : (String(child.props.align) as
+                              | 'left'
+                              | 'center'
+                              | 'right'),
+                content: child.props?.content as ApiTableColumn['content'],
+                detail: child.props?.detail as ApiTableColumn['detail'],
+            }))
+            .filter((column) => column.key);
+
+        return (
+            <Table
+                data={
+                    Array.isArray(props?.data) ? (props.data as object[]) : []
+                }
+                columns={columns}
+            />
         );
     }
 

--- a/web/src/components/longlink/Hero.tsx
+++ b/web/src/components/longlink/Hero.tsx
@@ -5,17 +5,12 @@ import { Icon } from '@/components/longlink/Icon';
 type HeroProps = {
     icon?: string | null;
     title: string;
-    action?: string | null;
     subtitle?: string | null;
+    action?: string | null;
     children?: ReactNode;
 };
 
-/* 
-    A Hero component, it allows to to display a basic information about a page.
-    It can be used with a single title, with a subtitle, with an action button that opens a dialog (with a form)
-    It supports an icon
-*/
-export function Hero({ title, subtitle, action, icon, children }: HeroProps) {
+export function Hero({ title, subtitle, icon, action, children }: HeroProps) {
     return (
         <div className="flex items-start justify-between gap-4">
             <div className="flex items-center gap-3">
@@ -39,6 +34,8 @@ export function Hero({ title, subtitle, action, icon, children }: HeroProps) {
                 <Button variant="outline" text={action}>
                     {children}
                 </Button>
+            ) : children ? (
+                <div className="shrink-0">{children}</div>
             ) : null}
         </div>
     );

--- a/web/src/components/longlink/Input.tsx
+++ b/web/src/components/longlink/Input.tsx
@@ -2,31 +2,129 @@ import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Input as UIInput } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+
+type InputOption = {
+    label: string;
+    value: string;
+};
 
 type InputProps = {
+    name?: string;
+    kind?:
+        | 'text'
+        | 'number'
+        | 'password'
+        | 'textarea'
+        | 'date'
+        | 'datetime'
+        | 'select'
+        | 'switch';
     label?: string;
+    value?: string | number | boolean;
     placeholder?: string;
     description?: string;
+    options?: InputOption[];
+    required?: boolean;
+    disabled?: boolean;
     submit?: string;
 };
 
-export function Input({ label, placeholder, description, submit }: InputProps) {
+export function Input({
+    kind = 'text',
+    label,
+    value,
+    placeholder,
+    description,
+    options,
+    required,
+    disabled,
+    submit,
+}: InputProps) {
+    const renderControl = () => {
+        if (kind === 'textarea') {
+            return (
+                <Textarea
+                    placeholder={placeholder}
+                    defaultValue={typeof value === 'string' ? value : undefined}
+                    required={required}
+                    disabled={disabled}
+                />
+            );
+        }
+
+        if (kind === 'switch') {
+            return (
+                <Switch defaultChecked={Boolean(value)} disabled={disabled} />
+            );
+        }
+
+        if (kind === 'select') {
+            return (
+                <Select disabled={disabled} defaultValue={String(value ?? '')}>
+                    <SelectTrigger className="w-full">
+                        <SelectValue
+                            placeholder={placeholder ?? 'Select an option'}
+                        />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {(options ?? []).map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            );
+        }
+
+        const type = kind === 'datetime' ? 'datetime-local' : kind;
+
+        return (
+            <UIInput
+                type={type}
+                placeholder={placeholder}
+                defaultValue={
+                    typeof value === 'string' || typeof value === 'number'
+                        ? value
+                        : undefined
+                }
+                required={required}
+                disabled={disabled}
+            />
+        );
+    };
+
     return (
         <div className="space-y-2">
             {label && <Label>{label}</Label>}
 
-            <ButtonGroup className="w-full">
-                <UIInput placeholder={placeholder} />
-                {submit && (
-                    <Button type="button" className="cursor-pointer">
+            {submit ? (
+                <ButtonGroup className="w-full">
+                    {renderControl()}
+                    <Button
+                        type="button"
+                        className="cursor-pointer"
+                        disabled={disabled}
+                    >
                         {submit}
                     </Button>
-                )}
-            </ButtonGroup>
-
-            {description && (
-                <p className="text-muted-foreground text-sm">{description}</p>
+                </ButtonGroup>
+            ) : (
+                renderControl()
             )}
+
+            {description ? (
+                <p className="text-muted-foreground text-sm">{description}</p>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/longlink/Table.tsx
+++ b/web/src/components/longlink/Table.tsx
@@ -24,43 +24,59 @@ import { useApiTable } from '@/components/table/useApiTable';
 
 export type { ApiTableColumn, TableAlign };
 
-export type TableSchema = {
-    columns: ApiTableColumn[];
-};
-
-export type TableSchemaConfig = {
-    title: string;
-    description?: string;
-    schema: TableSchema;
-};
-
-type TableProps = {
+type SchemaTableProps = {
     endpoint: string;
-    schema: TableSchemaConfig;
+    schema: {
+        title: string;
+        description?: string;
+        schema: {
+            columns: ApiTableColumn[];
+        };
+    };
     pageSize?: number;
+    data?: never;
+    columns?: never;
 };
 
-export function Table<T extends object>({
-    endpoint,
-    schema,
-    pageSize = 10,
-}: TableProps) {
+type DataTableProps = {
+    data: object[];
+    columns: ApiTableColumn[];
+    pageSize?: number;
+    endpoint?: never;
+    schema?: never;
+};
+
+type TableProps = SchemaTableProps | DataTableProps;
+
+export function Table<T extends object>(props: TableProps) {
     const [pagination, setPagination] = useState({
         pageIndex: 0,
-        pageSize,
+        pageSize: props.pageSize ?? 10,
     });
 
     const [sorting, setSorting] = useState<SortingState>([]);
 
-    const { data, total, loading } = useApiTable<T>({
-        endpoint,
+    const isSchemaMode = 'endpoint' in props;
+
+    const apiEndpoint = isSchemaMode
+        ? (props as SchemaTableProps).endpoint
+        : '/__noop__';
+
+    const apiData = useApiTable<T>({
+        endpoint: apiEndpoint,
         pagination,
         sorting,
     });
+    const data = (isSchemaMode ? apiData.data : props.data) as T[];
+    const total = isSchemaMode ? apiData.total : props.data.length;
+    const loading = isSchemaMode ? apiData.loading : false;
+    const columnsConfig = isSchemaMode
+        ? (props.schema?.schema?.columns ?? [])
+        : props.columns;
 
     const columns = useMemo(
-        () => buildColumns<T>(schema?.schema?.columns ?? []),
-        [schema]
+        () => buildColumns<T>(columnsConfig ?? []),
+        [columnsConfig]
     );
 
     const table = useReactTable({
@@ -72,9 +88,9 @@ export function Table<T extends object>({
         },
         onPaginationChange: setPagination,
         onSortingChange: setSorting,
-        manualPagination: true,
-        manualSorting: true,
-        pageCount: total > 0 ? Math.ceil(total / pagination.pageSize) : 1,
+        manualPagination: isSchemaMode,
+        manualSorting: isSchemaMode,
+        pageCount: Math.max(Math.ceil(total / pagination.pageSize), 1),
         getCoreRowModel: getCoreRowModel(),
     });
 

--- a/web/src/components/longlink/Tabs.tsx
+++ b/web/src/components/longlink/Tabs.tsx
@@ -23,7 +23,7 @@ export function Tab({ name, children }: TabProps) {
 
 export function Tabs({ tabs, children }: TabsProps) {
     return (
-        <UITabs>
+        <UITabs defaultValue={tabs[0]}>
             <TabsList>
                 {tabs.map((tab) => (
                     <TabsTrigger


### PR DESCRIPTION
### Motivation
- Ensure the web runtime renders the server-driven SDK component schema exactly as the SDK defines so the frontend stays a dumb renderer of backend-driven UI trees. 
- Provide parity for `Input` so schema `kind`, `value`, `options`, `required`, `disabled`, and inline `submit` are supported by the web controls. 
- Make `table` nodes from the SDK usable in the renderer (parse `column` children into table column configs) and support both schema-driven and data-driven table usage on the web.

### Description
- Updated the renderer (`web/src/components/Render.tsx`) to treat `table` nodes specially by collecting `column` children into `ApiTableColumn[]` and passing `data` + parsed `columns` to the longlink `Table` component.
- Expanded `Input` (`web/src/components/longlink/Input.tsx`) to accept SDK props (`kind`, `value`, `options`, `required`, `disabled`, `submit`) and render the corresponding shadcn controls (`input`, `textarea`, `select`, `switch`) and inline submit button when present.
- Reworked `Table` (`web/src/components/longlink/Table.tsx`) to support two modes: schema/endpoint-backed server pagination (existing behavior) and in-memory data + columns mode produced by the SDK renderer, including consistent sorting/pagination handling.
- Adjusted `Hero` (`web/src/components/longlink/Hero.tsx`) to render child nodes directly as the action area (preserving the legacy `action` prop for backward compatibility) and set `Tabs` (`web/src/components/longlink/Tabs.tsx`) to use the first tab as the default active value so schema-provided tab content is visible on initial render.

### Testing
- Ran formatting with `bun run format` in `web` and it completed successfully. 
- Attempted a production build with `bun run build` in `web` which failed due to pre-existing unrelated TypeScript issues in other UI files, for example `src/components/ui/resizable.tsx` (missing `PanelGroup` / `PanelResizeHandle` typings), `src/components/ui/scroll-area.tsx` (unused `React`), `src/components/ui/sidebar.tsx` (missing `@/hooks/use-mobile` types), and a couple of pages with incompatible types (`pages/org/Longlink.tsx`, `pages/org/People.tsx`). 
- The changes were lint/formatted and validated locally up to typechecking/build, with the build failure attributable to separate existing TS problems not introduced by these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a160c60e483238beea276a1db4038)