### PR TITLE
sdk: allow Input without explicit name by deriving fallback

### DIFF
--- a/sdk/longlink/ui/input.py
+++ b/sdk/longlink/ui/input.py
@@ -1,3 +1,4 @@
+import re
 from typing import Literal, TypeAlias, Any
 from dataclasses import dataclass, field
 from .__root__ import Component
@@ -51,7 +52,7 @@ class Input(Component):
     """
 
     # Core identity
-    name: str
+    name: str | None = None
     kind: InputKinds = "text"
 
     # UI metadata
@@ -74,6 +75,13 @@ class Input(Component):
         """
         Validate configuration constraints.
         """
+        if self.name is None:
+            if self.label:
+                normalized = re.sub(r"[^a-z0-9]+", "_", self.label.lower()).strip("_")
+                self.name = normalized or "input"
+            else:
+                self.name = "input"
+
         if self.kind == "select" and not self.options:
             raise ValueError("Select input requires 'options'.")
 


### PR DESCRIPTION
### Motivation
- Fix a runtime `TypeError` observed when helpers like `tab.input(...)` constructed `Input` instances without passing a required `name`, causing server errors during page rendering.

### Description
- Make `Input.name` optional (`str | None`) and add fallback generation in `__post_init__` that slugifies `label` to a lowercase, underscore-delimited identifier, falling back to `"input"` when no label is provided.
- Preserve existing validation logic for `select`/`options` and `switch` defaulting, and keep the serialization shape unchanged so `name` is present in the emitted `props`.
- Add an `import re` and small normalization implementation to produce stable autogenerated names.

### Testing
- Ran a quick runtime import check via `python - <<'PY' ...` which failed due to a missing environment dependency `pydantic_settings` and thus could not fully validate runtime behavior.
- Attempted to load the module with `importlib.util.spec_from_file_location` which failed due to relative-import context in this environment.
- Verified the file contents with `git diff`/`nl` and committed the change successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a23b763a483239c6bf58e90a4235f)