### PR TITLE
Support polymorphic Input kinds in SDK builders and web binding

### DIFF
--- a/sdk/longlink/ui/dialog.py
+++ b/sdk/longlink/ui/dialog.py
@@ -1,9 +1,10 @@
 from .__root__ import Component
 from dataclasses import dataclass, field
+from typing import Any
 
 
 # Import Components
-from .input import Input
+from .input import Input, InputKinds
 
 
 @dataclass
@@ -21,15 +22,27 @@ class Dialog(Component):
   
     def input(
         self,
+        name: str | None = None,
+        kind: InputKinds = "text",
         label: str | None = None,
+        value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
+        options: list[dict[str, str]] | None = None,
+        required: bool = False,
+        disabled: bool = False,
         submit: str | None = None,
     ) -> Input:
         input_component = Input(
+            name=name,
+            kind=kind,
             label=label,
+            value=value,
             placeholder=placeholder,
             description=description,
+            options=options,
+            required=required,
+            disabled=disabled,
             submit=submit,
         )
         self._components.append(input_component)

--- a/sdk/longlink/ui/menu.py
+++ b/sdk/longlink/ui/menu.py
@@ -1,10 +1,11 @@
 from longlink.ui.__root__ import Component
 from dataclasses import dataclass, field
+from typing import Any
 
 # Importing components
 from longlink.ui.tabs import Tab, Tabs
 from longlink.ui.hero import Hero
-from longlink.ui.input import Input
+from longlink.ui.input import Input, InputKinds
 from longlink.ui.table import Table
 from longlink.ui.separator import Separator
 from longlink.ui.columns import Column, Columns
@@ -72,16 +73,28 @@ class MenuSubSection(Component):
 
     def input(
         self,
+        name: str | None = None,
+        kind: InputKinds = "text",
         label: str | None = None,
+        value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
+        options: list[dict[str, str]] | None = None,
+        required: bool = False,
+        disabled: bool = False,
         submit: str | None = None,
     ) -> Input:
         """Append an Input component."""
         input_component = Input(
+            name=name,
+            kind=kind,
             label=label,
+            value=value,
             placeholder=placeholder,
             description=description,
+            options=options,
+            required=required,
+            disabled=disabled,
             submit=submit,
         )
         self._children.append(input_component)
@@ -173,15 +186,27 @@ class MenuSection(Component):
 
     def input(
         self,
+        name: str | None = None,
+        kind: InputKinds = "text",
         label: str | None = None,
+        value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
+        options: list[dict[str, str]] | None = None,
+        required: bool = False,
+        disabled: bool = False,
         submit: str | None = None,
     ) -> Input:
         input_component = Input(
+            name=name,
+            kind=kind,
             label=label,
+            value=value,
             placeholder=placeholder,
             description=description,
+            options=options,
+            required=required,
+            disabled=disabled,
             submit=submit,
         )
         self._root._children.append(input_component)

--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -2,7 +2,8 @@ from longlink.ui.tabs import Tab, Tabs
 from longlink.ui.hero import Hero
 from longlink.ui.menu import Menu
 from longlink.ui.table import Table
-from longlink.ui.input import Input
+from typing import Any
+from longlink.ui.input import Input, InputKinds
 from longlink.ui.button import Button, ButtonVariants
 from longlink.ui.columns import Column, Columns
 from longlink.ui.__root__ import Component
@@ -95,16 +96,28 @@ class Page:
 
     def input(
         self,
+        name: str | None = None,
+        kind: InputKinds = 'text',
         label: str | None = None,
+        value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
+        options: list[dict[str, str]] | None = None,
+        required: bool = False,
+        disabled: bool = False,
         submit: str | None = None,
     ) -> Input:
         """Append an Input component to the page."""
         input_component = Input(
+            name=name,
+            kind=kind,
             label=label,
+            value=value,
             placeholder=placeholder,
             description=description,
+            options=options,
+            required=required,
+            disabled=disabled,
             submit=submit,
         )
         self._children.append(input_component)

--- a/sdk/longlink/ui/tabs.py
+++ b/sdk/longlink/ui/tabs.py
@@ -1,9 +1,10 @@
 from .__root__ import Component
 from dataclasses import dataclass, field
+from typing import Any
 
 # Importing components
 from .hero import Hero
-from .input import Input
+from .input import Input, InputKinds
 from .table import Table
 from .columns import Column, Columns
 from .button import Button, ButtonVariants
@@ -81,9 +82,15 @@ class Tab(Component):
 
     def input(
         self,
+        name: str | None = None,
+        kind: InputKinds = "text",
         label: str | None = None,
+        value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
+        options: list[dict[str, str]] | None = None,
+        required: bool = False,
+        disabled: bool = False,
         submit: str | None = None,
     ) -> Input:
         """
@@ -92,9 +99,15 @@ class Tab(Component):
         Intended for lightweight forms or tab-scoped actions.
         """
         input_component = Input(
+            name=name,
+            kind=kind,
             label=label,
+            value=value,
             placeholder=placeholder,
             description=description,
+            options=options,
+            required=required,
+            disabled=disabled,
             submit=submit,
         )
         self._children.append(input_component)

--- a/web/src/components/longlink/Input.tsx
+++ b/web/src/components/longlink/Input.tsx
@@ -39,6 +39,7 @@ type InputProps = {
 };
 
 export function Input({
+    name,
     kind = 'text',
     label,
     value,
@@ -53,6 +54,7 @@ export function Input({
         if (kind === 'textarea') {
             return (
                 <Textarea
+                    name={name}
                     placeholder={placeholder}
                     defaultValue={typeof value === 'string' ? value : undefined}
                     required={required}
@@ -63,7 +65,11 @@ export function Input({
 
         if (kind === 'switch') {
             return (
-                <Switch defaultChecked={Boolean(value)} disabled={disabled} />
+                <Switch
+                    name={name}
+                    defaultChecked={Boolean(value)}
+                    disabled={disabled}
+                />
             );
         }
 
@@ -90,6 +96,7 @@ export function Input({
 
         return (
             <UIInput
+                name={name}
                 type={type}
                 placeholder={placeholder}
                 defaultValue={


### PR DESCRIPTION
### Motivation
- The SDK `Input` dataclass already supports multiple `kind` values and options, but common container helper methods only exposed minimal metadata making non-text inputs hard to create. 
- Frontend input controls must preserve backend field identity so server-driven forms can map events to the correct field names. 

### Description
- Extended SDK convenience helpers to expose the full `Input` API by adding `name`, `kind`, `value`, `options`, `required`, and `disabled` parameters to container methods in `Page`, `Tabs/Tab`, `Menu/MenuSection/MenuSubSection`, and `Dialog` so callers can construct any supported input kind directly. 
- Updated the web renderer `web/src/components/longlink/Input.tsx` to forward the backend-provided `name` prop to rendered controls (`Textarea`, `Switch`, and the base `input`) so frontend events retain the backend field identity. 
- Files changed include `sdk/longlink/ui/page.py`, `sdk/longlink/ui/tabs.py`, `sdk/longlink/ui/menu.py`, `sdk/longlink/ui/dialog.py`, and `web/src/components/longlink/Input.tsx`. 

### Testing
- Ran `python -m compileall sdk/longlink/ui` and it completed successfully. 
- Ran formatting on the web app with `bun run format` and it completed successfully. 
- Attempted `bun run build` for the web app which failed due to unrelated pre-existing TypeScript errors elsewhere in the repository and not due to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3650f56883238d0b58a415b23d87)