### PR TITLE
Add Switch component to Longlink web renderer and Python SDK

### DIFF
--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -8,6 +8,7 @@ from longlink.ui.button import Button, ButtonVariants
 from longlink.ui.columns import Column, Columns
 from longlink.ui.__root__ import Component
 from longlink.ui.separator import Separator
+from longlink.ui.switch import Switch
 
 
 class Page:
@@ -122,6 +123,22 @@ class Page:
         )
         self._children.append(input_component)
         return input_component
+
+
+    def switch(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        active: bool = False,
+    ) -> Switch:
+        """Append a Switch component to the page."""
+        switch_component = Switch(
+            label=label,
+            description=description,
+            active=active,
+        )
+        self._children.append(switch_component)
+        return switch_component
 
     def separator(self) -> Separator:
         """Insert a visual separator between top-level components."""

--- a/sdk/longlink/ui/switch.py
+++ b/sdk/longlink/ui/switch.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+from .__root__ import Component
+
+
+@dataclass
+class Switch(Component):
+    """
+    Standalone switch/toggle component.
+
+    Serialization shape:
+        {
+            "type": "switch",
+            "props": {
+                "label": <str | null>,
+                "description": <str | null>,
+                "active": <bool>
+            },
+            "children": []
+        }
+    """
+
+    label: str | None = None
+    description: str | None = None
+    active: bool = False
+
+    def __iter__(self):
+        props = {
+            "label": self.label,
+            "description": self.description,
+            "active": self.active,
+        }
+
+        cleaned = {k: v for k, v in props.items() if v is not None}
+
+        yield "type", "switch"
+        yield "props", cleaned
+        yield "children", []

--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -6,6 +6,7 @@ import Hero from '@/components/longlink/Hero';
 import Input from '@/components/longlink/Input';
 import Menu, { MenuSection, MenuSubSection } from '@/components/longlink/Menu';
 import Separator from '@/components/longlink/Separator';
+import Switch from '@/components/longlink/Switch';
 import Table, { type ApiTableColumn } from '@/components/longlink/Table';
 import Tabs, { Tab } from '@/components/longlink/Tabs';
 
@@ -23,6 +24,7 @@ const registry = {
     menusection: MenuSection,
     menuSubSection: MenuSubSection,
     input: Input,
+    switch: Switch,
 };
 
 type Registry = typeof registry;

--- a/web/src/components/longlink/Switch.tsx
+++ b/web/src/components/longlink/Switch.tsx
@@ -1,0 +1,30 @@
+import { useId } from 'react';
+import { Label } from '@/components/ui/label';
+import { Switch as UISwitch } from '@/components/ui/switch';
+
+type SwitchProps = {
+    label?: string;
+    description?: string;
+    active?: boolean;
+};
+
+export function Switch({ label, description, active = false }: SwitchProps) {
+    const id = useId();
+
+    return (
+        <div className="flex items-start justify-between gap-4 rounded-lg border p-4">
+            <div className="space-y-1">
+                {label ? <Label htmlFor={id}>{label}</Label> : null}
+                {description ? (
+                    <p className="text-muted-foreground text-sm">
+                        {description}
+                    </p>
+                ) : null}
+            </div>
+
+            <UISwitch id={id} defaultChecked={active} />
+        </div>
+    );
+}
+
+export default Switch;


### PR DESCRIPTION
### Motivation
- Provide a reusable toggle/switch component for Longlink pages that is authorable from the Python SDK and renderable by the web runtime. 
- Keep the server-driven UI contract (`type` / `props` / `children`) consistent with other Longlink components.

### Description
- Add a new frontend component `web/src/components/longlink/Switch.tsx` built on the shadcn `Switch` and exposing `label`, `description`, and `active` props. 
- Register the new `switch` node in the renderer registry at `web/src/components/Render.tsx` so server-driven schemas with `type: "switch"` are rendered. 
- Add a Python SDK dataclass `sdk/longlink/ui/switch.py` which serializes to `{"type": "switch", "props": {label, description, active}, "children": []}`. 
- Expose a `Page.switch(...)` helper in `sdk/longlink/ui/page.py` to append switch nodes from Python page definitions.

### Testing
- Ran `bun run format` in the web workspace to format files, which completed successfully. 
- Ran `python -m compileall sdk/longlink/ui` to validate Python SDK modules, which completed successfully. 
- Ran `bun run build` for the web app which failed due to pre-existing TypeScript errors unrelated to the added switch (build failure noted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4a1278f0832392ff5186feff2fa0)