### PR TITLE
Add LongLink checkbox component in SDK and web renderer

### DIFF
--- a/sdk/longlink/ui/checkbox.py
+++ b/sdk/longlink/ui/checkbox.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+from .__root__ import Component
+
+
+@dataclass
+class Checkbox(Component):
+    """
+    Standalone checkbox component.
+
+    Serialization shape:
+        {
+            "type": "checkbox",
+            "props": {
+                "label": <str | null>,
+                "description": <str | null>,
+                "checked": <bool>
+            },
+            "children": []
+        }
+    """
+
+    label: str | None = None
+    description: str | None = None
+    checked: bool = False
+
+    def __iter__(self):
+        props = {
+            "label": self.label,
+            "description": self.description,
+            "checked": self.checked,
+        }
+
+        cleaned = {k: v for k, v in props.items() if v is not None}
+
+        yield "type", "checkbox"
+        yield "props", cleaned
+        yield "children", []

--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -9,6 +9,7 @@ from longlink.ui.columns import Column, Columns
 from longlink.ui.__root__ import Component
 from longlink.ui.separator import Separator
 from longlink.ui.switch import Switch
+from longlink.ui.checkbox import Checkbox
 
 
 class Page:
@@ -139,6 +140,22 @@ class Page:
         )
         self._children.append(switch_component)
         return switch_component
+
+
+    def checkbox(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        checked: bool = False,
+    ) -> Checkbox:
+        """Append a Checkbox component to the page."""
+        checkbox_component = Checkbox(
+            label=label,
+            description=description,
+            checked=checked,
+        )
+        self._children.append(checkbox_component)
+        return checkbox_component
 
     def separator(self) -> Separator:
         """Insert a visual separator between top-level components."""

--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import Button from '@/components/longlink/Button';
+import Checkbox from '@/components/longlink/Checkbox';
 import Columns, { Column } from '@/components/longlink/Columns';
 import Dialog from '@/components/longlink/Dialog';
 import Hero from '@/components/longlink/Hero';
@@ -25,6 +26,7 @@ const registry = {
     menuSubSection: MenuSubSection,
     input: Input,
     switch: Switch,
+    checkbox: Checkbox,
 };
 
 type Registry = typeof registry;

--- a/web/src/components/longlink/Checkbox.tsx
+++ b/web/src/components/longlink/Checkbox.tsx
@@ -1,0 +1,33 @@
+import { useId } from 'react';
+import { Checkbox as UICheckbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+type CheckboxProps = {
+    label?: string;
+    description?: string;
+    checked?: boolean;
+};
+
+export function Checkbox({
+    label,
+    description,
+    checked = false,
+}: CheckboxProps) {
+    const id = useId();
+
+    return (
+        <div className="flex items-start space-x-3 rounded-md border p-4">
+            <UICheckbox id={id} defaultChecked={checked} />
+            <div className="space-y-1 leading-none">
+                {label ? <Label htmlFor={id}>{label}</Label> : null}
+                {description ? (
+                    <p className="text-muted-foreground text-sm">
+                        {description}
+                    </p>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+export default Checkbox;


### PR DESCRIPTION
### Motivation
- Provide a server-driven checkbox component so backend authors can declare checkboxes with `label`, `description`, and `checked` state and have the frontend render them with shadcn primitives.
- Keep the SDK-first authoring model by exposing a `Page.checkbox(...)` helper to append checkbox nodes into serialized page trees.

### Description
- Added `sdk/longlink/ui/checkbox.py` implementing a `Checkbox` dataclass that serializes to a `type: "checkbox"` node with `props` `{label, description, checked}` and empty `children`.
- Extended the SDK `Page` API with a `checkbox(...)` method that constructs and appends a `Checkbox` instance to the page tree.
- Introduced `web/src/components/longlink/Checkbox.tsx`, a renderer that uses the existing shadcn `Checkbox` and `Label` primitives and supports `label`, `description`, and initial `checked` state.
- Registered `checkbox` in the frontend schema registry at `web/src/components/Render.tsx` so backend-emitted checkbox nodes are resolved to the new renderer.

### Testing
- Ran formatting for the web app with `bun run format`, which completed successfully.
- Compiled the SDK UI package with `python -m compileall sdk/longlink/ui`, which succeeded with no Python compilation errors.
- Attempted a full web build with `bun run build`, which failed due to pre-existing TypeScript errors in unrelated files (e.g. `src/components/ui/resizable.tsx`, `src/components/ui/sidebar.tsx`), so the failure is not caused by the checkbox changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4bf081e48323a156eac603760332)