### PR TITLE
Add server-driven Range slider component (SDK + web renderer)

### DIFF
--- a/sdk/longlink/ui/card.py
+++ b/sdk/longlink/ui/card.py
@@ -9,6 +9,7 @@ from .button import Button, ButtonVariants
 from .columns import Column, Columns
 from .separator import Separator
 from .tabs import Tab, Tabs
+from .range import Range
 
 
 @dataclass
@@ -82,6 +83,27 @@ class Card(Component):
         tabs = Tabs()
         self._children.append(tabs)
         return [tabs.tab(name=n) for n in names]
+
+
+    def range(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        min: float = 0,
+        max: float = 100,
+        step: float = 1,
+        value: list[float] | None = None,
+    ) -> Range:
+        range_component = Range(
+            label=label,
+            description=description,
+            min=min,
+            max=max,
+            step=step,
+            value=value if value is not None else [min, max],
+        )
+        self._children.append(range_component)
+        return range_component
 
     def add(self, component: Component) -> Component:
         """

--- a/sdk/longlink/ui/columns.py
+++ b/sdk/longlink/ui/columns.py
@@ -4,6 +4,7 @@ from longlink.ui.table import Table
 from longlink.ui.button import Button, ButtonVariants
 from longlink.ui.__root__ import Component
 from longlink.ui.separator import Separator
+from longlink.ui.range import Range
 
 
 @dataclass
@@ -55,6 +56,27 @@ class Column(Component):
         separator = Separator()
         self._components.append(separator)
         return separator
+
+
+    def range(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        min: float = 0,
+        max: float = 100,
+        step: float = 1,
+        value: list[float] | None = None,
+    ) -> Range:
+        range_component = Range(
+            label=label,
+            description=description,
+            min=min,
+            max=max,
+            step=step,
+            value=value if value is not None else [min, max],
+        )
+        self._components.append(range_component)
+        return range_component
 
 
 @dataclass

--- a/sdk/longlink/ui/dialog.py
+++ b/sdk/longlink/ui/dialog.py
@@ -5,6 +5,7 @@ from typing import Any
 
 # Import Components
 from .input import Input, InputKinds
+from .range import Range
 
 
 @dataclass
@@ -47,6 +48,27 @@ class Dialog(Component):
         )
         self._components.append(input_component)
         return input_component
+
+
+    def range(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        min: float = 0,
+        max: float = 100,
+        step: float = 1,
+        value: list[float] | None = None,
+    ) -> Range:
+        range_component = Range(
+            label=label,
+            description=description,
+            min=min,
+            max=max,
+            step=step,
+            value=value if value is not None else [min, max],
+        )
+        self._components.append(range_component)
+        return range_component
 
     def __iter__(self):
         yield 'type', 'dialog'

--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -10,6 +10,7 @@ from longlink.ui.__root__ import Component
 from longlink.ui.separator import Separator
 from longlink.ui.switch import Switch
 from longlink.ui.checkbox import Checkbox
+from longlink.ui.range import Range
 
 
 class Page:
@@ -156,6 +157,28 @@ class Page:
         )
         self._children.append(checkbox_component)
         return checkbox_component
+
+
+    def range(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        min: float = 0,
+        max: float = 100,
+        step: float = 1,
+        value: list[float] | None = None,
+    ) -> Range:
+        """Append a Range component to the page."""
+        range_component = Range(
+            label=label,
+            description=description,
+            min=min,
+            max=max,
+            step=step,
+            value=value if value is not None else [min, max],
+        )
+        self._children.append(range_component)
+        return range_component
 
     def separator(self) -> Separator:
         """Insert a visual separator between top-level components."""

--- a/sdk/longlink/ui/range.py
+++ b/sdk/longlink/ui/range.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass, field
+
+from .__root__ import Component
+
+
+@dataclass
+class Range(Component):
+    """
+    Standalone range slider component.
+
+    Serialization shape:
+        {
+            "type": "range",
+            "props": {
+                "label": <str | null>,
+                "description": <str | null>,
+                "min": <float>,
+                "max": <float>,
+                "step": <float>,
+                "value": <list[float]>
+            },
+            "children": []
+        }
+    """
+
+    label: str | None = None
+    description: str | None = None
+    min: float = 0
+    max: float = 100
+    step: float = 1
+    value: list[float] = field(default_factory=lambda: [0, 100])
+
+    def __post_init__(self) -> None:
+        if self.min > self.max:
+            raise ValueError("'min' must be lower than or equal to 'max'.")
+
+        if self.step <= 0:
+            raise ValueError("'step' must be greater than 0.")
+
+        if len(self.value) != 2:
+            raise ValueError("'value' must contain exactly two numbers.")
+
+    def __iter__(self):
+        props = {
+            "label": self.label,
+            "description": self.description,
+            "min": self.min,
+            "max": self.max,
+            "step": self.step,
+            "value": self.value,
+        }
+
+        cleaned = {k: v for k, v in props.items() if v is not None}
+
+        yield "type", "range"
+        yield "props", cleaned
+        yield "children", []

--- a/sdk/longlink/ui/tabs.py
+++ b/sdk/longlink/ui/tabs.py
@@ -9,6 +9,7 @@ from .table import Table
 from .columns import Column, Columns
 from .button import Button, ButtonVariants
 from .separator import Separator
+from .range import Range
 
 
 @dataclass
@@ -112,6 +113,28 @@ class Tab(Component):
         )
         self._children.append(input_component)
         return input_component
+
+
+    def range(
+        self,
+        label: str | None = None,
+        description: str | None = None,
+        min: float = 0,
+        max: float = 100,
+        step: float = 1,
+        value: list[float] | None = None,
+    ) -> Range:
+        """Append a Range component to this tab."""
+        range_component = Range(
+            label=label,
+            description=description,
+            min=min,
+            max=max,
+            step=step,
+            value=value if value is not None else [min, max],
+        )
+        self._children.append(range_component)
+        return range_component
 
 
 @dataclass

--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -6,6 +6,7 @@ import Dialog from '@/components/longlink/Dialog';
 import Hero from '@/components/longlink/Hero';
 import Input from '@/components/longlink/Input';
 import Menu, { MenuSection, MenuSubSection } from '@/components/longlink/Menu';
+import Range from '@/components/longlink/Range';
 import Separator from '@/components/longlink/Separator';
 import Switch from '@/components/longlink/Switch';
 import Table, { type ApiTableColumn } from '@/components/longlink/Table';
@@ -27,6 +28,7 @@ const registry = {
     input: Input,
     switch: Switch,
     checkbox: Checkbox,
+    range: Range,
 };
 
 type Registry = typeof registry;

--- a/web/src/components/longlink/Range.tsx
+++ b/web/src/components/longlink/Range.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Label } from '@/components/ui/label';
+import { Slider } from '@/components/ui/slider';
+
+type RangeProps = {
+    label?: string;
+    description?: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    value?: number[];
+};
+
+export function Range({
+    label,
+    description,
+    min = 0,
+    max = 100,
+    step = 1,
+    value = [min, max],
+}: RangeProps) {
+    const normalizedValue =
+        value.length === 2 ? value : [value[0] ?? min, value[1] ?? max];
+
+    return (
+        <div className="space-y-2">
+            {(label || normalizedValue.length > 0) && (
+                <div className="flex items-center justify-between gap-2">
+                    {label ? <Label>{label}</Label> : <span />}
+                    <span className="text-muted-foreground text-sm">
+                        {normalizedValue.join(', ')}
+                    </span>
+                </div>
+            )}
+
+            <Slider value={normalizedValue} min={min} max={max} step={step} />
+
+            {description ? (
+                <p className="text-muted-foreground text-sm">{description}</p>
+            ) : null}
+        </div>
+    );
+}
+
+export default Range;


### PR DESCRIPTION
### Motivation
- Provide a server-driven range slider component so backend authors can declare numeric ranges (two-point values) with `label`, `description`, `min`, `max`, and `step` and have the frontend render it using the existing shadcn `Slider` UI.

### Description
- Added `sdk/longlink/ui/range.py` implementing the `Range` dataclass that serializes to `type: "range"` and validates `min <= max`, `step > 0`, and a two-element `value` list.
- Exposed `range(...)` composition helpers on SDK containers (`Page`, `Tab`, `Dialog`, `Column`, and `Card`) so the component can be created from those builders.
- Added the frontend renderer `web/src/components/longlink/Range.tsx` that uses the shadcn `Slider` and renders the label + current values on top, the slider in the middle, and the description below.
- Registered `range` in the renderer registry at `web/src/components/Render.tsx` so server-driven schemas with `type: "range"` are mapped to the new component.

### Testing
- Ran `bun run format` in the `web/` workspace which completed successfully.
- Ran `python -m compileall sdk/longlink/ui` which completed successfully to validate the updated Python modules.
- Ran `bun run build` which failed due to pre-existing unrelated TypeScript errors in other files, so the build did not complete (the new `Range` files are formatted and the SDK Python modules compile).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5b0732908323a8ef4840800df50c)