### PR TITLE
Add standalone Textarea component to SDK and frontend renderer

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,3 +1,5 @@
 from .ui import Page
 from .app import LongLink
 from .router import Router
+
+from longlink.ui.textarea import Textarea

--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -10,6 +10,7 @@ from longlink.ui.__root__ import Component
 from longlink.ui.separator import Separator
 from longlink.ui.switch import Switch
 from longlink.ui.checkbox import Checkbox
+from longlink.ui.textarea import Textarea
 
 
 class Page:
@@ -162,6 +163,21 @@ class Page:
         separator = Separator()
         self._children.append(separator)
         return separator
+
+    def textarea(
+        self,
+        label: str | None = None,
+        placeholder: str | None = None,
+        description: str | None = None,
+    ) -> Textarea:
+        """Append a standalone Textarea component to the page."""
+        textarea_component = Textarea(
+            label=label,
+            placeholder=placeholder,
+            description=description,
+        )
+        self._children.append(textarea_component)
+        return textarea_component
 
     def __iter__(self):
         """

--- a/sdk/longlink/ui/textarea.py
+++ b/sdk/longlink/ui/textarea.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+from .__root__ import Component
+
+
+@dataclass
+class Textarea(Component):
+    """
+    Standalone textarea component.
+
+    Serialization shape:
+        {
+            "type": "textarea",
+            "props": {
+                "label": <str | null>,
+                "placeholder": <str | null>,
+                "description": <str | null>
+            },
+            "children": []
+        }
+    """
+
+    label: str | None = None
+    placeholder: str | None = None
+    description: str | None = None
+
+    def __iter__(self):
+        props = {
+            "label": self.label,
+            "placeholder": self.placeholder,
+            "description": self.description,
+        }
+
+        cleaned = {k: v for k, v in props.items() if v is not None}
+
+        yield "type", "textarea"
+        yield "props", cleaned
+        yield "children", []

--- a/sdk/sample/src/pages/input.py
+++ b/sdk/sample/src/pages/input.py
@@ -42,6 +42,14 @@ async def input_page() -> Page:
         submit="Save",
     )
 
+
+    # Standalone textarea element
+    page.textarea(
+        label="Standalone Textarea",
+        placeholder="Write your notes here",
+        description="This is a standalone textarea without save actions.",
+    )
+
     # Date input
     page.input(
         kind="date",

--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -9,6 +9,7 @@ import Menu, { MenuSection, MenuSubSection } from '@/components/longlink/Menu';
 import Separator from '@/components/longlink/Separator';
 import Switch from '@/components/longlink/Switch';
 import Table, { type ApiTableColumn } from '@/components/longlink/Table';
+import Textarea from '@/components/longlink/Textarea';
 import Tabs, { Tab } from '@/components/longlink/Tabs';
 
 const registry = {
@@ -27,6 +28,7 @@ const registry = {
     input: Input,
     switch: Switch,
     checkbox: Checkbox,
+    textarea: Textarea,
 };
 
 type Registry = typeof registry;

--- a/web/src/components/longlink/Textarea.tsx
+++ b/web/src/components/longlink/Textarea.tsx
@@ -1,0 +1,24 @@
+import { Label } from '@/components/ui/label';
+import { Textarea as UITextarea } from '@/components/ui/textarea';
+
+type TextareaProps = {
+    label?: string;
+    placeholder?: string;
+    description?: string;
+};
+
+export function Textarea({ label, placeholder, description }: TextareaProps) {
+    return (
+        <div className="space-y-2">
+            {label ? <Label>{label}</Label> : null}
+
+            <UITextarea placeholder={placeholder} />
+
+            {description ? (
+                <p className="text-muted-foreground text-sm">{description}</p>
+            ) : null}
+        </div>
+    );
+}
+
+export default Textarea;


### PR DESCRIPTION
### Motivation

- Provide a simple, server-driven standalone textarea element with `label`, `placeholder`, and `description` props that does not include a save button or submit action.
- Keep the backend-first UI model consistent by making the textarea serializable as a distinct component type so frontends can render it from schema.
- Offer an easy authoring API on `Page` so apps can declare textareas alongside other components.

### Description

- Added a new SDK component `Textarea` that serializes to `type: "textarea"` with `label`, `placeholder`, and `description` props in `sdk/longlink/ui/textarea.py`.
- Extended the page builder with a `textarea(...)` helper on `Page` and exported `Textarea` from the package root so apps can append standalone textareas (`sdk/longlink/ui/page.py`, `sdk/longlink/__init__.py`).
- Implemented a frontend renderer component `web/src/components/longlink/Textarea.tsx` that uses existing shadcn `Textarea` + `Label`, and registered the new `textarea` type in the renderer registry (`web/src/components/Render.tsx`).
- Added a sample usage to the SDK sample page to demonstrate a standalone textarea without save actions (`sdk/sample/src/pages/input.py`).

### Testing

- Ran `python -m compileall sdk/longlink/ui sdk/sample/src/pages/input.py` and it completed successfully with compiled modules present.
- Ran `cd web && bun run format` and formatting completed successfully with no changes required.
- Ran `cd web && bun run build` which failed due to pre-existing TypeScript issues in unrelated files (e.g. `src/components/ui/resizable.tsx` and `src/components/ui/sidebar.tsx`), so the failure is unrelated to the added `textarea` changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5bc3bd4c8323a60e2b45631301ef)