### PR TITLE
Support app-relative URL clicks on Button (SDK + web)

### DIFF
--- a/sdk/longlink/ui/button.py
+++ b/sdk/longlink/ui/button.py
@@ -31,7 +31,13 @@ class Button(Component):
 
     text: str
     variant: ButtonVariants
+    url: str | None = None
     _dialog: Dialog | None = field(default=None)
+
+    def click(self, url: str) -> 'Button':
+        """Configure an app-relative endpoint to call on click."""
+        self.url = url
+        return self
 
     def dialog(self, confirm: str = 'Confirm', cancel: str = 'Cancel') -> Dialog:
         self._dialog = Dialog(confirm=confirm, cancel=cancel)
@@ -42,6 +48,7 @@ class Button(Component):
         yield 'props', {
             'text': self.text,
             'variant': self.variant,
+            'url': self.url,
         }
 
         if self._dialog is not None:

--- a/sdk/longlink/ui/card.py
+++ b/sdk/longlink/ui/card.py
@@ -64,8 +64,13 @@ class Card(Component):
         self._children.append(input_component)
         return input_component
 
-    def button(self, text: str, variant: ButtonVariants = "default") -> Button:
-        button = Button(text=text, variant=variant)
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = "default",
+        url: str | None = None,
+    ) -> Button:
+        button = Button(text=text, variant=variant, url=url)
         self._children.append(button)
         return button
 

--- a/sdk/longlink/ui/columns.py
+++ b/sdk/longlink/ui/columns.py
@@ -47,8 +47,13 @@ class Column(Component):
         self._components.append(table)
         return table
 
-    def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
-        button = Button(text=text, variant=variant)
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = 'default',
+        url: str | None = None,
+    ) -> Button:
+        button = Button(text=text, variant=variant, url=url)
         self._components.append(button)
         return button
 

--- a/sdk/longlink/ui/hero.py
+++ b/sdk/longlink/ui/hero.py
@@ -41,8 +41,13 @@ class Hero(Component):
     icon: IconTypes | None = None
     action: Button | None = field(default=None)
 
-    def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
-        button = Button(text=text, variant=variant)
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = 'default',
+        url: str | None = None,
+    ) -> Button:
+        button = Button(text=text, variant=variant, url=url)
         self.action = button
         return button
 

--- a/sdk/longlink/ui/menu.py
+++ b/sdk/longlink/ui/menu.py
@@ -53,9 +53,14 @@ class MenuSubSection(Component):
         self._children.append(table)
         return table
 
-    def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = 'default',
+        url: str | None = None,
+    ) -> Button:
         """Append a Button component to this subsection."""
-        button = Button(text=text, variant=variant)
+        button = Button(text=text, variant=variant, url=url)
         self._children.append(button)
         return button
 
@@ -169,8 +174,13 @@ class MenuSection(Component):
         self._root._children.append(table)
         return table
 
-    def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
-        button = Button(text=text, variant=variant)
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = 'default',
+        url: str | None = None,
+    ) -> Button:
+        button = Button(text=text, variant=variant, url=url)
         self._root._children.append(button)
         return button
 

--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -58,9 +58,14 @@ class Page:
         self._children.append(table)
         return table
 
-    def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = 'default',
+        url: str | None = None,
+    ) -> Button:
         """Append a Button component to the page."""
-        button = Button(text=text, variant=variant)
+        button = Button(text=text, variant=variant, url=url)
         self._children.append(button)
         return button
 

--- a/sdk/longlink/ui/tabs.py
+++ b/sdk/longlink/ui/tabs.py
@@ -58,9 +58,14 @@ class Tab(Component):
         self._children.append(table)
         return table
 
-    def button(self, text: str, variant: ButtonVariants = 'default') -> Button:
+    def button(
+        self,
+        text: str,
+        variant: ButtonVariants = 'default',
+        url: str | None = None,
+    ) -> Button:
         """Append a Button component to this tab."""
-        button = Button(text=text, variant=variant)
+        button = Button(text=text, variant=variant, url=url)
         self._children.append(button)
         return button
 

--- a/web/src/components/longlink/Button.tsx
+++ b/web/src/components/longlink/Button.tsx
@@ -1,23 +1,49 @@
 import { useState, type ComponentProps, type ReactNode } from 'react';
+import { useParams } from 'react-router';
 import { Button as UIButton } from '@/components/ui/button';
 import { Dialog } from '@/components/ui/dialog';
+import { apiFetch } from '@/lib/api';
 
 type ButtonProps = {
     text: string;
     variant?: ComponentProps<typeof UIButton>['variant'];
+    url?: string;
     children?: ReactNode;
 };
 
-export function Button({ text, variant = 'default', children }: ButtonProps) {
+const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
+
+export function Button({
+    text,
+    variant = 'default',
+    url,
+    children,
+}: ButtonProps) {
     const [open, setOpen] = useState(false);
+    const { app } = useParams();
     const hasDialog = Boolean(children);
+    const normalizedUrl = normalizePath(url ?? '');
+
+    const handleClick = async () => {
+        if (hasDialog) {
+            setOpen(true);
+        }
+
+        if (!app || !normalizedUrl) {
+            return;
+        }
+
+        await apiFetch(`/apps/${app}/${normalizedUrl}`, {
+            method: 'POST',
+        });
+    };
 
     return (
         <>
             <UIButton
                 variant={variant}
                 onClick={() => {
-                    if (hasDialog) setOpen(true);
+                    void handleClick();
                 }}
                 className="cursor-pointer"
             >


### PR DESCRIPTION
### Motivation
- Enable server-driven buttons to trigger app endpoints so a button can call an app-relative URL (e.g. `/sample`) to perform exports, backend actions, or page reloads.

### Description
- Added an optional `url: str | None` property and a fluent `click(url)` helper to the SDK `Button` so authors can configure endpoint calls, and serialized `url` in the button props (`sdk/longlink/ui/button.py`).
- Updated container helpers to accept and forward an optional `url` parameter when creating buttons in `Page`, `Hero`, `Tab`, `MenuSubSection`, `MenuSection`, `Column`, and `Card` so app authors can declare clickable endpoints from those contexts (`sdk/longlink/ui/*.py`).
- Implemented web renderer logic for longlink buttons to accept `url`, normalize the path, obtain the current `app` via `useParams()`, and POST to the app endpoint using `apiFetch` at `/apps/{app}/{url}` while preserving dialog-open behavior (`web/src/components/longlink/Button.tsx`).

### Testing
- Ran web formatting with `bun run format`, which completed successfully.
- Attempted a web build with `bun run build`, which failed due to pre-existing TypeScript issues unrelated to these Button changes (errors in `resizable.tsx`, `sidebar.tsx`, `Longlink.tsx`, and `People.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c872266c83238748f8c94e162c9a)