### PR TITLE
Split select into standalone SDK/UI component

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -3,3 +3,5 @@ from .app import LongLink
 from .router import Router
 
 from longlink.ui.textarea import Textarea
+
+from longlink.ui.select import Select

--- a/sdk/longlink/ui/dialog.py
+++ b/sdk/longlink/ui/dialog.py
@@ -5,6 +5,7 @@ from typing import Any
 
 # Import Components
 from .input import Input, InputKinds
+from .select import Select
 from .range import Range
 
 
@@ -29,7 +30,6 @@ class Dialog(Component):
         value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
-        options: list[dict[str, str]] | None = None,
         required: bool = False,
         disabled: bool = False,
         submit: str | None = None,
@@ -41,13 +41,38 @@ class Dialog(Component):
             value=value,
             placeholder=placeholder,
             description=description,
-            options=options,
             required=required,
             disabled=disabled,
             submit=submit,
         )
         self._components.append(input_component)
         return input_component
+
+    def select(
+        self,
+        options: list[dict[str, str]],
+        name: str | None = None,
+        label: str | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        description: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        submit: str | None = None,
+    ) -> Select:
+        select_component = Select(
+            options=options,
+            name=name,
+            label=label,
+            value=value,
+            placeholder=placeholder,
+            description=description,
+            required=required,
+            disabled=disabled,
+            submit=submit,
+        )
+        self._components.append(select_component)
+        return select_component
 
 
     def range(

--- a/sdk/longlink/ui/menu.py
+++ b/sdk/longlink/ui/menu.py
@@ -6,6 +6,7 @@ from typing import Any
 from longlink.ui.tabs import Tab, Tabs
 from longlink.ui.hero import Hero
 from longlink.ui.input import Input, InputKinds
+from longlink.ui.select import Select
 from longlink.ui.table import Table
 from longlink.ui.separator import Separator
 from longlink.ui.columns import Column, Columns
@@ -79,7 +80,6 @@ class MenuSubSection(Component):
         value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
-        options: list[dict[str, str]] | None = None,
         required: bool = False,
         disabled: bool = False,
         submit: str | None = None,
@@ -92,13 +92,39 @@ class MenuSubSection(Component):
             value=value,
             placeholder=placeholder,
             description=description,
-            options=options,
             required=required,
             disabled=disabled,
             submit=submit,
         )
         self._children.append(input_component)
         return input_component
+
+    def select(
+        self,
+        options: list[dict[str, str]],
+        name: str | None = None,
+        label: str | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        description: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        submit: str | None = None,
+    ) -> Select:
+        """Append a Select component."""
+        select_component = Select(
+            options=options,
+            name=name,
+            label=label,
+            value=value,
+            placeholder=placeholder,
+            description=description,
+            required=required,
+            disabled=disabled,
+            submit=submit,
+        )
+        self._children.append(select_component)
+        return select_component
 
     def tabs(self, names: list[str]) -> list[Tab]:
         """Append a Tabs container."""
@@ -192,7 +218,6 @@ class MenuSection(Component):
         value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
-        options: list[dict[str, str]] | None = None,
         required: bool = False,
         disabled: bool = False,
         submit: str | None = None,
@@ -204,13 +229,38 @@ class MenuSection(Component):
             value=value,
             placeholder=placeholder,
             description=description,
-            options=options,
             required=required,
             disabled=disabled,
             submit=submit,
         )
         self._root._children.append(input_component)
         return input_component
+
+    def select(
+        self,
+        options: list[dict[str, str]],
+        name: str | None = None,
+        label: str | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        description: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        submit: str | None = None,
+    ) -> Select:
+        select_component = Select(
+            options=options,
+            name=name,
+            label=label,
+            value=value,
+            placeholder=placeholder,
+            description=description,
+            required=required,
+            disabled=disabled,
+            submit=submit,
+        )
+        self._root._children.append(select_component)
+        return select_component
 
     def tabs(self, names: list[str]) -> list[Tab]:
         tabs = Tabs()

--- a/sdk/longlink/ui/page.py
+++ b/sdk/longlink/ui/page.py
@@ -4,6 +4,7 @@ from longlink.ui.menu import Menu
 from longlink.ui.table import Table
 from typing import Any
 from longlink.ui.input import Input, InputKinds
+from longlink.ui.select import Select
 from longlink.ui.button import Button, ButtonVariants
 from longlink.ui.columns import Column, Columns
 from longlink.ui.__root__ import Component
@@ -106,7 +107,6 @@ class Page:
         value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
-        options: list[dict[str, str]] | None = None,
         required: bool = False,
         disabled: bool = False,
         submit: str | None = None,
@@ -119,13 +119,39 @@ class Page:
             value=value,
             placeholder=placeholder,
             description=description,
-            options=options,
             required=required,
             disabled=disabled,
             submit=submit,
         )
         self._children.append(input_component)
         return input_component
+
+    def select(
+        self,
+        options: list[dict[str, str]],
+        name: str | None = None,
+        label: str | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        description: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        submit: str | None = None,
+    ) -> Select:
+        """Append a standalone Select component to the page."""
+        select_component = Select(
+            options=options,
+            name=name,
+            label=label,
+            value=value,
+            placeholder=placeholder,
+            description=description,
+            required=required,
+            disabled=disabled,
+            submit=submit,
+        )
+        self._children.append(select_component)
+        return select_component
 
 
     def switch(

--- a/sdk/longlink/ui/select.py
+++ b/sdk/longlink/ui/select.py
@@ -1,46 +1,24 @@
+from dataclasses import dataclass
 import re
-from typing import Literal, TypeAlias, Any
-from dataclasses import dataclass, field
+
 from .__root__ import Component
 
 
-InputKinds: TypeAlias = Literal[
-    "text",
-    "number",
-    "password",
-    "textarea",
-    "date",
-    "datetime",
-    "switch",
-]
-
-
 @dataclass
-class Input(Component):
+class Select(Component):
     """
-    Generic standalone input component.
-
-    Design goals:
-    - Usable independently (not bound to a form container)
-    - Declarative and transport-safe
-    - Backend-driven event handling
-    - Polymorphic via `kind`
-
-    Behavior:
-    - If `submit` is provided, frontend emits a "submit" event.
-    - Otherwise, frontend emits "change" events immediately.
-    - `name` identifies the field in backend handlers.
+    Standalone select component.
 
     Serialization shape:
         {
-            "type": "input",
+            "type": "select",
             "props": {
-                "kind": <InputKinds>,
                 "name": <str>,
                 "label": <str | null>,
-                "value": <Any>,
+                "value": <str | null>,
                 "placeholder": <str | null>,
                 "description": <str | null>,
+                "options": <list[dict[str, str]]>,
                 "required": <bool>,
                 "disabled": <bool>,
                 "submit": <str | null>
@@ -49,53 +27,39 @@ class Input(Component):
         }
     """
 
-    # Core identity
+    options: list[dict[str, str]]
     name: str | None = None
-    kind: InputKinds = "text"
-
-    # UI metadata
     label: str | None = None
-    value: Any = None
+    value: str | None = None
     placeholder: str | None = None
     description: str | None = None
-
-    # State flags
     required: bool = False
     disabled: bool = False
-
-    # Optional inline submit button
     submit: str | None = None
 
     def __post_init__(self) -> None:
-        """
-        Validate configuration constraints.
-        """
         if self.name is None:
             if self.label:
                 normalized = re.sub(r"[^a-z0-9]+", "_", self.label.lower()).strip("_")
-                self.name = normalized or "input"
+                self.name = normalized or "select"
             else:
-                self.name = "input"
-
-        if self.kind == "switch" and self.value is None:
-            self.value = False
+                self.name = "select"
 
     def __iter__(self):
         props = {
-            "kind": self.kind,
             "name": self.name,
             "label": self.label,
             "value": self.value,
             "placeholder": self.placeholder,
             "description": self.description,
+            "options": self.options,
             "required": self.required,
             "disabled": self.disabled,
             "submit": self.submit,
         }
 
-        # Remove None values to keep schema clean
         cleaned = {k: v for k, v in props.items() if v is not None}
 
-        yield "type", "input"
+        yield "type", "select"
         yield "props", cleaned
         yield "children", []

--- a/sdk/longlink/ui/tabs.py
+++ b/sdk/longlink/ui/tabs.py
@@ -5,6 +5,7 @@ from typing import Any
 # Importing components
 from .hero import Hero
 from .input import Input, InputKinds
+from .select import Select
 from .table import Table
 from .columns import Column, Columns
 from .button import Button, ButtonVariants
@@ -89,7 +90,6 @@ class Tab(Component):
         value: Any = None,
         placeholder: str | None = None,
         description: str | None = None,
-        options: list[dict[str, str]] | None = None,
         required: bool = False,
         disabled: bool = False,
         submit: str | None = None,
@@ -106,13 +106,39 @@ class Tab(Component):
             value=value,
             placeholder=placeholder,
             description=description,
-            options=options,
             required=required,
             disabled=disabled,
             submit=submit,
         )
         self._children.append(input_component)
         return input_component
+
+    def select(
+        self,
+        options: list[dict[str, str]],
+        name: str | None = None,
+        label: str | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        description: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        submit: str | None = None,
+    ) -> Select:
+        """Append a standalone Select component to this tab."""
+        select_component = Select(
+            options=options,
+            name=name,
+            label=label,
+            value=value,
+            placeholder=placeholder,
+            description=description,
+            required=required,
+            disabled=disabled,
+            submit=submit,
+        )
+        self._children.append(select_component)
+        return select_component
 
 
     def range(

--- a/sdk/sample/src/pages/input.py
+++ b/sdk/sample/src/pages/input.py
@@ -67,8 +67,7 @@ async def input_page() -> Page:
     )
 
     # Select input
-    page.input(
-        kind="select",
+    page.select(
         label="Select Input",
         options=[
             {"label": "Option 1", "value": "option_1"},

--- a/web/src/components/Render.tsx
+++ b/web/src/components/Render.tsx
@@ -8,6 +8,7 @@ import Input from '@/components/longlink/Input';
 import Menu, { MenuSection, MenuSubSection } from '@/components/longlink/Menu';
 import Range from '@/components/longlink/Range';
 import Separator from '@/components/longlink/Separator';
+import Select from '@/components/longlink/Select';
 import Switch from '@/components/longlink/Switch';
 import Table, { type ApiTableColumn } from '@/components/longlink/Table';
 import Textarea from '@/components/longlink/Textarea';
@@ -27,6 +28,7 @@ const registry = {
     menusection: MenuSection,
     menuSubSection: MenuSubSection,
     input: Input,
+    select: Select,
     switch: Switch,
     checkbox: Checkbox,
     range: Range,

--- a/web/src/components/longlink/Input.tsx
+++ b/web/src/components/longlink/Input.tsx
@@ -2,20 +2,8 @@ import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Input as UIInput } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-
-type InputOption = {
-    label: string;
-    value: string;
-};
 
 type InputProps = {
     name?: string;
@@ -26,13 +14,11 @@ type InputProps = {
         | 'textarea'
         | 'date'
         | 'datetime'
-        | 'select'
         | 'switch';
     label?: string;
     value?: string | number | boolean;
     placeholder?: string;
     description?: string;
-    options?: InputOption[];
     required?: boolean;
     disabled?: boolean;
     submit?: string;
@@ -45,7 +31,6 @@ export function Input({
     value,
     placeholder,
     description,
-    options,
     required,
     disabled,
     submit,
@@ -70,25 +55,6 @@ export function Input({
                     defaultChecked={Boolean(value)}
                     disabled={disabled}
                 />
-            );
-        }
-
-        if (kind === 'select') {
-            return (
-                <Select disabled={disabled} defaultValue={String(value ?? '')}>
-                    <SelectTrigger className="w-full">
-                        <SelectValue
-                            placeholder={placeholder ?? 'Select an option'}
-                        />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {(options ?? []).map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                                {option.label}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
             );
         }
 

--- a/web/src/components/longlink/Select.tsx
+++ b/web/src/components/longlink/Select.tsx
@@ -1,0 +1,84 @@
+import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
+import { Label } from '@/components/ui/label';
+import {
+    Select as UISelect,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+
+type SelectOption = {
+    label: string;
+    value: string;
+};
+
+type SelectProps = {
+    name?: string;
+    label?: string;
+    value?: string;
+    placeholder?: string;
+    description?: string;
+    options?: SelectOption[];
+    required?: boolean;
+    disabled?: boolean;
+    submit?: string;
+};
+
+export function Select({
+    name,
+    label,
+    value,
+    placeholder,
+    description,
+    options,
+    disabled,
+    submit,
+}: SelectProps) {
+    const renderControl = () => (
+        <UISelect
+            name={name}
+            disabled={disabled}
+            defaultValue={String(value ?? '')}
+        >
+            <SelectTrigger className="w-full">
+                <SelectValue placeholder={placeholder ?? 'Select an option'} />
+            </SelectTrigger>
+            <SelectContent>
+                {(options ?? []).map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </UISelect>
+    );
+
+    return (
+        <div className="space-y-2">
+            {label && <Label>{label}</Label>}
+
+            {submit ? (
+                <ButtonGroup className="w-full">
+                    {renderControl()}
+                    <Button
+                        type="button"
+                        className="cursor-pointer"
+                        disabled={disabled}
+                    >
+                        {submit}
+                    </Button>
+                </ButtonGroup>
+            ) : (
+                renderControl()
+            )}
+
+            {description ? (
+                <p className="text-muted-foreground text-sm">{description}</p>
+            ) : null}
+        </div>
+    );
+}
+
+export default Select;


### PR DESCRIPTION
### Motivation
- Decouple the `select` control from the polymorphic `Input` to make `select` a first-class, standalone element with its own schema and behavior.
- Simplify `Input` to only handle text-like, date/datetime, textarea and switch kinds, avoiding select-specific props on the generic input.
- Provide explicit SDK APIs for creating selects from container contexts to keep the server-driven UI model consistent and composable.

### Description
- Added a dedicated SDK `Select` component at `sdk/longlink/ui/select.py` that serializes to `type: "select"` and includes `options`, `submit`, name normalization, and other props.
- Removed `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c7acc2ac832384a1aeba781925fe)