### PR TITLE
Add bulk settings get and set API endpoints

### DIFF
--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -1,4 +1,4 @@
 from .apps import AppCreate, AppResponse
 from .lists.countries import CountryCode
 from .users import UserUpdate
-from .settings import SettingSet, SettingResponse
+from .settings import SettingSet, SettingResponse, SettingSetItem

--- a/api/src/models/settings.py
+++ b/api/src/models/settings.py
@@ -5,6 +5,11 @@ class SettingSet(BaseModel):
     value: str
 
 
+class SettingSetItem(BaseModel):
+    key: str
+    value: str
+
+
 class SettingResponse(BaseModel):
     key: str
     value: str

--- a/api/src/routes/settings.py
+++ b/api/src/routes/settings.py
@@ -1,8 +1,48 @@
-from fastapi import HTTPException
+from typing import List
+
+from fastapi import HTTPException, Query
 
 import src.db as db
-from src.models.settings import SettingResponse, SettingSet
+from src.models.settings import SettingResponse, SettingSet, SettingSetItem
 from src.router import router
+
+
+@router.get('/settings')
+async def get_settings(keys: List[str] = Query(...)) -> List[SettingResponse]:
+    results: List[SettingResponse] = []
+
+    for key in keys:
+        setting = await db.settings.get(key, app_id=None)
+        if setting is None:
+            raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
+
+        results.append(
+            SettingResponse(
+                key=setting.key,
+                value=setting.value,
+                app_id=setting.appid,
+            )
+        )
+
+    return results
+
+
+@router.put('/settings')
+async def set_settings(payload: List[SettingSetItem]) -> List[SettingResponse]:
+    results: List[SettingResponse] = []
+
+    for item in payload:
+        setting = await db.settings.set(item.key, item.value, app_id=None)
+
+        results.append(
+            SettingResponse(
+                key=setting.key,
+                value=setting.value,
+                app_id=setting.appid,
+            )
+        )
+
+    return results
 
 
 @router.get('/settings/{key}')


### PR DESCRIPTION
### Motivation

- Add API support to fetch and save multiple settings in a single request to reduce round-trips and simplify client code. 
- Preserve existing single-key endpoints for backward compatibility while exposing bulk operations.

### Description

- Added a new request model `SettingSetItem` with `key` and `value` fields in `api/src/models/settings.py` to represent individual items for bulk updates.
- Implemented `GET /settings` in `api/src/routes/settings.py` which accepts `keys` as a `Query` list and returns `List[SettingResponse]`, returning `404` if any requested key is not found.
- Implemented `PUT /settings` in `api/src/routes/settings.py` which accepts `List[SettingSetItem]` and saves each setting via `db.settings.set`, returning the saved `SettingResponse` entries.
- Exported the new model from `api/src/models/__init__.py` so it is available through the project's models package.

### Testing

- Ran `python -m compileall api/src/routes/settings.py api/src/models/settings.py api/src/models/__init__.py` and compilation completed successfully. 
- Basic static validation performed by compiling the modified modules succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c909f2dc83238e0d43fd307bd77b)