### PR TITLE
Remove switch option from generic Input component

### DIFF
--- a/sdk/longlink/ui/input.py
+++ b/sdk/longlink/ui/input.py
@@ -11,7 +11,6 @@ InputKinds: TypeAlias = Literal[
     "textarea",
     "date",
     "datetime",
-    "switch",
 ]
 
 
@@ -76,9 +75,6 @@ class Input(Component):
                 self.name = normalized or "input"
             else:
                 self.name = "input"
-
-        if self.kind == "switch" and self.value is None:
-            self.value = False
 
     def __iter__(self):
         props = {

--- a/sdk/sample/src/pages/input.py
+++ b/sdk/sample/src/pages/input.py
@@ -77,13 +77,6 @@ async def input_page() -> Page:
         submit="Save",
     )
 
-    # Switch input
-    page.input(
-        kind="switch",
-        label="Switch Input",
-        description="Toggle this setting on or off.",
-        submit="Save",
-    )
 
     page.switch(
         label="Switch Input",

--- a/web/src/components/longlink/Input.tsx
+++ b/web/src/components/longlink/Input.tsx
@@ -2,19 +2,11 @@ import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Input as UIInput } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 
 type InputProps = {
     name?: string;
-    kind?:
-        | 'text'
-        | 'number'
-        | 'password'
-        | 'textarea'
-        | 'date'
-        | 'datetime'
-        | 'switch';
+    kind?: 'text' | 'number' | 'password' | 'textarea' | 'date' | 'datetime';
     label?: string;
     value?: string | number | boolean;
     placeholder?: string;
@@ -43,16 +35,6 @@ export function Input({
                     placeholder={placeholder}
                     defaultValue={typeof value === 'string' ? value : undefined}
                     required={required}
-                    disabled={disabled}
-                />
-            );
-        }
-
-        if (kind === 'switch') {
-            return (
-                <Switch
-                    name={name}
-                    defaultChecked={Boolean(value)}
                     disabled={disabled}
                 />
             );


### PR DESCRIPTION
### Motivation

- Avoid duplicate representations of the same control by removing the `switch` variant from the generic `Input` component and rely on the dedicated `Switch` element. 
- Keep SDK and web runtime consistent so the backend-driven schema does not expose a `switch` kind on the generic input when a proper `page.switch(...)` element exists.

### Description

- Removed `"switch"` from `InputKinds` and deleted switch-specific default-value logic in `sdk/longlink/ui/input.py` so `Input` now supports only text/number/password/textarea/date/datetime. 
- Removed the `switch` branch and its import from `web/src/components/longlink/Input.tsx` and tightened the TS `kind` union to exclude `switch`. 
- Updated the sample page `sdk/sample/src/pages/input.py` to stop using `page.input(kind="switch")` and kept the standalone `page.switch(...)` usage. 
- Ran formatting in the web workspace and committed the three updated files.

### Testing

- Ran `bun run format` in the `web` workspace and formatting completed successfully. 
- Verified Python files by running `python -m py_compile sdk/longlink/ui/input.py sdk/sample/src/pages/input.py`, which succeeded. 
- Ran `bun run lint` in `web`, which failed due to pre-existing lint errors in unrelated files (`Menu.tsx`, `ui/menu.tsx`, and `lib/navigation.ts`) and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c9ec9b28832386d4c55b2b9fa8b7)