### PR TITLE
Use shadcn date picker for date and datetime inputs

### DIFF
--- a/web/src/components/longlink/Input.tsx
+++ b/web/src/components/longlink/Input.tsx
@@ -1,8 +1,17 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
+import { format, isValid, parse } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import { Calendar } from '@/components/ui/calendar';
 import { Input as UIInput } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
 import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 import { apiFetch } from '@/lib/api';
 
 type InputProps = {
@@ -15,6 +24,38 @@ type InputProps = {
     required?: boolean;
     disabled?: boolean;
     submit?: string;
+};
+
+const DATE_FORMAT = 'yyyy-MM-dd';
+const DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm";
+
+const parseDateValue = (rawValue: string): Date | undefined => {
+    if (!rawValue) {
+        return undefined;
+    }
+
+    const parsed = parse(rawValue.slice(0, 10), DATE_FORMAT, new Date());
+
+    return isValid(parsed) ? parsed : undefined;
+};
+
+const parseDatetimeValue = (
+    rawValue: string
+): { date?: Date; time: string } => {
+    if (!rawValue) {
+        return { date: undefined, time: '00:00' };
+    }
+
+    const parsed = parse(rawValue.slice(0, 16), DATETIME_FORMAT, new Date());
+
+    if (isValid(parsed)) {
+        return { date: parsed, time: format(parsed, 'HH:mm') };
+    }
+
+    return {
+        date: parseDateValue(rawValue),
+        time: rawValue.slice(11, 16) || '00:00',
+    };
 };
 
 export function Input({
@@ -37,6 +78,14 @@ export function Input({
         return '';
     }, [value]);
     const previousValueRef = useRef(defaultFieldValue);
+    const [selectedDate, setSelectedDate] = useState<Date | undefined>(() =>
+        kind === 'date' ? parseDateValue(defaultFieldValue) : undefined
+    );
+    const [selectedDateTime, setSelectedDateTime] = useState<
+        { date?: Date; time: string } | undefined
+    >(() =>
+        kind === 'datetime' ? parseDatetimeValue(defaultFieldValue) : undefined
+    );
 
     const normalizedSubmitPath = (submit ?? '').replace(/^\/+|\/+$/g, '');
 
@@ -76,12 +125,126 @@ export function Input({
             );
         }
 
-        const type = kind === 'datetime' ? 'datetime-local' : kind;
+        if (kind === 'date') {
+            return (
+                <Popover>
+                    <PopoverTrigger
+                        disabled={disabled}
+                        className={cn(
+                            'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring inline-flex h-9 w-full items-center justify-start rounded-md border px-3 py-2 text-sm font-normal shadow-xs focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+                            !selectedDate && 'text-muted-foreground'
+                        )}
+                    >
+                        <CalendarIcon className="mr-2 size-4" />
+                        {selectedDate ? (
+                            format(selectedDate, 'PPP')
+                        ) : (
+                            <span>{placeholder ?? 'Pick a date'}</span>
+                        )}
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                            mode="single"
+                            selected={selectedDate}
+                            onSelect={(nextDate) => {
+                                setSelectedDate(nextDate);
+                                void handleBlur(
+                                    nextDate
+                                        ? format(nextDate, DATE_FORMAT)
+                                        : ''
+                                );
+                            }}
+                        />
+                    </PopoverContent>
+                </Popover>
+            );
+        }
+
+        if (kind === 'datetime') {
+            const datetimeValue = selectedDateTime ?? {
+                date: undefined,
+                time: '00:00',
+            };
+
+            return (
+                <div className="space-y-2">
+                    <Popover>
+                        <PopoverTrigger
+                            disabled={disabled}
+                            className={cn(
+                                'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring inline-flex h-9 w-full items-center justify-start rounded-md border px-3 py-2 text-sm font-normal shadow-xs focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+                                !datetimeValue.date && 'text-muted-foreground'
+                            )}
+                        >
+                            <CalendarIcon className="mr-2 size-4" />
+                            {datetimeValue.date ? (
+                                format(datetimeValue.date, 'PPP')
+                            ) : (
+                                <span>{placeholder ?? 'Pick a date'}</span>
+                            )}
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar
+                                mode="single"
+                                selected={datetimeValue.date}
+                                onSelect={(nextDate) => {
+                                    const nextValue = {
+                                        ...datetimeValue,
+                                        date: nextDate,
+                                    };
+
+                                    setSelectedDateTime(nextValue);
+                                    void handleBlur(
+                                        nextDate
+                                            ? format(
+                                                  new Date(
+                                                      `${format(nextDate, DATE_FORMAT)}T${nextValue.time}`
+                                                  ),
+                                                  DATETIME_FORMAT
+                                              )
+                                            : ''
+                                    );
+                                }}
+                            />
+                        </PopoverContent>
+                    </Popover>
+
+                    <UIInput
+                        name={name}
+                        type="time"
+                        value={datetimeValue.time}
+                        required={required}
+                        disabled={disabled}
+                        onChange={(event) => {
+                            const nextTime = event.currentTarget.value;
+                            setSelectedDateTime({
+                                ...datetimeValue,
+                                time: nextTime,
+                            });
+                        }}
+                        onBlur={(event) => {
+                            if (!datetimeValue.date) {
+                                return;
+                            }
+
+                            void handleBlur(
+                                format(
+                                    new Date(
+                                        `${format(datetimeValue.date, DATE_FORMAT)}T${event.currentTarget.value}`
+                                    ),
+                                    DATETIME_FORMAT
+                                )
+                            );
+                        }}
+                    />
+                </div>
+            );
+        }
 
         return (
             <UIInput
                 name={name}
-                type={type}
+                type={kind}
                 placeholder={placeholder}
                 defaultValue={defaultFieldValue}
                 required={required}


### PR DESCRIPTION
### Motivation
- Replace native `type="date"`/`datetime-local` inputs with a consistent shadcn-style calendar popover to improve UX and match the app's component patterns.
- Ensure existing string values initialize correctly and remain serialized in API-friendly formats when sent back to the server.

### Description
- Reworked `web/src/components/longlink/Input.tsx` to render a shadcn-style `Calendar` inside a `Popover` for `kind="date"` and a calendar + `time` input for `kind="datetime"` using `Popover`, `Calendar`, and `CalendarIcon` components.
- Added parsing and formatting helpers `parseDateValue`, `parseDatetimeValue`, and constants `DATE_FORMAT` / `DATETIME_FORMAT` so existing values initialize the calendar/time controls and submissions are formatted as `yyyy-MM-dd` and `yyyy-MM-dd'T'HH:mm`.
- Kept the original blur-based submit behavior via `handleBlur` + `apiFetch`, serializing the selected date/time before sending to the API, and added small utility imports (`date-fns`, `cn`) required by the new controls.

### Testing
- Ran code formatting with `bun run format`, which completed successfully.
- Ran lint on the updated file with `bunx eslint src/components/longlink/Input.tsx`, which reported no errors.
- Attempted a full build with `bun run build`, which failed due to unrelated pre-existing TypeScript errors in other files outside this change, so the new component changes were validated locally but full project build is blocked by unrelated issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cdbb509883239a9887c67715abf9)