### PR TITLE
web: keep datetime date and time controls on one row

### DIFF
--- a/web/src/components/longlink/Input.tsx
+++ b/web/src/components/longlink/Input.tsx
@@ -167,7 +167,7 @@ export function Input({
             };
 
             return (
-                <div className="space-y-2">
+                <div className="flex items-center gap-2">
                     <Popover>
                         <PopoverTrigger
                             disabled={disabled}
@@ -215,6 +215,7 @@ export function Input({
                         value={datetimeValue.time}
                         required={required}
                         disabled={disabled}
+                        className="w-36 shrink-0"
                         onChange={(event) => {
                             const nextTime = event.currentTarget.value;
                             setSelectedDateTime({


### PR DESCRIPTION
### Motivation
- Ensure that when both a date and a time are present the UI renders the date picker trigger and the time input on the same horizontal line for better visual grouping and usability.

### Description
- Changed the datetime control wrapper in `web/src/components/longlink/Input.tsx` from vertical spacing to a horizontal layout by replacing `className="space-y-2"` with `className="flex items-center gap-2"`.
- Constrained the time input width by adding `className="w-36 shrink-0"` to the time `UIInput` so the time field stays adjacent to the date control and does not wrap.
- Preserved existing parsing and submission logic for datetime values (`parseDatetimeValue`, formatting with `DATE_FORMAT`/`DATETIME_FORMAT`, and `handleBlur` behavior).

### Testing
- Ran `bun run format` in the `web` package which completed successfully as required by project pre-commit hooks.
- Attempted `bun run build` in the `web` package which failed due to existing unrelated TypeScript errors in other files, and the change in this PR did not introduce new build errors in the edited file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d23ead808323aa68cf005d1dee91)