### PR TITLE
feat(sample): add SDK button on sample input page to call /sample

### DIFF
--- a/sdk/sample/src/pages/input.py
+++ b/sdk/sample/src/pages/input.py
@@ -90,4 +90,9 @@ async def input_page() -> Page:
         checked=True,
     )
 
+    page.button(
+        text="Call /sample endpoint",
+        variant="secondary",
+    ).click("/sample")
+
     return page


### PR DESCRIPTION
### Motivation
- Provide a simple click example on the sample input page demonstrating how to use the SDK `Button` to call a backend endpoint (`/sample`).

### Description
- Added `page.button(text="Call /sample endpoint", variant="secondary").click("/sample")` to `sdk/sample/src/pages/input.py` so the sample page exposes a button that triggers the `/sample` endpoint when clicked.

### Testing
- Compiled the updated page with `python -m compileall sdk/sample/src/pages/input.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4367e0c6c8323bb729b6bd95c20c3)