### PR TITLE
docs(sdk): add markdown reference files for SDK UI components

### DIFF
--- a/ARC/ui/button.md
+++ b/ARC/ui/button.md
@@ -1,0 +1,17 @@
+# Button
+
+`Button` triggers backend-driven actions from the UI.
+
+## Purpose
+- Call an app endpoint (`url`) when clicked.
+- Optionally open a `Dialog` as a child interaction flow.
+
+## Main properties
+- `text` (str): label shown in the button.
+- `variant`: visual style (`default`, `outline`, `secondary`, `ghost`, `destructive`, `link`).
+- `url` (optional str): backend endpoint to call.
+
+## Behavior
+- `.click(url)` sets the backend action endpoint.
+- `.dialog(confirm, cancel)` attaches a modal dialog child.
+- Serializes as `type: button` with `props` and optional `children`.

--- a/ARC/ui/card.md
+++ b/ARC/ui/card.md
@@ -1,0 +1,15 @@
+# Card
+
+`Card` is a visual container used to group related content.
+
+## Purpose
+- Structure content in vertically stacked blocks.
+- Optionally show `title` and `subtitle` metadata.
+
+## Main properties
+- `title` (optional str)
+- `subtitle` (optional str)
+
+## Behavior
+- Supports composition helpers (`hero`, `table`, `input`, `button`, `columns`, `separator`, `tabs`, `range`, `add`).
+- Serializes as `type: card` with nested children.

--- a/ARC/ui/checkbox.md
+++ b/ARC/ui/checkbox.md
@@ -1,0 +1,13 @@
+# Checkbox
+
+`Checkbox` is a standalone boolean input component.
+
+## Main properties
+- `label` (optional str)
+- `description` (optional str)
+- `checked` (bool, default `False`)
+
+## Behavior
+- Serializes as `type: checkbox`.
+- Produces no children.
+- Omits `None` optional fields from serialized props.

--- a/ARC/ui/columns.md
+++ b/ARC/ui/columns.md
@@ -1,0 +1,17 @@
+# Columns and Column
+
+`Columns` defines a horizontal layout, and `Column` is each vertical lane inside it.
+
+## Purpose
+- Build explicit horizontal grouping in the server-driven layout.
+- Populate each column with nested components.
+
+## Column
+- Property: `width` (relative width/weight).
+- Accepts composed children (hero, table, input, button, separator, tabs, range, etc.).
+- Serializes as `type: column`.
+
+## Columns
+- Holds an ordered list of `Column` items.
+- `.column(width)` appends a new column and returns it.
+- Serializes as `type: columns` with child columns.

--- a/ARC/ui/component.md
+++ b/ARC/ui/component.md
@@ -1,0 +1,14 @@
+# Component (Base Class)
+
+`Component` is the abstract base for SDK UI elements.
+
+## Purpose
+- Enforce the common server-driven serialization contract.
+- Standardize output shape as:
+  - `type`
+  - `props`
+  - `children`
+
+## Behavior
+- `__iter__` emits a minimal default schema.
+- Concrete components override/extend serialization as needed.

--- a/ARC/ui/dialog.md
+++ b/ARC/ui/dialog.md
@@ -1,0 +1,12 @@
+# Dialog
+
+`Dialog` is a modal container used for confirm/cancel interactions.
+
+## Main properties
+- `confirm` (str, default `Confirm`)
+- `cancel` (str, default `Cancel`)
+
+## Behavior
+- Can contain nested UI children.
+- Often attached from `Button.dialog(...)`.
+- Serializes as `type: dialog`.

--- a/ARC/ui/form.md
+++ b/ARC/ui/form.md
@@ -1,0 +1,14 @@
+# Form and FormRow
+
+`Form` is a submission boundary for backend-driven input handling. `FormRow` enables horizontal grouping inside a form.
+
+## Form
+- Main properties include form metadata such as labels/actions and submit endpoint.
+- Owns child components and emits an atomic submit event.
+- Provides helpers to add inputs/selects/buttons and row groups.
+- Serializes as `type: form`.
+
+## FormRow
+- Lightweight horizontal row container inside a form.
+- Used to place related controls side by side.
+- Serializes as `type: form-row`.

--- a/ARC/ui/hero.md
+++ b/ARC/ui/hero.md
@@ -1,0 +1,11 @@
+# Hero
+
+`Hero` is a heading/introduction component for sections and pages.
+
+## Main properties
+- `title` (str)
+- `subtitle` (optional str)
+
+## Behavior
+- Displays high-level context for a page or block.
+- Serializes as `type: hero`.

--- a/ARC/ui/input.md
+++ b/ARC/ui/input.md
@@ -1,0 +1,16 @@
+# Input
+
+`Input` is a polymorphic field component used for text and other primitive input kinds.
+
+## Purpose
+- Single reusable field model with a `kind` discriminator.
+- Works standalone or within containers like forms/tabs/cards.
+
+## Main properties
+- `name`, `kind`, `label`, `value`, `placeholder`, `description`
+- `required`, `disabled`
+- `submit` (optional endpoint for event-driven submission)
+
+## Behavior
+- Serializes as `type: input` with normalized props.
+- Frontend renders; backend owns validation/business logic.

--- a/ARC/ui/menu.md
+++ b/ARC/ui/menu.md
@@ -1,0 +1,18 @@
+# Menu, MenuSection, and MenuSubSection
+
+The menu elements define hierarchical navigation.
+
+## Menu
+- Root navigation container.
+- Holds ordered `MenuSection` entries.
+- Serializes as `type: menu`.
+
+## MenuSection
+- First-level group in the menu.
+- Can contain direct pages/actions and nested subsections.
+- Serializes as `type: menu-section`.
+
+## MenuSubSection
+- Nested grouping level under a section.
+- Used to structure larger navigation trees.
+- Serializes as `type: menu-sub-section`.

--- a/ARC/ui/page.md
+++ b/ARC/ui/page.md
@@ -1,0 +1,12 @@
+# Page
+
+`Page` is the root UI container returned by SDK handlers.
+
+## Purpose
+- Top-level composition boundary for all visible components.
+- Defines metadata such as page title and optional navigation context.
+
+## Behavior
+- Exposes helper methods to add supported child components.
+- Serializes to the canonical server-driven schema (`type`, `props`, `children`).
+- Serves as the primary payload consumed by the frontend renderer.

--- a/ARC/ui/range.md
+++ b/ARC/ui/range.md
@@ -1,0 +1,13 @@
+# Range
+
+`Range` is a numeric interval selector.
+
+## Main properties
+- `label` (optional str)
+- `description` (optional str)
+- `min`, `max`, `step`
+- `value` (usually `[min_value, max_value]`)
+
+## Behavior
+- Represents bounded numeric ranges for filtering or thresholds.
+- Serializes as `type: range`.

--- a/ARC/ui/select.md
+++ b/ARC/ui/select.md
@@ -1,0 +1,14 @@
+# Select
+
+`Select` is a standalone option picker.
+
+## Main properties
+- `options` (list of option objects)
+- `name`, `label`, `value`, `placeholder`, `description`
+- `required`, `disabled`
+- `submit` (optional endpoint/event target)
+
+## Behavior
+- Renders a controlled list of options.
+- Can be used inside forms or as a standalone interactive field.
+- Serializes as `type: select`.

--- a/ARC/ui/separator.md
+++ b/ARC/ui/separator.md
@@ -1,0 +1,10 @@
+# Separator
+
+`Separator` is a visual divider between components.
+
+## Purpose
+- Improve readability by splitting logical groups.
+- Carry no business logic and no interactive behavior.
+
+## Behavior
+- Serializes as `type: separator` with empty/default props.

--- a/ARC/ui/switch.md
+++ b/ARC/ui/switch.md
@@ -1,0 +1,12 @@
+# Switch
+
+`Switch` is a toggle control for on/off state.
+
+## Main properties
+- `label` (optional str)
+- `description` (optional str)
+- `checked` / current boolean state
+
+## Behavior
+- Represents boolean preference or feature toggles.
+- Serializes as `type: switch`.

--- a/ARC/ui/table.md
+++ b/ARC/ui/table.md
@@ -1,0 +1,16 @@
+# Table and Table Column
+
+`Table` renders structured row data, and its table-specific `Column` describes per-column presentation.
+
+## Table
+- Main property: `data` (`list[dict]`) as raw row payload.
+- Supports column definitions for labels, keys, and display behavior.
+- Serializes as `type: table`.
+
+## Table Column
+- Column metadata model used by `Table`.
+- Defines field binding and presentation semantics.
+- Serializes as `type: column` in table context.
+
+## Cell model
+- Supports value metadata like text, bold style, and optional link.

--- a/ARC/ui/tabs.md
+++ b/ARC/ui/tabs.md
@@ -1,0 +1,14 @@
+# Tabs and Tab
+
+`Tabs` organizes content into switchable views. `Tab` is one named tab panel.
+
+## Tabs
+- Maintains ordered tab names.
+- Owns child `Tab` components.
+- `.tab(name)` appends and returns a tab.
+- Serializes as `type: tabs` with `tabs` metadata.
+
+## Tab
+- Property: `name`.
+- Hosts child components (hero/table/button/columns/input/select/range/etc.).
+- Serializes as `type: tab`.

--- a/ARC/ui/textarea.md
+++ b/ARC/ui/textarea.md
@@ -1,0 +1,13 @@
+# Textarea
+
+`Textarea` is a multiline text input component.
+
+## Main properties
+- `label` (optional str)
+- `placeholder` (optional str)
+- `description` (optional str)
+
+## Behavior
+- Serializes as `type: textarea`.
+- Emits no children.
+- Optional `None` fields are excluded from serialized props.


### PR DESCRIPTION
### Motivation
- Provide concise, per-component documentation for the server-driven SDK UI to help authors understand component intent and serialization shape.  
- Capture composition patterns and key props for layout, inputs, containers and navigation elements used by the frontend renderer.  
- Centralize UI element references under `ARC/ui` to make SDK UI concepts discoverable and maintainable.

### Description
- Added a set of markdown reference files under `ARC/ui` (one file per SDK UI element) describing purpose, main properties, behavior, and serialization for components such as `Button`, `Card`, `Input`, `Form`/`FormRow`, `Tabs`/`Tab`, `Table`/`Column`, `Menu` hierarchy, `Page`, and the base `Component`.  
- Files explicitly document server-driven aspects (props, children, event/submit semantics and omission of None fields) and composition helpers exposed by container components.  
- No runtime SDK code was modified; this change is documentation-only and complements existing `sdk/longlink/ui` implementations.

### Testing
- Confirmed the new documentation files exist with `find ARC/ui -maxdepth 1 -type f | sort` and listed the created files.  
- Verified the documentation files are present in the repository and being tracked by the VCS.  
- No unit tests were added or modified as this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a439a4d3cc8323a3d51ca510c84ef8)