### PR TITLE
feat(api): add CRUD support for root database connections

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -31,6 +31,7 @@ app.add_middleware(
 # Register routers
 import src.routes.apps
 import src.routes.auth
+import src.routes.databases
 import src.routes.user
 import src.routes.users
 import src.routes.sample

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,7 +1,8 @@
-from .models import App, Env, Setting, User
-from .services import AppsService, EnvsService, SettingsService, UsersService
+from .models import App, Database, Env, Setting, User
+from .services import AppsService, DatabasesService, EnvsService, SettingsService, UsersService
 
 apps = AppsService()
+databases = DatabasesService()
 envs = EnvsService()
 settings = SettingsService()
 users = UsersService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -1,6 +1,7 @@
 # Import all models here to ensure they are registered with Base
 from .__base__ import Base
 from .apps import App
+from .databases import Database
 from .envs import Env
 from .settings import Setting
 from .users import User

--- a/api/src/db/models/databases.py
+++ b/api/src/db/models/databases.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class Database(Base):
+    '''Represent a root database server connection used by the control panel.'''
+    __tablename__ = 'databases'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    type: Mapped[str] = mapped_column(String(32), nullable=False, default='postgresql')
+    host: Mapped[str] = mapped_column(String(255), nullable=False)
+    port: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    username: Mapped[str] = mapped_column(String(255), nullable=False)
+    password: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # Timestamp informations
+    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -1,4 +1,5 @@
 from .apps import AppsService
+from .databases import DatabasesService
 from .envs import EnvsService
 from .settings import SettingsService
 from .users import UsersService

--- a/api/src/db/services/databases.py
+++ b/api/src/db/services/databases.py
@@ -1,0 +1,98 @@
+from sqlalchemy import select
+
+from src.db.models import Database
+from src.db.session import get_session
+
+
+class DatabasesService:
+    async def list(self) -> list[Database]:
+        '''Return all configured database root connections.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Database)
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
+    async def get(self, database_id: int) -> Database | None:
+        '''Return a database root connection by id.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Database).where(Database.id == database_id)
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        *,
+        type: str,
+        host: str,
+        port: int,
+        name: str,
+        username: str,
+        password: str,
+    ) -> Database:
+        '''Create a database root connection.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            database = Database(
+                type=type,
+                host=host,
+                port=port,
+                name=name,
+                username=username,
+                password=password,
+            )
+            session.add(database)
+            await session.commit()
+            await session.refresh(database)
+            return database
+
+    async def update(
+        self,
+        database_id: int,
+        *,
+        type: str,
+        host: str,
+        port: int,
+        name: str,
+        username: str,
+        password: str,
+    ) -> Database | None:
+        '''Update a database root connection.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Database).where(Database.id == database_id)
+            result = await session.execute(statement)
+            database = result.scalar_one_or_none()
+            if database is None:
+                return None
+
+            database.type = type
+            database.host = host
+            database.port = port
+            database.name = name
+            database.username = username
+            database.password = password
+
+            await session.commit()
+            await session.refresh(database)
+            return database
+
+    async def delete(self, database_id: int) -> bool:
+        '''Delete a database root connection by id.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Database).where(Database.id == database_id)
+            result = await session.execute(statement)
+            database = result.scalar_one_or_none()
+            if database is None:
+                return False
+
+            await session.delete(database)
+            await session.commit()
+            return True

--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -1,4 +1,5 @@
 from .apps import AppCreate, AppResponse
+from .databases import DatabaseCreate, DatabaseResponse, DatabaseUpdate
 from .lists.countries import CountryCode
+from .settings import SettingResponse, SettingSet, SettingSetItem
 from .users import UserUpdate
-from .settings import SettingSet, SettingResponse, SettingSetItem

--- a/api/src/models/databases.py
+++ b/api/src/models/databases.py
@@ -1,0 +1,32 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class DatabaseCreate(BaseModel):
+    type: Literal['postgresql'] = 'postgresql'
+    host: str
+    port: int
+    name: str
+    username: str
+    password: str
+
+
+class DatabaseUpdate(BaseModel):
+    type: Literal['postgresql'] = 'postgresql'
+    host: str
+    port: int
+    name: str
+    username: str
+    password: str
+
+
+class DatabaseResponse(BaseModel):
+    id: int
+    type: str
+    host: str
+    port: int
+    name: str
+    username: str
+    password: str
+    connection_url: str

--- a/api/src/routes/databases.py
+++ b/api/src/routes/databases.py
@@ -1,0 +1,63 @@
+from fastapi import HTTPException
+
+import src.db as db
+from src.models.databases import DatabaseCreate, DatabaseResponse, DatabaseUpdate
+from src.router import router
+
+
+def to_response(database: db.Database) -> DatabaseResponse:
+    return DatabaseResponse(
+        id=database.id,
+        type=database.type,
+        host=database.host,
+        port=database.port,
+        name=database.name,
+        username=database.username,
+        password=database.password,
+        connection_url=f'{database.type}://{database.username}:{database.password}@{database.host}:{database.port}/{database.name}',
+    )
+
+
+@router.get('/databases')
+async def list_databases() -> list[DatabaseResponse]:
+    databases = await db.databases.list()
+    return [to_response(database) for database in databases]
+
+
+@router.post('/databases')
+async def create_database(payload: DatabaseCreate) -> DatabaseResponse:
+    database = await db.databases.create(
+        type=payload.type,
+        host=payload.host,
+        port=payload.port,
+        name=payload.name,
+        username=payload.username,
+        password=payload.password,
+    )
+    return to_response(database)
+
+
+@router.put('/databases/{database_id}')
+async def edit_database(database_id: int, payload: DatabaseUpdate) -> DatabaseResponse:
+    database = await db.databases.update(
+        database_id,
+        type=payload.type,
+        host=payload.host,
+        port=payload.port,
+        name=payload.name,
+        username=payload.username,
+        password=payload.password,
+    )
+    if database is None:
+        raise HTTPException(status_code=404, detail='Database not found')
+
+    return to_response(database)
+
+
+@router.delete('/databases/{database_id}')
+async def remove_database(database_id: int) -> dict[str, bool]:
+    deleted = await db.databases.delete(database_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail='Database not found')
+
+    return {'deleted': True}


### PR DESCRIPTION
### Motivation
- Provide a way for the control panel to store root/admin database server credentials so it can create app-specific databases on demand. 
- Expose CRUD operations so operators can add, update, list and remove these root connections from the API. 
- Start with `postgresql` as the supported `type` and return a standard connection string (`protocol://username:password@host:port/database`) for convenience.

### Description
- Added a new ORM model `Database` (`src/db/models/databases.py`) with fields `type`, `host`, `port`, `name`, `username`, `password` and timestamps. 
- Implemented `DatabasesService` (`src/db/services/databases.py`) with `list`, `get`, `create`, `update` and `delete` methods and exported it via `src/db/__init__.py`. 
- Added Pydantic request/response schemas (`src/models/databases.py`) and REST endpoints (`src/routes/databases.py`) for `GET /databases`, `POST /databases`, `PUT /databases/{database_id}` and `DELETE /databases/{database_id}`, including a computed `connection_url` string. 
- Wired route registration into startup (`main.py`) and updated module exports (`src/db/models/__init__.py`, `src/db/services/__init__.py`, `src/models/__init__.py`) so the new model/service/routes are loaded by the application.

### Testing
- Ran a static compile check with `python -m compileall src main.py`, which completed successfully and compiled the new modules. 
- Attempted a runtime CRUD smoke script against `db.databases` but it failed to run due to a missing dependency (`ModuleNotFoundError: No module named 'pydantic_settings'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a467eb1a0483239585102b49735e25)