### PR TITLE
docs(ui): add SDK and web metadata frontmatter to UI component docs

### DIFF
--- a/arc/ui/button.md
+++ b/arc/ui/button.md
@@ -1,5 +1,7 @@
 ---
 component: Button
+sdk: longlink/ui/button.py
+web: src/components/longlink/Button.tsx
 ---
 
 # Button

--- a/arc/ui/card.md
+++ b/arc/ui/card.md
@@ -1,3 +1,9 @@
+---
+component: Card
+sdk: longlink/ui/card.py
+web: src/components/longlink/Card.tsx
+---
+
 # Card
 
 `Card` is a visual container used to group related content.

--- a/arc/ui/checkbox.md
+++ b/arc/ui/checkbox.md
@@ -1,3 +1,9 @@
+---
+component: Checkbox
+sdk: longlink/ui/checkbox.py
+web: src/components/longlink/Checkbox.tsx
+---
+
 # Checkbox
 
 `Checkbox` is a standalone boolean input component.

--- a/arc/ui/columns.md
+++ b/arc/ui/columns.md
@@ -1,3 +1,9 @@
+---
+component: Columns
+sdk: longlink/ui/columns.py
+web: src/components/longlink/Columns.tsx
+---
+
 # Columns and Column
 
 `Columns` defines a horizontal layout, and `Column` is each vertical lane inside it.

--- a/arc/ui/component.md
+++ b/arc/ui/component.md
@@ -1,3 +1,9 @@
+---
+component: Component
+sdk: longlink/ui/__root__.py
+web: src/components/Render.tsx
+---
+
 # Component (Base Class)
 
 `Component` is the abstract base for SDK UI elements.

--- a/arc/ui/dialog.md
+++ b/arc/ui/dialog.md
@@ -1,3 +1,9 @@
+---
+component: Dialog
+sdk: longlink/ui/dialog.py
+web: src/components/longlink/Dialog.tsx
+---
+
 # Dialog
 
 `Dialog` is a modal container used for confirm/cancel interactions.

--- a/arc/ui/form.md
+++ b/arc/ui/form.md
@@ -1,3 +1,9 @@
+---
+component: Form
+sdk: longlink/ui/form.py
+web: src/components/longlink/Form.tsx
+---
+
 # Form and FormRow
 
 `Form` is a submission boundary for backend-driven input handling. `FormRow` enables horizontal grouping inside a form.

--- a/arc/ui/hero.md
+++ b/arc/ui/hero.md
@@ -1,3 +1,9 @@
+---
+component: Hero
+sdk: longlink/ui/hero.py
+web: src/components/longlink/Hero.tsx
+---
+
 # Hero
 
 `Hero` is a heading/introduction component for sections and pages.

--- a/arc/ui/input.md
+++ b/arc/ui/input.md
@@ -1,3 +1,9 @@
+---
+component: Input
+sdk: longlink/ui/input.py
+web: src/components/longlink/Input.tsx
+---
+
 # Input
 
 `Input` is a polymorphic field component used for text and other primitive input kinds.

--- a/arc/ui/menu.md
+++ b/arc/ui/menu.md
@@ -1,3 +1,9 @@
+---
+component: Menu
+sdk: longlink/ui/menu.py
+web: src/components/longlink/Menu.tsx
+---
+
 # Menu, MenuSection, and MenuSubSection
 
 The menu elements define hierarchical navigation.

--- a/arc/ui/page.md
+++ b/arc/ui/page.md
@@ -1,3 +1,9 @@
+---
+component: Page
+sdk: longlink/ui/page.py
+web: src/components/longlink/Page.tsx
+---
+
 # Page
 
 `Page` is the root UI container returned by SDK handlers.

--- a/arc/ui/range.md
+++ b/arc/ui/range.md
@@ -1,3 +1,9 @@
+---
+component: Range
+sdk: longlink/ui/range.py
+web: src/components/longlink/Range.tsx
+---
+
 # Range
 
 `Range` is a numeric interval selector.

--- a/arc/ui/select.md
+++ b/arc/ui/select.md
@@ -1,3 +1,9 @@
+---
+component: Select
+sdk: longlink/ui/select.py
+web: src/components/longlink/Select.tsx
+---
+
 # Select
 
 `Select` is a standalone option picker.

--- a/arc/ui/separator.md
+++ b/arc/ui/separator.md
@@ -1,3 +1,9 @@
+---
+component: Separator
+sdk: longlink/ui/separator.py
+web: src/components/longlink/Separator.tsx
+---
+
 # Separator
 
 `Separator` is a visual divider between components.

--- a/arc/ui/switch.md
+++ b/arc/ui/switch.md
@@ -1,3 +1,9 @@
+---
+component: Switch
+sdk: longlink/ui/switch.py
+web: src/components/longlink/Switch.tsx
+---
+
 # Switch
 
 `Switch` is a toggle control for on/off state.

--- a/arc/ui/table.md
+++ b/arc/ui/table.md
@@ -1,3 +1,9 @@
+---
+component: Table
+sdk: longlink/ui/table.py
+web: src/components/longlink/Table.tsx
+---
+
 # Table and Table Column
 
 `Table` renders structured row data, and its table-specific `Column` describes per-column presentation.

--- a/arc/ui/tabs.md
+++ b/arc/ui/tabs.md
@@ -1,3 +1,9 @@
+---
+component: Tabs
+sdk: longlink/ui/tabs.py
+web: src/components/longlink/Tabs.tsx
+---
+
 # Tabs and Tab
 
 `Tabs` organizes content into switchable views. `Tab` is one named tab panel.

--- a/arc/ui/textarea.md
+++ b/arc/ui/textarea.md
@@ -1,3 +1,9 @@
+---
+component: Textarea
+sdk: longlink/ui/textarea.py
+web: src/components/longlink/Textarea.tsx
+---
+
 # Textarea
 
 `Textarea` is a multiline text input component.


### PR DESCRIPTION
### Motivation
- Improve discoverability and machine-readability of UI component docs by linking each doc to its SDK and web implementation locations.
- Standardize metadata across component documentation to aid tooling and cross-references between the SDK and frontend code.

### Description
- Prepend a YAML frontmatter block with `component`, `sdk`, and `web` keys to each component markdown file under `arc/ui/` (18 files updated, e.g. `arc/ui/button.md`, `arc/ui/table.md`).
- Each frontmatter entry points to the corresponding SDK Python file under `longlink/ui/` and the web component under `src/components/longlink/` (for example `sdk: longlink/ui/button.py` and `web: src/components/longlink/Button.tsx`).
- Existing documentation content in each file was preserved and retained after the inserted frontmatter.

### Testing
- No automated tests were added or run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46b0895688323b30955232672b10e)