### PR TITLE
web: add mock Database section to organization settings

### DIFF
--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -3,6 +3,11 @@ import { useRef, useState } from 'react';
 import { ImagePlus } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import { Button as LonglinkButton } from '@/components/longlink/Button';
+import {
+    Table as LonglinkTable,
+    type ApiTableColumn,
+} from '@/components/longlink/Table';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -13,6 +18,7 @@ const settingSections = [
     'Identity & Authentication',
     'Access Control (RBAC)',
     'Applications',
+    'Database',
     'Infrastructure',
     'Storage',
     'Audit & Compliance',
@@ -22,6 +28,58 @@ const settingSections = [
     'API & Integrations',
     'Advanced / System',
 ] as const;
+
+const mockDatabases = [
+    {
+        name: 'org_core',
+        engine: 'PostgreSQL 16',
+        region: 'us-east-1',
+        status: 'Active',
+        updatedAt: '2h ago',
+    },
+    {
+        name: 'analytics_warehouse',
+        engine: 'ClickHouse',
+        region: 'eu-west-1',
+        status: 'Active',
+        updatedAt: '20m ago',
+    },
+    {
+        name: 'event_stream_archive',
+        engine: 'MongoDB 7',
+        region: 'ap-southeast-1',
+        status: 'Maintenance',
+        updatedAt: '1d ago',
+    },
+] as const;
+
+const mockDatabaseColumns: ApiTableColumn[] = [
+    {
+        key: 'name',
+        label: 'Name',
+        value: '{name}',
+    },
+    {
+        key: 'engine',
+        label: 'Engine',
+        value: '{engine}',
+    },
+    {
+        key: 'region',
+        label: 'Region',
+        value: '{region}',
+    },
+    {
+        key: 'status',
+        label: 'Status',
+        value: '{status}',
+    },
+    {
+        key: 'updatedAt',
+        label: 'Last updated',
+        value: '{updatedAt}',
+    },
+];
 
 const toMenuValue = (section: string) =>
     section
@@ -58,6 +116,7 @@ export default function SettingsPage() {
                 <div className="space-y-3">
                     {settingSections.map((section) => {
                         const isGeneralSection = section === 'General';
+                        const isDatabaseSection = section === 'Database';
 
                         return (
                             <MenuContent
@@ -182,6 +241,22 @@ export default function SettingsPage() {
                                                 Upload logo
                                             </Button>
                                         </div>
+                                    </div>
+                                ) : isDatabaseSection ? (
+                                    <div className="mt-4 space-y-4">
+                                        <div className="flex items-center justify-between gap-3">
+                                            <p className="text-muted-foreground text-sm">
+                                                Current organization databases
+                                                (mock data).
+                                            </p>
+                                            <LonglinkButton text="Add database" />
+                                        </div>
+
+                                        <LonglinkTable
+                                            data={[...mockDatabases]}
+                                            columns={mockDatabaseColumns}
+                                            pageSize={5}
+                                        />
                                     </div>
                                 ) : (
                                     <p className="text-muted-foreground mt-1 text-sm">


### PR DESCRIPTION
### Motivation
- Provide an organization-level "Database" settings tab so admins can view and manage organization databases from the settings UI.
- Surface a realistic mock listing to iterate on UI layout and interactions before wiring a backend API.
- Reuse existing longlink UI primitives instead of introducing new card components.

### Description
- Added a new `Database` entry to the organization settings menu and a corresponding content panel in `web/src/pages/org/Settings.tsx`.
- Implemented local mocked database rows in `mockDatabases` and a column definition `mockDatabaseColumns` using the `ApiTableColumn` shape.
- Rendered the listing with the longlink table component (`Table` from `@/components/longlink/Table`) and replaced the action with the longlink button (`Button` from `@/components/longlink/Button`) to create an `Add database` action; the table is fed static `data` and `columns` props (no API integration).
- Kept the implementation visual-only and avoided introducing card components, following project styling conventions.

### Testing
- Ran formatting with `bun run format` in `web/`, which completed successfully.
- Attempted a full build with `bun run build` in `web/`, which failed due to pre-existing TypeScript errors in unrelated files (`src/components/ui/resizable.tsx`, `src/components/ui/sidebar.tsx`, `src/pages/org/Longlink.tsx`, and `src/pages/org/People.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46effbf248323a15d94b9eceb446c)