### PR TITLE
Add Storages support: DB model, service, routes and API wiring

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -36,6 +36,7 @@ import src.routes.user
 import src.routes.users
 import src.routes.sample
 import src.routes.settings
+import src.routes.storages
 
 app.include_router(router)
 

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,8 +1,10 @@
-from .models import App, Database, Env, Setting, User
-from .services import AppsService, DatabasesService, EnvsService, SettingsService, UsersService
+from .models import App, Database, Env, Setting, Storage, User
+from .services import AppsService, DatabasesService, EnvsService, SettingsService, StoragesService, UsersService
 
 apps = AppsService()
 databases = DatabasesService()
 envs = EnvsService()
 settings = SettingsService()
 users = UsersService()
+
+storages = StoragesService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -5,3 +5,4 @@ from .databases import Database
 from .envs import Env
 from .settings import Setting
 from .users import User
+from .storages import Storage

--- a/api/src/db/models/storages.py
+++ b/api/src/db/models/storages.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from sqlalchemy import DateTime, Integer, JSON, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class Storage(Base):
+    '''Represent a root storage connection used by the control panel.'''
+    __tablename__ = 'storages'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    type: Mapped[str] = mapped_column(String(64), nullable=False)
+    base_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    options: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False, default=dict)
+
+    # Timestamp informations
+    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -3,3 +3,4 @@ from .databases import DatabasesService
 from .envs import EnvsService
 from .settings import SettingsService
 from .users import UsersService
+from .storages import StoragesService

--- a/api/src/db/services/storages.py
+++ b/api/src/db/services/storages.py
@@ -1,0 +1,86 @@
+from sqlalchemy import select
+
+from src.db.models import Storage
+from src.db.session import get_session
+
+
+class StoragesService:
+    async def list(self) -> list[Storage]:
+        '''Return all configured storage root connections.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Storage)
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
+    async def get(self, storage_id: int) -> Storage | None:
+        '''Return a storage root connection by id.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Storage).where(Storage.id == storage_id)
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        *,
+        type: str,
+        base_path: str,
+        options: dict[str, object],
+    ) -> Storage:
+        '''Create a storage root connection.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            storage = Storage(
+                type=type,
+                base_path=base_path,
+                options=options,
+            )
+            session.add(storage)
+            await session.commit()
+            await session.refresh(storage)
+            return storage
+
+    async def update(
+        self,
+        storage_id: int,
+        *,
+        type: str,
+        base_path: str,
+        options: dict[str, object],
+    ) -> Storage | None:
+        '''Update a storage root connection.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Storage).where(Storage.id == storage_id)
+            result = await session.execute(statement)
+            storage = result.scalar_one_or_none()
+            if storage is None:
+                return None
+
+            storage.type = type
+            storage.base_path = base_path
+            storage.options = options
+
+            await session.commit()
+            await session.refresh(storage)
+            return storage
+
+    async def delete(self, storage_id: int) -> bool:
+        '''Delete a storage root connection by id.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Storage).where(Storage.id == storage_id)
+            result = await session.execute(statement)
+            storage = result.scalar_one_or_none()
+            if storage is None:
+                return False
+
+            await session.delete(storage)
+            await session.commit()
+            return True

--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -3,3 +3,5 @@ from .databases import DatabaseCreate, DatabaseResponse, DatabaseUpdate
 from .lists.countries import CountryCode
 from .settings import SettingResponse, SettingSet, SettingSetItem
 from .users import UserUpdate
+
+from .storages import StorageCreate, StorageResponse, StorageUpdate

--- a/api/src/models/storages.py
+++ b/api/src/models/storages.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class StorageCreate(BaseModel):
+    type: str
+    base_path: str
+    options: dict[str, Any] = Field(default_factory=dict)
+
+
+class StorageUpdate(BaseModel):
+    type: str
+    base_path: str
+    options: dict[str, Any] = Field(default_factory=dict)
+
+
+class StorageResponse(BaseModel):
+    id: int
+    type: str
+    base_path: str
+    options: dict[str, Any]
+    connection_url: str

--- a/api/src/routes/storages.py
+++ b/api/src/routes/storages.py
@@ -1,0 +1,71 @@
+import fsspec
+from fastapi import HTTPException
+
+import src.db as db
+from src.models.storages import StorageCreate, StorageResponse, StorageUpdate
+from src.router import router
+
+
+def to_response(storage: db.Storage) -> StorageResponse:
+    return StorageResponse(
+        id=storage.id,
+        type=storage.type,
+        base_path=storage.base_path,
+        options=storage.options,
+        connection_url=f'{storage.type}://{storage.base_path}',
+    )
+
+
+def ensure_storage_type_supported(storage_type: str) -> None:
+    try:
+        fsspec.get_filesystem_class(storage_type)
+    except ValueError:
+        raise HTTPException(status_code=400, detail='Storage type not supported') from None
+
+
+@router.get('/storage-types')
+async def list_storage_types() -> list[str]:
+    return sorted(fsspec.available_protocols())
+
+
+@router.get('/storages')
+async def list_storages() -> list[StorageResponse]:
+    storages = await db.storages.list()
+    return [to_response(storage) for storage in storages]
+
+
+@router.post('/storages')
+async def create_storage(payload: StorageCreate) -> StorageResponse:
+    ensure_storage_type_supported(payload.type)
+
+    storage = await db.storages.create(
+        type=payload.type,
+        base_path=payload.base_path,
+        options=payload.options,
+    )
+    return to_response(storage)
+
+
+@router.put('/storages/{storage_id}')
+async def edit_storage(storage_id: int, payload: StorageUpdate) -> StorageResponse:
+    ensure_storage_type_supported(payload.type)
+
+    storage = await db.storages.update(
+        storage_id,
+        type=payload.type,
+        base_path=payload.base_path,
+        options=payload.options,
+    )
+    if storage is None:
+        raise HTTPException(status_code=404, detail='Storage not found')
+
+    return to_response(storage)
+
+
+@router.delete('/storages/{storage_id}')
+async def remove_storage(storage_id: int) -> dict[str, bool]:
+    deleted = await db.storages.delete(storage_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail='Storage not found')
+
+    return {'deleted': True}


### PR DESCRIPTION
### Motivation
- Provide first-class support for configurable storage root connections so the control panel can manage external storage backends via `fsspec`.

### Description
- Add a new DB model `Storage` in `src/db/models/storages.py` with fields `type`, `base_path`, `options`, and timestamps mapped to the `storages` table.
- Implement `StoragesService` in `src/db/services/storages.py` with asynchronous CRUD methods `list`, `get`, `create`, `update`, and `delete` using `get_session` and SQLAlchemy `select`.
- Add Pydantic models `StorageCreate`, `StorageUpdate`, and `StorageResponse` in `src/models/storages.py` and expose them from `src/models/__init__.py`.
- Add REST endpoints in `src/routes/storages.py` including `GET /storage-types`, `GET /storages`, `POST /storages`, `PUT /storages/{storage_id}`, and `DELETE /storages/{storage_id}`, including validation of storage types via `fsspec` and conversion helpers to `StorageResponse`.
- Wire everything into the application by importing the new routes in `main.py`, registering `storages` on the DB package in `src/db/__init__.py`, and exporting the new model in `src/db/models/__init__.py` and services `src/db/services/__init__.py`.

### Testing
- No automated tests were added for this change and no automated test suite was executed as part of this pull request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46eb2b73c8323b0e2830e7efb4178)