### PR TITLE
Longlink table: compact pagination (1, 2, …, last-1, last)

### DIFF
--- a/web/src/components/longlink/Table.tsx
+++ b/web/src/components/longlink/Table.tsx
@@ -111,18 +111,8 @@ export function Table<T extends object>(props: TableProps) {
             return Array.from({ length: totalPages }, (_, index) => index + 1);
         }
 
-        const pages = new Set<number>([1, totalPages, currentPage]);
-
-        if (currentPage > 1) {
-            pages.add(currentPage - 1);
-        }
-
-        if (currentPage < totalPages) {
-            pages.add(currentPage + 1);
-        }
-
-        return Array.from(pages).sort((a, b) => a - b);
-    }, [currentPage, totalPages]);
+        return [1, 2, totalPages - 1, totalPages];
+    }, [totalPages]);
 
     return (
         <div className="overflow-hidden rounded-md border">
@@ -229,38 +219,26 @@ export function Table<T extends object>(props: TableProps) {
                             />
                         </PaginationItem>
 
-                        {pageItems.flatMap((page, index) => {
-                            const previousPage = pageItems[index - 1];
-                            const showEllipsis =
-                                previousPage !== undefined &&
-                                page - previousPage > 1;
+                        {pageItems.map((page) => (
+                            <PaginationItem key={`page-${page}`}>
+                                <PaginationLink
+                                    href="#"
+                                    isActive={page === currentPage}
+                                    onClick={(event) => {
+                                        event.preventDefault();
+                                        table.setPageIndex(page - 1);
+                                    }}
+                                >
+                                    {page}
+                                </PaginationLink>
+                            </PaginationItem>
+                        ))}
 
-                            const pageItem = (
-                                <PaginationItem key={`page-${page}`}>
-                                    <PaginationLink
-                                        href="#"
-                                        isActive={page === currentPage}
-                                        onClick={(event) => {
-                                            event.preventDefault();
-                                            table.setPageIndex(page - 1);
-                                        }}
-                                    >
-                                        {page}
-                                    </PaginationLink>
-                                </PaginationItem>
-                            );
-
-                            if (!showEllipsis) {
-                                return [pageItem];
-                            }
-
-                            return [
-                                <PaginationItem key={`ellipsis-${page}`}>
-                                    <PaginationEllipsis />
-                                </PaginationItem>,
-                                pageItem,
-                            ];
-                        })}
+                        {totalPages > 5 && (
+                            <PaginationItem key="ellipsis">
+                                <PaginationEllipsis />
+                            </PaginationItem>
+                        )}
 
                         <PaginationItem>
                             <PaginationNext


### PR DESCRIPTION
### Motivation
- Provide a compact, predictable pagination layout for large tables so the longlink table matches the requested shadcn-style pattern (`1, 2, …, last-1, last`).

### Description
- Reworked pagination logic in `web/src/components/longlink/Table.tsx` to render all pages when `totalPages <= 5` and to render the fixed sequence `[1, 2, …, last-1, last]` when `totalPages > 5`.
- Simplified the pagination rendering to map `pageItems` to `PaginationItem`/`PaginationLink` elements and added a single `PaginationEllipsis` when `totalPages > 5` while keeping existing `PaginationPrevious` and `PaginationNext` behavior.
- Kept use of existing shadcn pagination primitives and preserved click handlers to navigate pages via the table instance.

### Testing
- Ran formatting with `bun run format`, which completed successfully.
- Ran a build with `bun run build`, which failed due to pre-existing TypeScript issues unrelated to this change (examples include errors in `src/components/ui/resizable.tsx`, `src/components/ui/sidebar.tsx`, and `src/pages/org/People.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47238b2b483239e17155f62356cc0)