### PR TITLE
Simplify organization settings sections to use Longlink Hero

### DIFF
--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -1,16 +1,4 @@
-import type { ChangeEvent } from 'react';
-import { useRef, useState } from 'react';
-import { ImagePlus } from 'lucide-react';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
-import { Button as LonglinkButton } from '@/components/longlink/Button';
-import {
-    Table as LonglinkTable,
-    type ApiTableColumn,
-} from '@/components/longlink/Table';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import Hero from '@/components/longlink/Hero';
 import { Menu, MenuContent, MenuList, MenuSection } from '@/components/ui/menu';
 
 const settingSections = [
@@ -29,58 +17,6 @@ const settingSections = [
     'Advanced / System',
 ] as const;
 
-const mockDatabases = [
-    {
-        name: 'org_core',
-        engine: 'PostgreSQL 16',
-        region: 'us-east-1',
-        status: 'Active',
-        updatedAt: '2h ago',
-    },
-    {
-        name: 'analytics_warehouse',
-        engine: 'ClickHouse',
-        region: 'eu-west-1',
-        status: 'Active',
-        updatedAt: '20m ago',
-    },
-    {
-        name: 'event_stream_archive',
-        engine: 'MongoDB 7',
-        region: 'ap-southeast-1',
-        status: 'Maintenance',
-        updatedAt: '1d ago',
-    },
-] as const;
-
-const mockDatabaseColumns: ApiTableColumn[] = [
-    {
-        key: 'name',
-        label: 'Name',
-        value: '{name}',
-    },
-    {
-        key: 'engine',
-        label: 'Engine',
-        value: '{engine}',
-    },
-    {
-        key: 'region',
-        label: 'Region',
-        value: '{region}',
-    },
-    {
-        key: 'status',
-        label: 'Status',
-        value: '{status}',
-    },
-    {
-        key: 'updatedAt',
-        label: 'Last updated',
-        value: '{updatedAt}',
-    },
-];
-
 const toMenuValue = (section: string) =>
     section
         .toLowerCase()
@@ -88,18 +24,6 @@ const toMenuValue = (section: string) =>
         .replace(/(^-|-$)/g, '');
 
 export default function SettingsPage() {
-    const [logoPreview, setLogoPreview] = useState<string | null>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-
-    const handleLogoChange = (event: ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (!file) {
-            return;
-        }
-
-        setLogoPreview(URL.createObjectURL(file));
-    };
-
     return (
         <div className="space-y-6">
             <Menu defaultValue={toMenuValue(settingSections[0])}>
@@ -114,159 +38,19 @@ export default function SettingsPage() {
                 </MenuList>
 
                 <div className="space-y-3">
-                    {settingSections.map((section) => {
-                        const isGeneralSection = section === 'General';
-                        const isDatabaseSection = section === 'Database';
-
-                        return (
-                            <MenuContent
-                                key={section}
-                                value={toMenuValue(section)}
-                                className="rounded-xl border border-border bg-card p-4"
-                            >
-                                <h2 className="text-lg font-semibold">
-                                    {section}
-                                </h2>
-
-                                {isGeneralSection ? (
-                                    <div className="mt-4 grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
-                                        <div className="grid gap-4 sm:grid-cols-2">
-                                            <div className="space-y-2 sm:col-span-2">
-                                                <Label htmlFor="organization-name">
-                                                    Organization name
-                                                </Label>
-                                                <Input
-                                                    id="organization-name"
-                                                    defaultValue="LongLink"
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="legal-name">
-                                                    Legal name
-                                                </Label>
-                                                <Input
-                                                    id="legal-name"
-                                                    defaultValue="LongLink Technologies LLC"
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="tax-id">
-                                                    Registration / tax ID
-                                                </Label>
-                                                <Input
-                                                    id="tax-id"
-                                                    defaultValue="US-12-3456789"
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="primary-contact-email">
-                                                    Primary contact email
-                                                </Label>
-                                                <Input
-                                                    id="primary-contact-email"
-                                                    type="email"
-                                                    defaultValue="contact@longlink.dev"
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="support-email">
-                                                    Support email
-                                                </Label>
-                                                <Input
-                                                    id="support-email"
-                                                    type="email"
-                                                    defaultValue="support@longlink.dev"
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="phone-number">
-                                                    Phone number
-                                                </Label>
-                                                <Input
-                                                    id="phone-number"
-                                                    defaultValue="+1 (415) 555-0138"
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="website">
-                                                    Website
-                                                </Label>
-                                                <Input
-                                                    id="website"
-                                                    defaultValue="https://longlink.dev"
-                                                />
-                                            </div>
-                                            <div className="space-y-2 sm:col-span-2">
-                                                <Label htmlFor="physical-address">
-                                                    Physical address
-                                                </Label>
-                                                <Textarea
-                                                    id="physical-address"
-                                                    defaultValue="548 Market St, PMB 98234&#10;San Francisco, CA 94104&#10;United States"
-                                                    rows={4}
-                                                />
-                                            </div>
-                                        </div>
-
-                                        <div className="flex flex-col items-center gap-4 rounded-lg border border-border/70 bg-background/30 p-4 text-center">
-                                            <div className="text-sm font-semibold">
-                                                Organization logo
-                                            </div>
-                                            <Avatar className="size-32 rounded-xl border border-border/60">
-                                                <AvatarImage
-                                                    src={logoPreview ?? ''}
-                                                    alt="Organization logo"
-                                                />
-                                                <AvatarFallback className="rounded-xl text-lg">
-                                                    LL
-                                                </AvatarFallback>
-                                            </Avatar>
-                                            <input
-                                                ref={fileInputRef}
-                                                type="file"
-                                                accept="image/*"
-                                                onChange={handleLogoChange}
-                                                className="hidden"
-                                            />
-                                            <Button
-                                                type="button"
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() =>
-                                                    fileInputRef.current?.click()
-                                                }
-                                                className="gap-2"
-                                            >
-                                                <ImagePlus className="h-4 w-4" />
-                                                Upload logo
-                                            </Button>
-                                        </div>
-                                    </div>
-                                ) : isDatabaseSection ? (
-                                    <div className="mt-4 space-y-4">
-                                        <div className="flex items-center justify-between gap-3">
-                                            <p className="text-muted-foreground text-sm">
-                                                Current organization databases
-                                                (mock data).
-                                            </p>
-                                            <LonglinkButton text="Add database" />
-                                        </div>
-
-                                        <LonglinkTable
-                                            data={[...mockDatabases]}
-                                            columns={mockDatabaseColumns}
-                                            pageSize={5}
-                                        />
-                                    </div>
-                                ) : (
-                                    <p className="text-muted-foreground mt-1 text-sm">
-                                        Configure {section.toLowerCase()}{' '}
-                                        settings.
-                                    </p>
-                                )}
-                            </MenuContent>
-                        );
-                    })}
+                    {settingSections.map((section) => (
+                        <MenuContent
+                            key={section}
+                            value={toMenuValue(section)}
+                            className="rounded-xl border border-border bg-card p-4"
+                        >
+                            <Hero
+                                title={section}
+                                subtitle="Configuration panel"
+                                icon="building-2"
+                            />
+                        </MenuContent>
+                    ))}
                 </div>
             </Menu>
         </div>


### PR DESCRIPTION
### Motivation
- Simplify the organization settings UI by removing dense card content and using a single, consistent hero header per section for clarity and reusability.
- Remove unused UI logic and mock data that is no longer needed by the simplified layout to reduce maintenance surface.

### Description
- Replaced the detailed card bodies in `web/src/pages/org/Settings.tsx` with the reusable `Hero` component showing the section title, subtitle `Configuration panel`, and the `building-2` icon.
- Removed logo upload state/handlers, avatar UI, mock database data and table rendering, and related imports that were only used by the previous detailed cards.
- Simplified the `settingSections` rendering so each `MenuContent` now renders a single `Hero` block, reducing component complexity and duplication.

### Testing
- Ran `bun run format` in `web/`, which completed successfully.
- Ran `bun run build` in `web/`, which failed due to unrelated pre-existing TypeScript errors in other files and not due to this change.
- No tests were added as per repository guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47285dd308323b8767dc80d9482f5)