### PR TITLE
Center longlink table pagination and remove page summary

### DIFF
--- a/web/src/components/longlink/Table.tsx
+++ b/web/src/components/longlink/Table.tsx
@@ -196,12 +196,8 @@ export function Table<T extends object>(props: TableProps) {
                 </TableBody>
             </UITable>
 
-            <div className="flex flex-col gap-2 border-t p-3 text-sm sm:flex-row sm:items-center sm:justify-between">
-                <span className="text-muted-foreground">
-                    Page {currentPage} of {totalPages}
-                </span>
-
-                <Pagination className="mx-0 w-auto justify-end">
+            <div className="border-t p-3 text-sm">
+                <Pagination className="mx-0 w-full justify-center">
                     <PaginationContent>
                         <PaginationItem>
                             <PaginationPrevious


### PR DESCRIPTION
### Motivation
- Simplify and improve the table footer by removing the redundant "Page X of Y" text and centering the pagination control while preserving the highlighted current page.

### Description
- Removed the `Page {currentPage} of {totalPages}` span from the longlink table footer in `web/src/components/longlink/Table.tsx`.
- Replaced the footer wrapper classes and pagination layout by changing the container to `className="border-t p-3 text-sm"` and the pagination to `className="mx-0 w-full justify-center"` to center the control.
- Kept existing navigation handlers and `PaginationLink isActive={page === currentPage}` so the active page remains highlighted.

### Testing
- Ran `bun run format` in `web`, which succeeded.
- Ran `bun run build` in `web`, which failed due to pre-existing TypeScript issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4734ff6508323bed0858cd620f21d)