### PR TITLE
Add placeholder settings pages and integrate them into Settings menu

### DIFF
--- a/web/src/components/settings/AccessControl.tsx
+++ b/web/src/components/settings/AccessControl.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function AccessControl() {
+    return (
+        <Hero
+            title="Access Control Settings"
+            subtitle="Define roles, permissions, and organization access rules"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Applications() {
+    return (
+        <Hero
+            title="Application Settings"
+            subtitle="Control app defaults, permissions, and lifecycle settings"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/AuditCompliance.tsx
+++ b/web/src/components/settings/AuditCompliance.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function AuditCompliance() {
+    return (
+        <Hero
+            title="Audit & Compliance Settings"
+            subtitle="Track activity logs, policies, and compliance controls"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/Authentication.tsx
+++ b/web/src/components/settings/Authentication.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Authentication() {
+    return (
+        <Hero
+            title="Authentication Settings"
+            subtitle="Manage sign in options and identity providers"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/Billing.tsx
+++ b/web/src/components/settings/Billing.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Billing() {
+    return (
+        <Hero
+            title="Billing & Plan Settings"
+            subtitle="View plan details, billing configuration, and usage limits"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/Database.tsx
+++ b/web/src/components/settings/Database.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Database() {
+    return (
+        <Hero
+            title="Database Settings"
+            subtitle="Configure database connectivity, retention, and backups"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/General.tsx
+++ b/web/src/components/settings/General.tsx
@@ -1,6 +1,11 @@
 import Hero from '@/components/longlink/Hero';
 
-
 export default function General() {
-    return <Hero title="General Settings" subtitle="Configure general organization settings" icon="settings" />;
+    return (
+        <Hero
+            title="General Settings"
+            subtitle="Configure general organization settings"
+            icon="settings"
+        />
+    );
 }

--- a/web/src/components/settings/Infrastructure.tsx
+++ b/web/src/components/settings/Infrastructure.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Infrastructure() {
+    return (
+        <Hero
+            title="Infrastructure Settings"
+            subtitle="Review deployment regions, runtime limits, and scaling"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/Integrations.tsx
+++ b/web/src/components/settings/Integrations.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Integrations() {
+    return (
+        <Hero
+            title="Integration Settings"
+            subtitle="Connect external services and manage integration access"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/Security.tsx
+++ b/web/src/components/settings/Security.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Security() {
+    return (
+        <Hero
+            title="Security Settings"
+            subtitle="Manage security baselines and organization protections"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/components/settings/SettingsPlaceholder.tsx
+++ b/web/src/components/settings/SettingsPlaceholder.tsx
@@ -1,0 +1,13 @@
+import Hero from '@/components/longlink/Hero';
+
+type SettingsPlaceholderProps = {
+    title: string;
+    subtitle: string;
+};
+
+export default function SettingsPlaceholder({
+    title,
+    subtitle,
+}: SettingsPlaceholderProps) {
+    return <Hero title={title} subtitle={subtitle} icon="settings" />;
+}

--- a/web/src/components/settings/Storage.tsx
+++ b/web/src/components/settings/Storage.tsx
@@ -1,0 +1,11 @@
+import Hero from '@/components/longlink/Hero';
+
+export default function Storage() {
+    return (
+        <Hero
+            title="Storage Settings"
+            subtitle="Manage storage providers, quotas, and file policies"
+            icon="settings"
+        />
+    );
+}

--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -1,7 +1,15 @@
+import AccessControl from '@/components/settings/AccessControl';
+import Applications from '@/components/settings/Applications';
+import AuditCompliance from '@/components/settings/AuditCompliance';
+import Authentication from '@/components/settings/Authentication';
+import Billing from '@/components/settings/Billing';
+import Database from '@/components/settings/Database';
 import General from '@/components/settings/General';
+import Infrastructure from '@/components/settings/Infrastructure';
+import Integrations from '@/components/settings/Integrations';
+import Security from '@/components/settings/Security';
+import Storage from '@/components/settings/Storage';
 import { Menu, MenuContent, MenuList, MenuSection } from '@/components/ui/menu';
-
-
 
 export default function SettingsPage() {
     return (
@@ -9,19 +17,62 @@ export default function SettingsPage() {
             <Menu defaultValue="general">
                 <MenuList>
                     <MenuSection value="general" label="General" />
-                    <MenuSection value="authentication" label="Authentication" />
-                    <MenuSection value="access-control" label="Access Control (RBAC)" />
+                    <MenuSection
+                        value="authentication"
+                        label="Authentication"
+                    />
+                    <MenuSection
+                        value="access-control"
+                        label="Access Control (RBAC)"
+                    />
                     <MenuSection value="applications" label="Applications" />
                     <MenuSection value="database" label="Database" />
                     <MenuSection value="storage" label="Storage" />
-                    <MenuSection value="infrastructure" label="Infrastructure" />
-                    <MenuSection value="audit-compliance" label="Audit & Compliance" />
+                    <MenuSection
+                        value="infrastructure"
+                        label="Infrastructure"
+                    />
+                    <MenuSection
+                        value="audit-compliance"
+                        label="Audit & Compliance"
+                    />
                     <MenuSection value="security" label="Security" />
                     <MenuSection value="billing" label="Billing & Plan" />
                     <MenuSection value="integrations" label="Integrations" />
                 </MenuList>
-
-                <MenuContent value="general"> <General /> </MenuContent>
+                <MenuContent value="general">
+                    <General />
+                </MenuContent>
+                <MenuContent value="authentication">
+                    <Authentication />
+                </MenuContent>
+                <MenuContent value="access-control">
+                    <AccessControl />
+                </MenuContent>
+                <MenuContent value="applications">
+                    <Applications />
+                </MenuContent>
+                <MenuContent value="database">
+                    <Database />
+                </MenuContent>
+                <MenuContent value="storage">
+                    <Storage />
+                </MenuContent>
+                <MenuContent value="infrastructure">
+                    <Infrastructure />
+                </MenuContent>
+                <MenuContent value="audit-compliance">
+                    <AuditCompliance />
+                </MenuContent>
+                <MenuContent value="security">
+                    <Security />
+                </MenuContent>
+                <MenuContent value="billing">
+                    <Billing />
+                </MenuContent>
+                <MenuContent value="integrations">
+                    <Integrations />
+                </MenuContent>
             </Menu>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Scaffold individual settings pages so each settings area has a dedicated placeholder component for future implementation.
- Wire the new settings components into the organization `Settings` page to enable navigation and provide consistent UI placeholders.

### Description
- Added new placeholder components under `web/src/components/settings/` for `AccessControl`, `Applications`, `AuditCompliance`, `Authentication`, `Billing`, `Database`, `Infrastructure`, `Integrations`, `Security`, and `Storage` that render a shared `Hero` UI.
- Added a reusable `SettingsPlaceholder` component at `web/src/components/settings/SettingsPlaceholder.tsx` to standardize title/subtitle rendering (the individual files currently use `Hero` directly).
- Updated `web/src/components/settings/General.tsx` to use a multi-line `Hero` JSX format for consistency.
- Updated `web/src/pages/org/Settings.tsx` to import the new components and register them in the `Menu` via `MenuSection` and `MenuContent` entries so each section displays its placeholder component.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a475061990832393774a7b7fd2dbc2)