### PR TITLE
Add organization detail fields to General settings

### DIFF
--- a/web/src/components/settings/General.tsx
+++ b/web/src/components/settings/General.tsx
@@ -1,11 +1,149 @@
+import { useRef, useState, type ChangeEvent } from 'react';
 import Hero from '@/components/longlink/Hero';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 
 export default function General() {
+    const [logoPreview, setLogoPreview] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleLogoChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+
+        if (!file) {
+            return;
+        }
+
+        setLogoPreview(URL.createObjectURL(file));
+    };
+
     return (
-        <Hero
-            title="General Settings"
-            subtitle="Configure general organization settings"
-            icon="settings"
-        />
+        <div className="space-y-6">
+            <Hero
+                title="General Settings"
+                subtitle="Configure your organization public and legal details"
+                icon="settings"
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Organization details</CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_260px]">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2 sm:col-span-2">
+                            <Label htmlFor="organization-name">
+                                Organization name
+                            </Label>
+                            <Input
+                                id="organization-name"
+                                defaultValue="Longlink"
+                                placeholder="Organization display name"
+                            />
+                        </div>
+
+                        <div className="space-y-2 sm:col-span-2">
+                            <Label htmlFor="legal-name">Legal name</Label>
+                            <Input
+                                id="legal-name"
+                                placeholder="Registered legal entity name"
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="registration-tax-id">
+                                Registration / tax ID
+                            </Label>
+                            <Input
+                                id="registration-tax-id"
+                                placeholder="Company registration or tax ID"
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="phone-number">Phone number</Label>
+                            <Input
+                                id="phone-number"
+                                type="tel"
+                                placeholder="+1 (000) 000-0000"
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="primary-contact-email">
+                                Primary contact email
+                            </Label>
+                            <Input
+                                id="primary-contact-email"
+                                type="email"
+                                placeholder="contact@company.com"
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="support-email">Support email</Label>
+                            <Input
+                                id="support-email"
+                                type="email"
+                                placeholder="support@company.com"
+                            />
+                        </div>
+
+                        <div className="space-y-2 sm:col-span-2">
+                            <Label htmlFor="website">Website</Label>
+                            <Input
+                                id="website"
+                                type="url"
+                                placeholder="https://company.com"
+                            />
+                        </div>
+
+                        <div className="space-y-2 sm:col-span-2">
+                            <Label htmlFor="physical-address">
+                                Physical address
+                            </Label>
+                            <Textarea
+                                id="physical-address"
+                                placeholder="Street, city, state, ZIP/postal code, country"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="space-y-4">
+                        <Label>Logo</Label>
+                        <div className="flex flex-col items-center gap-4 rounded-xl border border-white/10 p-6 text-center">
+                            <Avatar className="size-28 rounded-xl border border-white/10">
+                                <AvatarImage
+                                    src={logoPreview ?? ''}
+                                    alt="Logo"
+                                />
+                                <AvatarFallback className="rounded-xl text-lg">
+                                    LL
+                                </AvatarFallback>
+                            </Avatar>
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                accept="image/*"
+                                onChange={handleLogoChange}
+                                className="hidden"
+                            />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => fileInputRef.current?.click()}
+                                className="w-full"
+                            >
+                                Upload logo
+                            </Button>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Replace the placeholder-only General settings view with a proper organization settings form to collect public and legal organization information. 

### Description
- Implemented a full Organization details form in `web/src/components/settings/General.tsx` using existing Longlink UI primitives (`Hero`, `Card`, `Input`, `Label`, `Textarea`, `Avatar`, `Button`).
- Added fields for Organization name, Legal name, Registration / tax ID, Primary contact email, Support email, Phone number, Website, and Physical address. 
- Added a Logo upload section with a hidden file input, live preview using `Avatar`/`AvatarImage`, and an upload trigger `Button` following existing UI patterns. 
- Kept layout responsive using the existing grid and spacing utilities and wrote elements explicitly (no `.map()` usage). 

### Testing
- Ran `bun run format` and the codebase was formatted successfully. 
- Ran `bun run build` which failed due to pre-existing TypeScript errors in unrelated files (for example `src/components/ui/resizable.tsx`, `src/components/ui/sidebar.tsx`, and `src/pages/org/People.tsx`), so the new UI compiles locally but the full project build is blocked by those unrelated issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47a62a11883238c4dfac84691672e)