### PR TITLE
Rename General settings to Organization and remove card wrapper

### DIFF
--- a/web/src/components/settings/General.tsx
+++ b/web/src/components/settings/General.tsx
@@ -2,7 +2,6 @@ import { useRef, useState, type ChangeEvent } from 'react';
 import Hero from '@/components/longlink/Hero';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -24,16 +23,16 @@ export default function General() {
     return (
         <div className="space-y-6">
             <Hero
-                title="General Settings"
+                title="Organization Settings"
                 subtitle="Configure your organization public and legal details"
                 icon="settings"
             />
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Organization details</CardTitle>
-                </CardHeader>
-                <CardContent className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <section className="space-y-6">
+                <h2 className="text-2xl font-semibold tracking-tight">
+                    Organization details
+                </h2>
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_260px]">
                     <div className="grid gap-4 sm:grid-cols-2">
                         <div className="space-y-2 sm:col-span-2">
                             <Label htmlFor="organization-name">
@@ -142,8 +141,8 @@ export default function General() {
                             </Button>
                         </div>
                     </div>
-                </CardContent>
-            </Card>
+                </div>
+            </section>
         </div>
     );
 }

--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -25,7 +25,7 @@ export default function SettingsPage() {
                 <MenuList>
                     <MenuSection
                         value="general"
-                        label="General"
+                        label="Organization"
                         icon={GlobeIcon}
                     />
                     <MenuSection


### PR DESCRIPTION
### Motivation

- Make the organization settings label more explicit by renaming the sidebar entry from `General` to `Organization`.
- Remove the card visual wrapper around the organization settings form so the form integrates directly into the page layout and loses the card look.

### Description

- Changed the settings sidebar label from `General` to `Organization` in `web/src/pages/org/Settings.tsx`.
- Updated the page hero title from `General Settings` to `Organization Settings` in `web/src/components/settings/General.tsx`.
- Removed the `Card` container markup and import in `web/src/components/settings/General.tsx` and replaced it with a plain `section` and `h2` heading while preserving the form fields and logo upload layout.
- Kept all existing inputs, handlers, and layout grid classes intact so the form behavior is unchanged aside from styling.

### Testing

- Ran the project formatter via `bun run format` in the `web/` folder and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47fbb32648323a307164ab121d2af)