### PR TITLE
Add settings tables for applications and storage providers

### DIFF
--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -1,11 +1,172 @@
+import { AppWindow, PlusCircle } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import Hero from '@/components/longlink/Hero';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+
+type Application = {
+    name: string;
+    slug: string;
+    owner: string;
+    runtime: string;
+    status: 'Active';
+};
 
 export default function Applications() {
+    const [name, setName] = useState('');
+    const [slug, setSlug] = useState('');
+    const [owner, setOwner] = useState('');
+    const [runtime, setRuntime] = useState('Python SDK');
+    const [applications, setApplications] = useState<Application[]>([]);
+
+    const canCreate = useMemo(() => {
+        return (
+            name.trim().length > 0 &&
+            slug.trim().length > 0 &&
+            owner.trim().length > 0 &&
+            runtime.trim().length > 0
+        );
+    }, [name, owner, runtime, slug]);
+
+    const onCreate = () => {
+        if (!canCreate) {
+            return;
+        }
+
+        setApplications((current) => [
+            {
+                name: name.trim(),
+                slug: slug.trim(),
+                owner: owner.trim(),
+                runtime: runtime.trim(),
+                status: 'Active',
+            },
+            ...current,
+        ]);
+
+        setName('');
+        setSlug('');
+        setOwner('');
+        setRuntime('Python SDK');
+    };
+
     return (
-        <Hero
-            title="Application Settings"
-            subtitle="Control app defaults, permissions, and lifecycle settings"
-            icon="settings"
-        />
+        <div className="space-y-6">
+            <Hero
+                title="Application Settings"
+                subtitle="Control app defaults, permissions, and lifecycle settings"
+                icon="settings"
+                action="Create app"
+            >
+                <DialogContent className="sm:max-w-3xl">
+                    <DialogHeader>
+                        <DialogTitle>Create application</DialogTitle>
+                        <DialogDescription>
+                            Register a new application to make it available for
+                            modules, storage bindings, and runtime deployment.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="grid gap-3 md:grid-cols-2">
+                        <Input
+                            placeholder="Application name"
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                        />
+                        <Input
+                            placeholder="Slug"
+                            value={slug}
+                            onChange={(event) => setSlug(event.target.value)}
+                        />
+                        <Input
+                            placeholder="Owner"
+                            value={owner}
+                            onChange={(event) => setOwner(event.target.value)}
+                        />
+                        <Input
+                            placeholder="Runtime"
+                            value={runtime}
+                            onChange={(event) => setRuntime(event.target.value)}
+                        />
+                    </div>
+
+                    <div className="flex justify-end">
+                        <Button
+                            variant="outline"
+                            onClick={onCreate}
+                            disabled={!canCreate}
+                        >
+                            <PlusCircle className="h-4 w-4" />
+                            Create
+                        </Button>
+                    </div>
+                </DialogContent>
+            </Hero>
+
+            <Card className="overflow-hidden">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Slug</TableHead>
+                            <TableHead>Owner</TableHead>
+                            <TableHead>Runtime</TableHead>
+                            <TableHead>Status</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {applications.length === 0 ? (
+                            <TableRow>
+                                <TableCell
+                                    colSpan={5}
+                                    className="py-8 text-center text-muted-foreground"
+                                >
+                                    No applications registered yet.
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            applications.map((application) => (
+                                <TableRow
+                                    key={`${application.slug}-${application.owner}`}
+                                >
+                                    <TableCell className="font-medium">
+                                        {application.name}
+                                    </TableCell>
+                                    <TableCell>{application.slug}</TableCell>
+                                    <TableCell>{application.owner}</TableCell>
+                                    <TableCell>{application.runtime}</TableCell>
+                                    <TableCell>{application.status}</TableCell>
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </Table>
+            </Card>
+
+            <Card className="border-dashed p-4 text-sm text-muted-foreground">
+                <div className="flex items-start gap-2">
+                    <AppWindow className="mt-0.5 h-4 w-4" />
+                    <p>
+                        Applications listed here can be attached to database and
+                        storage providers configured in this settings section.
+                    </p>
+                </div>
+            </Card>
+        </div>
     );
 }

--- a/web/src/components/settings/Storage.tsx
+++ b/web/src/components/settings/Storage.tsx
@@ -1,11 +1,194 @@
+import { HardDrive, PlusCircle } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import Hero from '@/components/longlink/Hero';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+
+type StorageProvider = {
+    name: string;
+    endpoint: string;
+    bucket: string;
+    accessKey: string;
+    status: 'Connected';
+};
 
 export default function Storage() {
+    const [providerName, setProviderName] = useState('');
+    const [endpoint, setEndpoint] = useState('');
+    const [bucket, setBucket] = useState('');
+    const [accessKey, setAccessKey] = useState('');
+    const [secretKey, setSecretKey] = useState('');
+    const [connectedProviders, setConnectedProviders] = useState<
+        StorageProvider[]
+    >([]);
+
+    const canConnect = useMemo(() => {
+        return (
+            providerName.trim().length > 0 &&
+            endpoint.trim().length > 0 &&
+            bucket.trim().length > 0 &&
+            accessKey.trim().length > 0 &&
+            secretKey.trim().length > 0
+        );
+    }, [accessKey, bucket, endpoint, providerName, secretKey]);
+
+    const onConnect = () => {
+        if (!canConnect) {
+            return;
+        }
+
+        setConnectedProviders((current) => [
+            {
+                name: providerName.trim(),
+                endpoint: endpoint.trim(),
+                bucket: bucket.trim(),
+                accessKey: accessKey.trim(),
+                status: 'Connected',
+            },
+            ...current,
+        ]);
+
+        setProviderName('');
+        setEndpoint('');
+        setBucket('');
+        setAccessKey('');
+        setSecretKey('');
+    };
+
     return (
-        <Hero
-            title="Storage Settings"
-            subtitle="Manage storage providers, quotas, and file policies"
-            icon="settings"
-        />
+        <div className="space-y-6">
+            <Hero
+                title="Storage Settings"
+                subtitle="Manage storage providers, quotas, and file policies"
+                icon="settings"
+                action="Connect"
+            >
+                <DialogContent className="sm:max-w-3xl">
+                    <DialogHeader>
+                        <DialogTitle>Connect storage provider</DialogTitle>
+                        <DialogDescription>
+                            Register a top-level object storage provider.
+                            Applications can create or bind buckets from these
+                            connections.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="grid gap-3 md:grid-cols-2">
+                        <Input
+                            placeholder="Provider name"
+                            value={providerName}
+                            onChange={(event) =>
+                                setProviderName(event.target.value)
+                            }
+                        />
+                        <Input
+                            placeholder="Endpoint"
+                            value={endpoint}
+                            onChange={(event) =>
+                                setEndpoint(event.target.value)
+                            }
+                        />
+                        <Input
+                            placeholder="Bucket"
+                            value={bucket}
+                            onChange={(event) => setBucket(event.target.value)}
+                        />
+                        <Input
+                            placeholder="Access key"
+                            value={accessKey}
+                            onChange={(event) =>
+                                setAccessKey(event.target.value)
+                            }
+                        />
+                        <Input
+                            type="password"
+                            placeholder="Secret key"
+                            value={secretKey}
+                            onChange={(event) =>
+                                setSecretKey(event.target.value)
+                            }
+                            className="md:col-span-2"
+                        />
+                    </div>
+
+                    <div className="flex justify-end">
+                        <Button
+                            variant="outline"
+                            onClick={onConnect}
+                            disabled={!canConnect}
+                        >
+                            <PlusCircle className="h-4 w-4" />
+                            Connect
+                        </Button>
+                    </div>
+                </DialogContent>
+            </Hero>
+
+            <Card className="overflow-hidden">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Provider</TableHead>
+                            <TableHead>Endpoint</TableHead>
+                            <TableHead>Bucket</TableHead>
+                            <TableHead>Access key</TableHead>
+                            <TableHead>Status</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {connectedProviders.length === 0 ? (
+                            <TableRow>
+                                <TableCell
+                                    colSpan={5}
+                                    className="py-8 text-center text-muted-foreground"
+                                >
+                                    No connected storage providers yet.
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            connectedProviders.map((provider) => (
+                                <TableRow
+                                    key={`${provider.name}-${provider.bucket}-${provider.endpoint}`}
+                                >
+                                    <TableCell className="font-medium">
+                                        {provider.name}
+                                    </TableCell>
+                                    <TableCell>{provider.endpoint}</TableCell>
+                                    <TableCell>{provider.bucket}</TableCell>
+                                    <TableCell>{provider.accessKey}</TableCell>
+                                    <TableCell>{provider.status}</TableCell>
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </Table>
+            </Card>
+
+            <Card className="border-dashed p-4 text-sm text-muted-foreground">
+                <div className="flex items-start gap-2">
+                    <HardDrive className="mt-0.5 h-4 w-4" />
+                    <p>
+                        Connected entries represent shared object storage
+                        providers. Applications can link dedicated buckets and
+                        file policies to one of these providers.
+                    </p>
+                </div>
+            </Card>
+        </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Provide the same interactive management experience for Applications and Storage as already exists for Database in the Settings area so admins can register and view top-level app/storage entries.

### Description
- Replace the `Applications` placeholder with an in-memory management UI that includes a create dialog, validation, and a status table (`web/src/components/settings/Applications.tsx`).
- Implement a matching `Storage` management UI with a connect dialog, required-field validation, and a providers table (`web/src/components/settings/Storage.tsx`).
- Use existing shadcn UI building blocks (`Hero`, `Dialog`, `Table`, `Card`, `Input`, `Button`) to keep pages consistent with the Database settings layout.
- Behavior is currently local UI state only, following the same in-memory pattern used by the Database settings page.

### Testing
- Ran `bun run format` (web) which completed successfully.
- Ran `bun run build` (web) which failed due to unrelated pre-existing TypeScript issues in other files and not because of the modified components.
- Started the dev server (`bun run dev`) and ran a Playwright script to capture a screenshot which produced `artifacts/settings-apps-storage.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a480f7a1ac8323bd2a3d00ecd37a9a)