### PR TITLE
feat(sdk): add /register endpoint returning app metadata and required envs

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -2,7 +2,7 @@ from typing import get_type_hints
 from pydantic import BaseModel
 from longlink.cron import Cron
 from longlink.router import Router
-from longlink.settings import Settings
+from longlink.envs import Envs
 
 
 class LongLink(Router, Cron):
@@ -21,6 +21,25 @@ class LongLink(Router, Cron):
                 "version": self.version,
                 "pages": self.pages(),
             }
+
+        @self.get("/register")
+        async def get_registration_information():
+            return self.registration()
+
+    def registration(self) -> dict[str, object]:
+        return {
+            "name": self.title,
+            "version": self.version,
+            "required_envs": self.required_envs(),
+        }
+
+    def required_envs(self) -> list[str]:
+        required_fields = [
+            name
+            for name, field in Envs.model_fields.items()
+            if field.is_required()
+        ]
+        return [field_name.upper() for field_name in required_fields]
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":


### PR DESCRIPTION
### Motivation
- Provide a simple registration metadata endpoint for LongLink applications so consumers (platform/CLI) can discover the application `name`, `version`, and which environment variables are required.
- Reuse the existing `Envs` model to keep required environment inference centralized and consistent with app configuration.

### Description
- Add a `GET /register` route to `LongLink` that returns the output of a new `registration()` helper. 
- Implement `registration()` to return `name`, `version`, and `required_envs` for the application. 
- Implement `required_envs()` to inspect `Envs.model_fields`, filter required fields with `field.is_required()`, and return the field names uppercased.
- Replace the previous import of settings with `from longlink.envs import Envs` to derive required envs directly from the SDK settings model.

### Testing
- Ran Python compilation on the modified file with `python -m compileall sdk/longlink/app.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a487f45d148323866b7bd056dbe844)