### PR TITLE
Add arc/sdk documentation with CLI reference

### DIFF
--- a/arc/sdk/CLI.md
+++ b/arc/sdk/CLI.md
@@ -1,0 +1,57 @@
+# SDK CLI Reference
+
+The LongLink SDK exposes a CLI through the `viavai` command.
+
+## Command Overview
+
+### `viavai create <app_name>`
+Creates a new app scaffold with the default project layout.
+
+Typical generated structure:
+
+```txt
+main.py
+migrations/
+src/
+├── cron/
+├── models/
+├── pages/
+├── routes/
+├── types/
+└── app.py
+tests/
+```
+
+### `viavai migrate`
+Generates database migration scripts for the app schema using Alembic/SQLAlchemy conventions.
+
+Use this after changing data models to keep database schema changes versioned.
+
+### `viavai publish`
+Publishes the app to the LongLink platform so it can be managed and executed by the control plane.
+
+## Common Workflow
+
+1. Create the app scaffold:
+
+   ```bash
+   viavai create my_app
+   ```
+
+2. Implement app logic, pages, and models.
+3. Generate migrations when schema changes:
+
+   ```bash
+   viavai migrate
+   ```
+
+4. Publish the app:
+
+   ```bash
+   viavai publish
+   ```
+
+## Notes
+
+- The SDK focuses on application business logic.
+- Infrastructure concerns (auth, RBAC, orchestration, runtime isolation) are managed by LongLink.

--- a/arc/sdk/README.md
+++ b/arc/sdk/README.md
@@ -1,0 +1,15 @@
+# SDK Documentation
+
+This folder documents the LongLink SDK and how developers use it to build and publish platform applications.
+
+## Contents
+
+- [`CLI.md`](./CLI.md): Reference for the `viavai` command-line interface.
+
+## Scope
+
+The SDK is used to:
+
+- scaffold new app modules,
+- generate database migration scripts,
+- and publish apps to the platform.


### PR DESCRIPTION
### Motivation
- Provide a dedicated, lowercase `arc/sdk` documentation area to explain the LongLink SDK and document the `viavai` CLI commands used to scaffold, migrate, and publish apps.

### Description
- Add `arc/sdk/README.md` that describes the SDK folder purpose and links to the CLI reference.
- Add `arc/sdk/CLI.md` documenting the `viavai` commands: `viavai create <app_name>`, `viavai migrate`, and `viavai publish`, plus a common workflow and notes.

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a488b449cc8323b0c454af78123ba7)