### PR TITLE
Fix settings update crash and standardize org settings keys to ORG_*

### DIFF
--- a/api/src/config.py
+++ b/api/src/config.py
@@ -17,6 +17,7 @@ class Config(BaseSettings):
     ORG_NAME_LEGAL: str | None = None
     ORG_MAIL_CONTACT: str | None = None
     ORG_MAIL_SUPPORT: str | None = None
+    ORG_TAX_ID: str | None = None
     ORG_PHONE: str | None = None
     ORG_WEBSITE: str | None = None
     ORG_ADDRESS: str | None = None
@@ -26,6 +27,18 @@ class Config(BaseSettings):
     ENV_DATABASE_URL: str  = 'sqlite+aiosqlite:///./db.sqlite3'
     ENV_GITHUB_CLIENT_ID: str | None = None
     ENV_GITHUB_CLIENT_SECRET: str | None = None 
+
+    ORG_KEY_ALIASES: dict[str, str] = {
+        'ORGANIZATION_NAME': 'ORG_NAME',
+        'ORGANIZATION_LEGAL_NAME': 'ORG_NAME_LEGAL',
+        'ORGANIZATION_PRIMARY_CONTACT_EMAIL': 'ORG_MAIL_CONTACT',
+        'ORGANIZATION_SUPPORT_EMAIL': 'ORG_MAIL_SUPPORT',
+        'ORGANIZATION_REGISTRATION_TAX_ID': 'ORG_TAX_ID',
+        'ORGANIZATION_PHONE_NUMBER': 'ORG_PHONE',
+        'ORGANIZATION_WEBSITE': 'ORG_WEBSITE',
+        'ORGANIZATION_PHYSICAL_ADDRESS': 'ORG_ADDRESS',
+        'ORGANIZATION_LOGO': 'ORG_LOGO',
+    }
     
     model_config = SettingsConfigDict(
         env_file=('.env'),
@@ -34,11 +47,18 @@ class Config(BaseSettings):
 
     def get(self, key: str) -> str | None:
         """Get a configuration value by key."""
-        return getattr(self, key, None)
+        normalized_key = self.normalize_key(key)
+        return getattr(self, normalized_key, None)
 
     def set(self, key: str, value: str) -> None:
         """Set a configuration value by key."""
-        setattr(self, key, value)
+        normalized_key = self.normalize_key(key)
+        if normalized_key in self.model_fields:
+            setattr(self, normalized_key, value)
+
+    def normalize_key(self, key: str) -> str:
+        normalized_key = key.upper()
+        return self.ORG_KEY_ALIASES.get(normalized_key, normalized_key)
 
 
 config = Config() # type: ignore

--- a/api/src/db/services/settings.py
+++ b/api/src/db/services/settings.py
@@ -20,9 +20,10 @@ class SettingsService:
 
     async def get(self, key: str, *, app_id: int | None = None) -> Setting | None:
         '''Return a setting by key and scope.'''
+        normalized_key = config.normalize_key(key)
         Session = await get_session()
         async with Session() as session:
-            statement = select(Setting).where(Setting.key == key)
+            statement = select(Setting).where(Setting.key == normalized_key)
             if app_id is None:
                 statement = statement.where(Setting.appid.is_(None))
             else:
@@ -33,9 +34,10 @@ class SettingsService:
 
     async def set(self, key: str, value: str, *, app_id: int | None = None) -> Setting:
         '''Create or update a setting by key and scope.'''
+        normalized_key = config.normalize_key(key)
         Session = await get_session()
         async with Session() as session:
-            statement = select(Setting).where(Setting.key == key)
+            statement = select(Setting).where(Setting.key == normalized_key)
             if app_id is None:
                 statement = statement.where(Setting.appid.is_(None))
             else:
@@ -45,13 +47,13 @@ class SettingsService:
             setting = result.scalar_one_or_none()
 
             if setting is None:
-                setting = Setting(key=key, value=value, appid=app_id)
+                setting = Setting(key=normalized_key, value=value, appid=app_id)
                 session.add(setting)
             else:
                 setting.value = value
 
             # Update the config in memory, this allows to change the envs without restarting the application
-            config.set(key, value)
+            config.set(normalized_key, value)
             
             await session.commit()
             await session.refresh(setting)

--- a/web/src/components/settings/General.tsx
+++ b/web/src/components/settings/General.tsx
@@ -26,14 +26,14 @@ const INITIAL_SETTINGS: OrganizationSettingsState = {
 };
 
 const ORGANIZATION_SETTING_KEYS = {
-    organizationName: 'organization_name',
-    legalName: 'organization_legal_name',
-    registrationTaxId: 'organization_registration_tax_id',
-    phoneNumber: 'organization_phone_number',
-    primaryContactEmail: 'organization_primary_contact_email',
-    supportEmail: 'organization_support_email',
-    website: 'organization_website',
-    physicalAddress: 'organization_physical_address',
+    organizationName: 'ORG_NAME',
+    legalName: 'ORG_NAME_LEGAL',
+    registrationTaxId: 'ORG_TAX_ID',
+    phoneNumber: 'ORG_PHONE',
+    primaryContactEmail: 'ORG_MAIL_CONTACT',
+    supportEmail: 'ORG_MAIL_SUPPORT',
+    website: 'ORG_WEBSITE',
+    physicalAddress: 'ORG_ADDRESS',
 } as const;
 
 type SettingResponse = {

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -4,8 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button';
 import { useUser } from '@/hooks/use-user';
 
-import { Table } from '@/components/longlink/Table'
-
+import { Table } from '@/components/longlink/Table';
 
 export default function NotFound() {
     const location = useLocation();
@@ -13,24 +12,25 @@ export default function NotFound() {
     const primaryLink = user ? '/' : '/';
     const primaryLabel = user ? 'Back to dashboard' : 'Back to home';
 
-
-    return <Table
-        endpoint="/sample"
-        schema={{
-            title: "Users",
-            schema: {
-                columns: [
-                    {
-                        key: "user",
-                        label: "Name",
-                        align: "left",
-                        value: "{name}",
-                        detail: "{email}"
-                    }
-                ]
-            }
-        }}
-    />
+    return (
+        <Table
+            endpoint="/sample"
+            schema={{
+                title: 'Users',
+                schema: {
+                    columns: [
+                        {
+                            key: 'user',
+                            label: 'Name',
+                            align: 'left',
+                            value: '{name}',
+                            detail: '{email}',
+                        },
+                    ],
+                },
+            }}
+        />
+    );
 
     return (
         <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">


### PR DESCRIPTION
### Motivation

- Prevent Pydantic `Config` assignment errors (`ValueError: "Config" object has no field "organization_name"`) when clients send legacy or lowercase organization keys by normalizing keys before applying them to in-memory settings. 
- Standardize organization-related setting keys to canonical uppercase `ORG_*` names so stored DB keys, in-memory config and frontend usage are consistent.

### Description

- Updated `api/src/config.py` to add `ORG_TAX_ID`, an `ORG_KEY_ALIASES` mapping for legacy key names, and `normalize_key` to convert incoming keys to canonical `ORG_*` names; `get` and `set` now normalize keys and `set` only assigns when the field exists (`model_fields`).
- Updated `api/src/db/services/settings.py` so `get` and `set` normalize keys before querying or creating `Setting` rows and persist the normalized key into the DB, and updated the in-memory `config.set` call to use the normalized key.
- Updated `web/src/components/settings/General.tsx` to use the canonical uppercase `ORG_*` keys (including `ORG_TAX_ID`) for all organization fields so frontend requests match the new canonical keys.
- Ran code formatting on the web app which produced whitespace/formatting changes in `web/src/pages/NotFound.tsx` (no functional change).

### Testing

- Ran `python -m compileall api/src` to verify Python sources compile successfully, and it succeeded.
- Ran `bun run format` in the `web` directory to apply formatting changes, and it succeeded.
- Attempted `bun run build` for the web bundle which failed due to pre-existing TypeScript issues unrelated to these changes (e.g. `react-resizable-panels` typings and missing `@/hooks/use-mobile`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a489618dd8832380327c3aa5bb87c2)