### PR TITLE
Add GitHub Actions workflow to generate PDF from workflow input

### DIFF
--- a/.github/pdf/document.md.j2
+++ b/.github/pdf/document.md.j2
@@ -1,0 +1,5 @@
+# Workflow PDF
+
+The provided workflow parameter is:
+
+**{{ pdf_text }}**

--- a/.github/pdf/template.tex
+++ b/.github/pdf/template.tex
@@ -1,0 +1,15 @@
+\\documentclass[11pt]{article}
+\\usepackage[margin=1in]{geometry}
+\\usepackage{fontspec}
+\\setmainfont{Latin Modern Roman}
+\\usepackage{hyperref}
+
+\\title{Workflow Generated PDF}
+\\date{}
+
+\\begin{document}
+\\maketitle
+
+$body$
+
+\\end{document}

--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -1,0 +1,66 @@
+name: Generate PDF
+
+on:
+  workflow_dispatch:
+    inputs:
+      pdf_text:
+        description: Text to include in the generated PDF
+        required: true
+        type: string
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install rendering and PDF dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jinja2
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive-xetex
+
+      - name: Render markdown from Jinja template
+        env:
+          PDF_TEXT: ${{ inputs.pdf_text }}
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from jinja2 import Environment, FileSystemLoader, select_autoescape
+          import os
+
+          template_dir = Path('.github/pdf')
+          env = Environment(
+              loader=FileSystemLoader(str(template_dir)),
+              autoescape=select_autoescape(disabled_extensions=('md',), default=False),
+              trim_blocks=True,
+              lstrip_blocks=True,
+          )
+
+          template = env.get_template('document.md.j2')
+          rendered_markdown = template.render(pdf_text=os.environ['PDF_TEXT'])
+          Path('workflow-output.md').write_text(rendered_markdown, encoding='utf-8')
+          PY
+
+      - name: Generate PDF with pandoc and LaTeX template
+        run: |
+          pandoc workflow-output.md \
+            --from markdown \
+            --pdf-engine=xelatex \
+            --template .github/pdf/template.tex \
+            --output workflow-output.pdf
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-output-pdf
+          path: |
+            workflow-output.pdf
+            workflow-output.md


### PR DESCRIPTION
### Motivation

- Provide a reusable GitHub Actions workflow to produce a PDF artifact from a user-supplied string so documentation or simple reports can be generated from the repository.

### Description

- Add a Jinja Markdown template at `.github/pdf/document.md.j2` that exposes the `pdf_text` input for rendering.
- Add a LaTeX template at `.github/pdf/template.tex` used by `pandoc` with the `xelatex` engine to produce a nicely formatted PDF.
- Add a workflow at `.github/workflows/generate-pdf.yml` that installs Python and system dependencies, renders the Jinja template to `workflow-output.md`, converts it to `workflow-output.pdf` via `pandoc`, and uploads `workflow-output.pdf` and `workflow-output.md` as artifacts. 
- The workflow is triggered via `workflow_dispatch` and accepts a `pdf_text` string input.

### Testing

- No automated tests were configured or executed as part of this change; the workflow can be exercised via `workflow_dispatch` in GitHub Actions to validate end-to-end artifact generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30f22ff108323a53c2ebfd91781a9)