### PR TITLE
Reorder organization tabs and add Overview/Tools/Spaces/Processes pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,10 @@ import NotFound from '@/pages/NotFound';
 // Organization related pages
 import People from '@/pages/org/People';
 import SettingsPage from '@/pages/org/Settings';
-import Apps from '@/pages/org/Apps';
+import Overview from '@/pages/org/Overview';
+import Tools from '@/pages/org/Tools';
+import Spaces from '@/pages/org/Spaces';
+import Processes from '@/pages/org/Processes';
 import Longlink from '@/pages/org/Longlink';
 
 const withAuth = (element: ReactElement) => (
@@ -26,8 +29,11 @@ const router = createBrowserRouter([
         path: '/',
         element: withAuth(<Layout />),
         children: [
-            { index: true, element: <Navigate to="/apps" replace /> },
-            { path: 'apps', element: <Apps /> },
+            { index: true, element: <Navigate to="/overview" replace /> },
+            { path: 'overview', element: <Overview /> },
+            { path: 'tools', element: <Tools /> },
+            { path: 'spaces', element: <Spaces /> },
+            { path: 'processes', element: <Processes /> },
             { path: 'people', element: <People /> },
             { path: 'settings', element: <SettingsPage /> },
             {

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -101,7 +101,7 @@ export function Navigation({
     const activeTab = isTabsLoading
         ? 'loading'
         : location.pathname.startsWith('/profile')
-          ? 'apps'
+          ? (tabs[0]?.value ?? '')
           : (activeTabConfig?.value ?? tabs[0]?.value ?? '');
 
     return (

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -1,10 +1,12 @@
 import type { LucideIcon } from 'lucide-react';
 import {
     BarChart3,
+    Blocks,
     FileText,
     FolderKanban,
     Settings,
     Users,
+    Workflow,
 } from 'lucide-react';
 
 // import { getIconByName } from '@/components/Icon';
@@ -17,7 +19,15 @@ export type NavigationTab = {
 };
 
 const organizationTabs: NavigationTab[] = [
-    { value: 'apps', label: 'Apps', path: 'apps', icon: FolderKanban },
+    { value: 'overview', label: 'Overview', path: 'overview', icon: BarChart3 },
+    { value: 'tools', label: 'Tools', path: 'tools', icon: Blocks },
+    { value: 'spaces', label: 'Spaces', path: 'spaces', icon: FolderKanban },
+    {
+        value: 'processes',
+        label: 'Processes',
+        path: 'processes',
+        icon: Workflow,
+    },
     { value: 'people', label: 'People', path: 'people', icon: Users },
     { value: 'settings', label: 'Settings', path: 'settings', icon: Settings },
 ];

--- a/web/src/pages/org/Overview.tsx
+++ b/web/src/pages/org/Overview.tsx
@@ -1,0 +1,74 @@
+import { Blocks, FolderGit2, Users } from 'lucide-react';
+import Hero from '@/components/longlink/Hero';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { useApps } from '@/hooks/use-apps';
+import { useUsers } from '@/hooks/use-users';
+
+export default function Overview() {
+    const { data: apps = [], isLoading: isAppsLoading } = useApps();
+    const { users, isLoading: isUsersLoading } = useUsers();
+
+    return (
+        <div className="space-y-6">
+            <Hero
+                title="Overview"
+                subtitle="A high-level snapshot of your organization workspace."
+                icon="layout-dashboard"
+            />
+
+            <div className="grid gap-4 md:grid-cols-3">
+                <Card>
+                    <CardHeader>
+                        <CardDescription className="flex items-center gap-2 text-white/60">
+                            <Blocks className="h-4 w-4" />
+                            Tools
+                        </CardDescription>
+                        <CardTitle>
+                            {isAppsLoading ? 'Loading…' : `${apps.length}`}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-white/60">
+                        Manage the apps and services available to your
+                        organization.
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardDescription className="flex items-center gap-2 text-white/60">
+                            <Users className="h-4 w-4" />
+                            People
+                        </CardDescription>
+                        <CardTitle>
+                            {isUsersLoading ? 'Loading…' : `${users.length}`}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-white/60">
+                        Keep track of teammates, collaborators, and workspace
+                        access.
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardDescription className="flex items-center gap-2 text-white/60">
+                            <FolderGit2 className="h-4 w-4" />
+                            Processes
+                        </CardDescription>
+                        <CardTitle>Coming next</CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-white/60">
+                        Organize repeatable workflows and shared operational
+                        steps.
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    );
+}

--- a/web/src/pages/org/Processes.tsx
+++ b/web/src/pages/org/Processes.tsx
@@ -1,0 +1,37 @@
+import { Workflow } from 'lucide-react';
+import Hero from '@/components/longlink/Hero';
+import { Card } from '@/components/ui/card';
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@/components/ui/empty';
+
+export default function Processes() {
+    return (
+        <div className="space-y-6">
+            <Hero
+                title="Processes"
+                subtitle="Document and automate the operational flows your teams rely on."
+                icon="workflow"
+            />
+
+            <Card className="p-10 text-center">
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <Workflow className="h-5 w-5" />
+                        </EmptyMedia>
+                        <EmptyTitle>No Processes Yet</EmptyTitle>
+                        <EmptyDescription>
+                            Processes will surface reusable workflows and
+                            playbooks for your organization.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </Card>
+        </div>
+    );
+}

--- a/web/src/pages/org/Spaces.tsx
+++ b/web/src/pages/org/Spaces.tsx
@@ -1,0 +1,37 @@
+import { PanelsTopLeft } from 'lucide-react';
+import Hero from '@/components/longlink/Hero';
+import { Card } from '@/components/ui/card';
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@/components/ui/empty';
+
+export default function Spaces() {
+    return (
+        <div className="space-y-6">
+            <Hero
+                title="Spaces"
+                subtitle="Create dedicated work areas for teams, projects, and context."
+                icon="panels-top-left"
+            />
+
+            <Card className="p-10 text-center">
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <PanelsTopLeft className="h-5 w-5" />
+                        </EmptyMedia>
+                        <EmptyTitle>No Spaces Yet</EmptyTitle>
+                        <EmptyDescription>
+                            Spaces will help organize work into focused
+                            environments for your organization.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </Card>
+        </div>
+    );
+}

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -21,7 +21,7 @@ import { Input } from '@/components/ui/input';
 import { useApps, useCreateApp } from '@/hooks/use-apps';
 
 const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
-    title: 'Apps',
+    title: 'Tools',
     schema: {
         columns: [
             {
@@ -41,14 +41,14 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
     },
 };
 
-export default function Apps() {
+export default function Tools() {
     const { data: apps = [], isLoading, error } = useApps();
     const { mutateAsync: createApp, isPending } = useCreateApp();
     const [name, setName] = useState('');
     const [url, setUrl] = useState('');
     const [createError, setCreateError] = useState<string | null>(null);
     const loadErrorMessage =
-        error instanceof Error ? error.message : 'Failed to load apps';
+        error instanceof Error ? error.message : 'Failed to load tools';
 
     const onCreateApp = async () => {
         if (!name.trim() || !url.trim()) {
@@ -65,7 +65,7 @@ export default function Apps() {
             setUrl('');
         } catch (err) {
             setCreateError(
-                err instanceof Error ? err.message : 'Failed to create app'
+                err instanceof Error ? err.message : 'Failed to create tool'
             );
         }
     };
@@ -73,27 +73,27 @@ export default function Apps() {
     return (
         <div className="space-y-6">
             <Hero
-                title="Apps"
-                subtitle={`${apps.length} apps`}
+                title="Tools"
+                subtitle={`${apps.length} tools`}
                 icon="sparkles"
-                action="Create New App"
+                action="Create Tool"
             >
                 <DialogContent className="sm:max-w-3xl">
                     <DialogHeader>
-                        <DialogTitle>Create a new app</DialogTitle>
+                        <DialogTitle>Create a new tool</DialogTitle>
                         <DialogDescription>
-                            Add a name and URL to register your app.
+                            Add a name and URL to register your tool.
                         </DialogDescription>
                     </DialogHeader>
 
                     <div className="grid gap-3 md:grid-cols-3">
                         <Input
-                            placeholder="App name"
+                            placeholder="Tool name"
                             value={name}
                             onChange={(event) => setName(event.target.value)}
                         />
                         <Input
-                            placeholder="http://localhost:1707/my-app"
+                            placeholder="http://localhost:1707/my-tool"
                             value={url}
                             onChange={(event) => setUrl(event.target.value)}
                         />
@@ -103,7 +103,7 @@ export default function Apps() {
                             disabled={isPending}
                         >
                             <Plus className="h-4 w-4" />
-                            New App
+                            New Tool
                         </Button>
                     </div>
 
@@ -115,7 +115,7 @@ export default function Apps() {
 
             {isLoading ? (
                 <Card className="p-10 text-center text-white/60">
-                    Loading apps...
+                    Loading tools...
                 </Card>
             ) : error ? (
                 <Card className="p-10 text-center text-red-300">
@@ -128,10 +128,10 @@ export default function Apps() {
                             <EmptyMedia variant="icon">
                                 <Sparkles className="h-5 w-5" />
                             </EmptyMedia>
-                            <EmptyTitle>No Apps Yet</EmptyTitle>
+                            <EmptyTitle>No Tools Yet</EmptyTitle>
                             <EmptyDescription>
-                                You haven&apos;t added any apps yet. Get started
-                                by creating your first app.
+                                You haven&apos;t added any tools yet. Get
+                                started by creating your first tool.
                             </EmptyDescription>
                         </EmptyHeader>
                     </Empty>


### PR DESCRIPTION
### Motivation
- Replace the single `Apps` organization tab with the requested ordered tab set: `Overview`, `Tools`, `Spaces`, `Processes`, `People`, and `Settings` to match the new organization UX flow.
- Provide initial pages for new tabs so the navigation has real destinations and the default organization landing page can show a high‑level snapshot.

### Description
- Updated organization navigation and routes to the new order and default: added routes in `web/src/App.tsx` and changed the default landing route to `Overview` via `Navigate` and new imports for `Overview`, `Tools`, `Spaces`, and `Processes`.
- Replaced the `organizationTabs` array in `web/src/lib/navigation.ts` to declare tabs in the order `overview`, `tools`, `spaces`, `processes`, `people`, `settings` and assigned appropriate icons.
- Adjusted `web/src/Layout.tsx` so the profile view keeps the first organization tab selected (`tabs[0]`) instead of referencing the old `apps` value.
- Added new pages `web/src/pages/org/Overview.tsx`, `web/src/pages/org/Spaces.tsx`, and `web/src/pages/org/Processes.tsx`, and repurposed the former `Apps.tsx` as `Tools.tsx` (renamed and updated UI copy for tools list/creation).

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bun run build` which failed due to unrelated pre-existing TypeScript errors elsewhere in the repo (errors in `src/components/ui/resizable.tsx`, `src/components/ui/sidebar.tsx`, `src/pages/org/Longlink.tsx`, and `src/pages/org/People.tsx`), so the build did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12bdd586c8323a17ce94edb6fe892)