### PR TITLE
Fix People table rendering (use content/detail fields)

### DIFF
--- a/web/src/pages/org/People.tsx
+++ b/web/src/pages/org/People.tsx
@@ -15,7 +15,8 @@ const columns: ApiTableColumn[] = [
     {
         key: 'name',
         label: 'Name',
-        cell: ['{name}', '{email}'],
+        content: { value: '{name}', bold: true },
+        detail: '{email}',
     },
 ];
 


### PR DESCRIPTION
### Motivation
- The People list stopped rendering user name/email rows because the page used an unsupported `cell` shape for columns while the shared table renderer expects `content` and `detail` fields. 

### Description
- Updated the column configuration in `web/src/pages/org/People.tsx` to replace the legacy `cell: ['{name}', '{email}']` with `content: { value: '{name}', bold: true }` and `detail: '{email}'` so rows render through the shared `Table` component.

### Testing
- Ran formatter with `bun run format` which completed successfully.
- Ran linter with `bunx eslint src/pages/org/People.tsx` which completed successfully.
- Ran build with `bun run build` which failed due to pre-existing unrelated TypeScript issues in other files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`, and `src/pages/org/Longlink.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12da714e4832387a121851ae7bef5)