### PR TITLE
api: split environment settings from runtime config

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from src.env import env
 from src.router import router
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -22,7 +23,7 @@ app.add_middleware(
 )
 app.add_middleware(
     SessionMiddleware,
-    secret_key='1234',
+    secret_key=env.KEY,
     same_site='lax',
     https_only=False,
 )

--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -1,7 +1,7 @@
 import src.db as db
 from authlib.integrations.starlette_client import OAuth
 from fastapi import HTTPException, Request
-from src.config import config
+from src.env import env
 
 """
 TODO: We do not create a new authentication system, instead we integrate with existing Identity Providers (IdP)
@@ -24,11 +24,11 @@ oauth = OAuth()
 AVAILABLE_AUTH_METHODS: list[str] = []
 
 
-if config.ENV_GITHUB_CLIENT_ID and config.ENV_GITHUB_CLIENT_SECRET:
+if env.ENV_GITHUB_CLIENT_ID and env.ENV_GITHUB_CLIENT_SECRET:
     oauth.register(
         name='github',
-        client_id=config.ENV_GITHUB_CLIENT_ID,
-        client_secret=config.ENV_GITHUB_CLIENT_SECRET,
+        client_id=env.ENV_GITHUB_CLIENT_ID,
+        client_secret=env.ENV_GITHUB_CLIENT_SECRET,
         access_token_url='https://github.com/login/oauth/access_token',
         authorize_url='https://github.com/login/oauth/authorize',
         api_base_url='https://api.github.com/',

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -1,34 +1,43 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from src.env import env
 
 
-class Config(BaseSettings):
-    """API Configuration
-    
-    1) When the application starts, it will load the configurations from the enviroment variables or from the .env file.
-    2) The settings are stored in the database, as well the envs and they can be overwrite the enviroment variables, this allows to change the settings without restarting the application.
+class Config:
+    '''Runtime mutable configuration stored in memory and persisted in the database.'''
 
-    """
-    # Secret key for signing the env in the database, 
-    # this is the only env that is required to set and should be set to a random string in production
-    KEY: str = '1234' 
+    _default_values: dict[str, str | None] = {
+        'ORG_NAME': None,
+        'ORG_NAME_LEGAL': None,
+        'ORG_MAIL_CONTACT': None,
+        'ORG_MAIL_SUPPORT': None,
+        'ORG_TAX_ID': None,
+        'ORG_PHONE': None,
+        'ORG_WEBSITE': None,
+        'ORG_ADDRESS': None,
+        'ORG_LOGO': None,
+    }
 
-    # Organization specific settings, those will be accessible to the sdk
-    ORG_NAME: str | None = None
-    ORG_NAME_LEGAL: str | None = None
-    ORG_MAIL_CONTACT: str | None = None
-    ORG_MAIL_SUPPORT: str | None = None
-    ORG_TAX_ID: str | None = None
-    ORG_PHONE: str | None = None
-    ORG_WEBSITE: str | None = None
-    ORG_ADDRESS: str | None = None
-    ORG_LOGO: str | None = None
+    def __init__(self) -> None:
+        self._values: dict[str, str | None] = dict(self._default_values)
+        self._reserved_keys = set(type(env).model_fields.keys())
 
-    # Environment variables, those can be in a .env file or 
-    ENV_DATABASE_URL: str  = 'sqlite+aiosqlite:///./db.sqlite3'
-    ENV_GITHUB_CLIENT_ID: str | None = None
-    ENV_GITHUB_CLIENT_SECRET: str | None = None 
-    
-    model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8' )
+    def normalize_key(self, key: str) -> str:
+        normalized_key = key.strip().upper().replace('-', '_')
+        if not normalized_key:
+            raise ValueError('Configuration key cannot be empty')
+
+        if normalized_key in self._reserved_keys or normalized_key.startswith('ENV_'):
+            raise ValueError(f"'{normalized_key}' is environment-backed and cannot be updated at runtime")
+
+        return normalized_key
+
+    def get(self, key: str) -> str | None:
+        normalized_key = self.normalize_key(key)
+        return self._values.get(normalized_key)
+
+    def set(self, key: str, value: str | None) -> str | None:
+        normalized_key = self.normalize_key(key)
+        self._values[normalized_key] = value
+        return value
 
 
-config = Config() # type: ignore
+config = Config()

--- a/api/src/db/services/envs.py
+++ b/api/src/db/services/envs.py
@@ -1,5 +1,4 @@
 from sqlalchemy import select
-from src.config import config
 from src.db.models import Env
 from src.db.session import get_session
 
@@ -38,7 +37,5 @@ class EnvsService:
             await session.commit()
             await session.refresh(env)
 
-            # Update the config in memory, this allows to change the envs without restarting the application
-            config.set(key, value)
 
             return env

--- a/api/src/db/services/settings.py
+++ b/api/src/db/services/settings.py
@@ -52,9 +52,8 @@ class SettingsService:
             else:
                 setting.value = value
 
-            # Update the config in memory, this allows to change the envs without restarting the application
             config.set(normalized_key, value)
-            
+
             await session.commit()
             await session.refresh(setting)
             return setting

--- a/api/src/db/session.py
+++ b/api/src/db/session.py
@@ -1,5 +1,5 @@
 from src.db.models import Base
-from src.config import config
+from src.env import env
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 
@@ -14,7 +14,7 @@ async def get_session() -> async_sessionmaker[AsyncSession]:
     if Session is not None:
         return Session
 
-    dburl = config.ENV_DATABASE_URL
+    dburl = env.ENV_DATABASE_URL
 
     engine_kwargs = {
         'pool_pre_ping': True,

--- a/api/src/env.py
+++ b/api/src/env.py
@@ -1,0 +1,15 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Env(BaseSettings):
+    '''Environment-backed API configuration loaded at startup.'''
+
+    KEY: str = '1234'
+    ENV_DATABASE_URL: str = 'sqlite+aiosqlite:///./db.sqlite3'
+    ENV_GITHUB_CLIENT_ID: str | None = None
+    ENV_GITHUB_CLIENT_SECRET: str | None = None
+
+    model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
+
+
+env = Env()

--- a/api/src/routes/settings.py
+++ b/api/src/routes/settings.py
@@ -7,12 +7,20 @@ from src.models.settings import SettingResponse, SettingSet, SettingSetItem
 from src.router import router
 
 
+def _invalid_key_error(error: ValueError) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(error))
+
+
 @router.get('/settings')
 async def get_settings(keys: List[str] = Query(...)) -> List[SettingResponse]:
     results: List[SettingResponse] = []
 
     for key in keys:
-        setting = await db.settings.get(key, app_id=None)
+        try:
+            setting = await db.settings.get(key, app_id=None)
+        except ValueError as error:
+            raise _invalid_key_error(error) from error
+
         if setting is None:
             raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
 
@@ -32,7 +40,10 @@ async def set_settings(payload: List[SettingSetItem]) -> List[SettingResponse]:
     results: List[SettingResponse] = []
 
     for item in payload:
-        setting = await db.settings.set(item.key, item.value, app_id=None)
+        try:
+            setting = await db.settings.set(item.key, item.value, app_id=None)
+        except ValueError as error:
+            raise _invalid_key_error(error) from error
 
         results.append(
             SettingResponse(
@@ -47,7 +58,11 @@ async def set_settings(payload: List[SettingSetItem]) -> List[SettingResponse]:
 
 @router.get('/settings/{key}')
 async def get_setting(key: str) -> SettingResponse:
-    setting = await db.settings.get(key, app_id=None)
+    try:
+        setting = await db.settings.get(key, app_id=None)
+    except ValueError as error:
+        raise _invalid_key_error(error) from error
+
     if setting is None:
         raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
 
@@ -60,7 +75,11 @@ async def get_setting(key: str) -> SettingResponse:
 
 @router.post('/settings/{key}')
 async def post_setting(key: str, payload: SettingSet) -> SettingResponse:
-    setting = await db.settings.set(key, payload.value, app_id=None)
+    try:
+        setting = await db.settings.set(key, payload.value, app_id=None)
+    except ValueError as error:
+        raise _invalid_key_error(error) from error
+
     return SettingResponse(
         key=setting.key,
         value=setting.value,
@@ -70,7 +89,11 @@ async def post_setting(key: str, payload: SettingSet) -> SettingResponse:
 
 @router.put('/settings/{key}')
 async def set_setting(key: str, payload: SettingSet) -> SettingResponse:
-    setting = await db.settings.set(key, payload.value, app_id=None)
+    try:
+        setting = await db.settings.set(key, payload.value, app_id=None)
+    except ValueError as error:
+        raise _invalid_key_error(error) from error
+
     return SettingResponse(
         key=setting.key,
         value=setting.value,


### PR DESCRIPTION
### Motivation
- Separate immutable, startup-loaded environment values (secrets, DB URL, OAuth credentials) from mutable platform settings that can be changed at runtime.
- Prevent accidental mutation of environment-backed values via the settings API or app-scoped env secrets.
- Make it explicit which values are safe to change at runtime and provide a clear runtime config surface for org/app settings.

### Description
- Add `api/src/env.py` containing a `pydantic` `Env` model and `env` instance for startup-only environment-backed settings (e.g. `KEY`, `ENV_DATABASE_URL`, GitHub client id/secret).
- Replace the previous monolithic `src/config.py` with a runtime `Config` class that stores mutable org settings in memory, implements `normalize_key`, and blocks updates to reserved/env-backed keys; exposed as `config` in `src/config.py`.
- Update consumers to use `env` for startup-only values: `api/main.py` (session secret), `api/src/db/session.py` (DB URL), and `api/src/auth.py` (OAuth registration) now read from `src.env`.
- Harden settings endpoints: `api/src/routes/settings.py` now catches `ValueError` from `config.normalize_key` and returns `400` for attempts to read/write env-backed keys; `api/src/db/services/envs.py` removed the previous in-memory mutation so app env secrets no longer update API runtime config.
- Kept runtime settings writes (platform settings) updating the in-memory `config` (`src/db/services/settings.py`) so mutable settings are still persisted and effective at runtime.

### Testing
- Ran `python -m compileall api/src api/main.py` to verify Python modules compile successfully (succeeded).
- Executed a small smoke script validating key normalization and env-key rejection using `from src.config import config` and `from src.env import env` which printed the normalized runtime key, the `ENV_DATABASE_URL`, and showed a `ValueError` when attempting to normalize an `ENV_` key (succeeded).
- Performed a whitespace/diff sanity check to ensure there are no obvious diff-check errors (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13c2738f88323b344165a7729426a)