### PR TITLE
Add docker-compose for local Postgres and MinIO (S3) testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: longlink-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-longlink}
+      POSTGRES_USER: ${POSTGRES_USER:-longlink}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-longlink}
+    ports:
+      - '${POSTGRES_PORT:-5432}:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-longlink} -d ${POSTGRES_DB:-longlink}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  minio:
+    image: minio/minio:latest
+    container_name: longlink-minio
+    restart: unless-stopped
+    command: server /data --console-address ':9001'
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - '${MINIO_API_PORT:-9000}:9000'
+      - '${MINIO_CONSOLE_PORT:-9001}:9001'
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  minio-setup:
+    image: minio/mc:latest
+    container_name: longlink-minio-setup
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin} &&
+      mc mb --ignore-existing local/${MINIO_BUCKET:-longlink} &&
+      mc anonymous set private local/${MINIO_BUCKET:-longlink}
+      "
+    restart: 'no'
+
+volumes:
+  postgres_data:
+  minio_data:


### PR DESCRIPTION
### Motivation
- Provide a reproducible local test stack that matches the app expectations for a SQL database and S3-compatible object storage. 
- Enable the API and SDK to be exercised against realistic services instead of only the built-in SQLite/file backends.

### Description
- Add a root `docker-compose.yml` that defines a `postgres` service using `postgres:16-alpine` with configurable `POSTGRES_*` environment variables, a mapped port, a persistent `postgres_data` volume, and a readiness `pg_isready` healthcheck. 
- Add a `minio` service using `minio/minio:latest` that exposes API and console ports, uses `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` defaults, a persistent `minio_data` volume, and an HTTP healthcheck. 
- Add a one-shot `minio-setup` service using `minio/mc:latest` that waits for MinIO to be healthy, creates the default bucket (`${MINIO_BUCKET:-longlink}`), and applies a private policy so the stack is ready-to-use on startup. 
- Use environment-variable driven defaults for credentials, ports, and bucket names so the compose file is configurable without modification.

### Testing
- Parsed and validated the `docker-compose.yml` YAML structure using Ruby with `YAML.load_file` and confirmed services `minio`, `minio-setup`, and `postgres` are present (succeeded). 
- Attempted `docker compose config` validation but could not run it in this environment because `docker` is not installed (not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13db652e88323872c25f8e24346c4)