### PR TITLE
Add DEV-only localhost login flow to API and web login page

### DIFF
--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -40,6 +40,9 @@ if env.ENV_GITHUB_CLIENT_ID and env.ENV_GITHUB_CLIENT_SECRET:
 else:
     print('GitHub authentication not configured')
 
+if env.DEV:
+    AVAILABLE_AUTH_METHODS.append('localhost')
+
 
 async def authuser(request: Request) -> db.User:
     userid = request.session.get('userid')

--- a/api/src/env.py
+++ b/api/src/env.py
@@ -6,6 +6,7 @@ class Env(BaseSettings):
 
     KEY: str = '1234'
     ENV_DATABASE_URL: str = 'sqlite+aiosqlite:///./db.sqlite3'
+    DEV: bool = False
     ENV_GITHUB_CLIENT_ID: str | None = None
     ENV_GITHUB_CLIENT_SECRET: str | None = None
 

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,19 +1,19 @@
 import src.db as db
 from typing import Any, cast
-from fastapi import Request, HTTPException
-from src.auth import oauth, AVAILABLE_AUTH_METHODS
-from src.router import router
-from fastapi.responses import RedirectResponse
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
+from fastapi import HTTPException, Request
+from fastapi.responses import RedirectResponse
+from src.auth import AVAILABLE_AUTH_METHODS, oauth
+from src.env import env
+from src.router import router
 
 
 URL = 'http://localhost:5173'
 
 
 @router.get('/login')
-async def login_methods() -> list[str]:
-    print(AVAILABLE_AUTH_METHODS)
-    return AVAILABLE_AUTH_METHODS
+async def login_methods() -> dict[str, list[str]]:
+    return {'methods': AVAILABLE_AUTH_METHODS}
 
 
 @router.get('/login/github')
@@ -70,9 +70,32 @@ async def auth_github(request: Request):
     return RedirectResponse(URL)
 
 
+@router.get('/login/localhost')
+async def login_localhost(request: Request):
+    if not env.DEV or 'localhost' not in AVAILABLE_AUTH_METHODS:
+        raise HTTPException(404, 'Authentication method not available')
+
+    localhost_oauth_id = 0
+    localhost_email = 'localhost@longlink.local'
+    localhost_name = 'Localhost User'
+
+    user = await db.users.get(localhost_oauth_id, by='github')
+    if user is None:
+        user = await db.users.get(localhost_email, by='email')
+
+    if user is None:
+        user = await db.users.create(
+            name=localhost_name,
+            email=localhost_email,
+            avatar=None,
+            oauth_github_id=localhost_oauth_id,
+        )
+
+    request.session['userid'] = user.id
+    return RedirectResponse(URL)
+
 
 @router.get('/logout')
 async def logout(request: Request):
     request.session.clear()
     return {'ok': True}
-    

--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -1,4 +1,4 @@
-import { Chrome, Github, Layers } from 'lucide-react';
+import { Chrome, Github, Laptop, Layers } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useEffect, useState } from 'react';
@@ -16,6 +16,7 @@ export default function Login() {
     const { data: user, isLoading } = useUser();
     const apiBaseUrl = getApiBaseUrl();
     const [availableMethods, setAvailableMethods] = useState<string[]>([]);
+    const isDevEnvironment = import.meta.env.VITE_DEV === 'true';
 
     const getDefaultReturnTo = () => {
         const referrer = document.referrer;
@@ -77,9 +78,15 @@ export default function Login() {
 
     const hasGoogleMethod = availableMethods.includes('google');
     const hasGithubMethod = availableMethods.includes('github');
+    const hasLocalhostMethod =
+        isDevEnvironment && availableMethods.includes('localhost');
 
     const handleGithubLogin = () => {
         window.location.href = `${apiBaseUrl}/login/github`;
+    };
+
+    const handleLocalhostLogin = () => {
+        window.location.href = `${apiBaseUrl}/login/localhost`;
     };
 
     return (
@@ -113,6 +120,16 @@ export default function Login() {
                             <Github className="h-4 w-4" />
                             Login with GitHub
                         </Button>
+                        {hasLocalhostMethod ? (
+                            <Button
+                                variant="secondary"
+                                className="h-11 gap-2"
+                                onClick={handleLocalhostLogin}
+                            >
+                                <Laptop className="h-4 w-4" />
+                                Localhost Login
+                            </Button>
+                        ) : null}
                     </div>
                 </CardContent>
             </Card>


### PR DESCRIPTION
### Motivation

- Allow developers to bypass OAuth during local development by exposing a temporary "Localhost Login" method when running in dev mode.

### Description

- Add a `DEV: bool = False` flag to the API environment config loaded from `.env` (`api/src/env.py`).
- Append a `localhost` auth method to `AVAILABLE_AUTH_METHODS` when `env.DEV` is true (`api/src/auth.py`).
- Change the `/login` endpoint to return `{ "methods": [...] }` and add a new `/login/localhost` endpoint that creates or reuses a local development user and sets the session (`api/src/routes/auth.py`).
- Update the web login page to show a "Localhost Login" button only when `VITE_DEV === 'true'` and the API reports the `localhost` method, and wire it to `GET /login/localhost` (`web/src/pages/user/Login.tsx`).

### Testing

- Ran frontend formatting with `cd web && bun run format`, which completed successfully.
- Compiled API sources with `cd api && python -m compileall src`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29948b5e883238f0a89c4cae85551)