### PR TITLE
Return `/login` auth methods as plain list of strings

### DIFF
--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -12,8 +12,8 @@ URL = 'http://localhost:5173'
 
 
 @router.get('/login')
-async def login_methods() -> dict[str, list[str]]:
-    return {'methods': AVAILABLE_AUTH_METHODS}
+async def login_methods() -> list[str]:
+    return AVAILABLE_AUTH_METHODS
 
 
 @router.get('/login/github')


### PR DESCRIPTION
### Motivation
- The frontend expects a plain list of authentication method names, and returning a wrapped dictionary prevented active methods like `localhost` from being detected correctly.

### Description
- Changed the `GET /login` handler in `api/src/routes/auth.py` to return `AVAILABLE_AUTH_METHODS` directly instead of `{'methods': AVAILABLE_AUTH_METHODS}`.
- Updated the function return type annotation from `dict[str, list[str]]` to `list[str]`.
- No other routes or logic were modified.

### Testing
- Ran `python -m compileall api/src/routes/auth.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29dd52dd48323a4e8c0f5a33fa8fc)