### PR TITLE
Return auth methods as array and make frontend accept the new shape

### DIFF
--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -12,8 +12,8 @@ URL = 'http://localhost:5173'
 
 
 @router.get('/login')
-async def login_methods() -> dict[str, list[str]]:
-    return {'methods': AVAILABLE_AUTH_METHODS}
+async def login_methods() -> list[str]:
+    return AVAILABLE_AUTH_METHODS
 
 
 @router.get('/login/github')

--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -6,9 +6,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { apiFetch, getApiBaseUrl } from '@/lib/api';
 import { useUser } from '@/hooks/use-user';
 
-type LoginMethodsResponse = {
-    methods?: string[];
-};
+type LoginMethodsResponse = string[] | { methods?: string[] };
 
 export default function Login() {
     const location = useLocation();
@@ -60,7 +58,9 @@ export default function Login() {
             try {
                 const data = await apiFetch<LoginMethodsResponse>('/login');
                 if (isMounted) {
-                    setAvailableMethods(data.methods ?? []);
+                    setAvailableMethods(
+                        Array.isArray(data) ? data : (data.methods ?? [])
+                    );
                 }
             } catch {
                 if (isMounted) {


### PR DESCRIPTION
### Motivation

- Simplify the `/login` endpoint payload to return a plain list of available authentication methods instead of an object wrapper.
- Make the login page resilient to the new API response shape while remaining backward-compatible with the previous `{ methods: [...] }` shape.

### Description

- Changed `login_methods` in `api/src/routes/auth.py` to return `list[str]` and now returns `AVAILABLE_AUTH_METHODS` directly instead of `{'methods': ...}`.
- Updated `web/src/pages/user/Login.tsx` to accept either `string[]` or `{ methods?: string[] }` via the `LoginMethodsResponse` type and to set `availableMethods` from either response shape using `Array.isArray(data) ? data : (data.methods ?? [])`.
- No other functional behavior changes were made; the login handlers and UI logic for `github`/`localhost` remain the same.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29dd52dd48323a4e8c0f5a33fa8fc)