### PR TITLE
web: show localhost login when available

### DIFF
--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -14,7 +14,6 @@ export default function Login() {
     const { data: user, isLoading } = useUser();
     const apiBaseUrl = getApiBaseUrl();
     const [availableMethods, setAvailableMethods] = useState<string[]>([]);
-    const isDevEnvironment = import.meta.env.VITE_DEV === 'true';
 
     const getDefaultReturnTo = () => {
         const referrer = document.referrer;
@@ -78,8 +77,7 @@ export default function Login() {
 
     const hasGoogleMethod = availableMethods.includes('google');
     const hasGithubMethod = availableMethods.includes('github');
-    const hasLocalhostMethod =
-        isDevEnvironment && availableMethods.includes('localhost');
+    const hasLocalhostMethod = availableMethods.includes('localhost');
 
     const handleGithubLogin = () => {
         window.location.href = `${apiBaseUrl}/login/github`;


### PR DESCRIPTION
### Motivation
- The login page additionally required `VITE_DEV === 'true'` to show the Localhost Login button which could hide the option even when the backend advertised `localhost` in its `/login` methods.

### Description
- Remove the `VITE_DEV` gate and rely on the backend methods list by using `const hasLocalhostMethod = availableMethods.includes('localhost');` in `web/src/pages/user/Login.tsx` so the UI shows the localhost option whenever the API exposes it.

### Testing
- Ran `bun run format` which completed successfully; attempted `bun run build` which failed due to pre-existing TypeScript errors in unrelated files (`src/components/ui/resizable.tsx`, `src/components/ui/scroll-area.tsx`, `src/components/ui/sidebar.tsx`, and `src/pages/org/Longlink.tsx`) and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a5432dbc8323ad687910bd7cbaff)