### PR TITLE
Fix localhost auth email validation failure

### DIFF
--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -76,7 +76,7 @@ async def login_localhost(request: Request):
         raise HTTPException(404, 'Authentication method not available')
 
     localhost_oauth_id = 0
-    localhost_email = 'localhost@longlink.local'
+    localhost_email = 'localhost@longlick.ch'
     localhost_name = 'Localhost User'
 
     user = await db.users.get(localhost_oauth_id, by='github')
@@ -90,6 +90,10 @@ async def login_localhost(request: Request):
             avatar=None,
             oauth_github_id=localhost_oauth_id,
         )
+    elif user.email != localhost_email:
+        updated_user = await db.users.update(user.id, email=localhost_email)
+        if updated_user is not None:
+            user = updated_user
 
     request.session['userid'] = user.id
     return RedirectResponse(URL)


### PR DESCRIPTION
### Motivation
- Pydantic `EmailStr` validation rejects the previous development fallback email `localhost@longlink.local` because the domain is a special-use/reserved name, causing `UserResponse` serialization to fail when listing users.
- The code needs a valid development email and a way to normalize any existing dev user records created with the old invalid email so listing and auth flows don't error.

### Description
- Changed the localhost development login email from `localhost@longlink.local` to `localhost@longlick.ch` in the `/login/localhost` route (`api/src/routes/auth.py`).
- Added a normalization step in `/login/localhost` that updates an existing localhost user's email to the new value using `db.users.update` when necessary.
- Preserves existing behavior of creating the dev user when none exists while preventing validation errors for `UserResponse`.

### Testing
- Ran `python -m compileall api/src/routes/auth.py` which compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2aafa84b48323bf21a463e6f34a04)