### PR TITLE
Bundle web build into API Docker image and serve static frontend

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,21 @@
+# --- frontend build ---
+FROM node:20 AS web-build
+WORKDIR /web
+COPY web/ ./
+RUN npm install && npm run build
+
+# --- api ---
+FROM python:3.11
+WORKDIR /app
+
+COPY sdk /sdk
+RUN pip install /sdk
+
+COPY api/ ./
+
+# copy built frontend into API
+COPY --from=web-build /web/dist /app/static
+
+RUN pip install -r requirements.txt
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -2,7 +2,10 @@ import os
 if __name__ == "__main__":
     os.environ.setdefault("DEV", "True")
 
+from pathlib import Path
+
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from src.env import env
 from src.router import router
 from fastapi.middleware.cors import CORSMiddleware
@@ -43,6 +46,10 @@ import src.routes.settings
 import src.routes.storages
 
 app.include_router(router)
+
+static_dir = Path(__file__).resolve().parent / 'static'
+if static_dir.exists():
+    app.mount('/', StaticFiles(directory=static_dir, html=True), name='static')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Provide a single container image that builds the frontend and serves it alongside the FastAPI backend so the web app is bundled with the API at runtime.

### Description
- Add a multi-stage Dockerfile at `api/Dockerfile` that builds the `web/` frontend with Node 20 and then creates a Python 3.11 image that installs the SDK via `pip install /sdk`, copies the API code, and places the frontend build into `/app/static`.
- Update the FastAPI entrypoint `api/main.py` to detect a `static` directory next to the application and mount it at `/` using `StaticFiles(directory=..., html=True)` so the built `index.html` can be served.
- Use `uvicorn` to start the app with the image entrypoint set to `uvicorn main:app --host 0.0.0.0 --port 8000`.

### Testing
- Run `python -m compileall api/main.py` to validate syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b1a1bdbc832390419c21c9dda7ea)