### PR TITLE
Add semantic-release workflow, config, changelog and package metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,0 +1,69 @@
+module.exports = {
+  branches: ['main'],
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'conventionalcommits',
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES']
+        },
+        releaseRules: [
+          { type: 'feat', release: 'minor' },
+          { type: 'fix', release: 'patch' },
+          { type: 'perf', release: 'patch' },
+          { breaking: true, release: 'major' }
+        ]
+      }
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'conventionalcommits',
+        presetConfig: {
+          types: [
+            { type: 'feat', section: 'Features' },
+            { type: 'fix', section: 'Bug Fixes' },
+            { type: 'perf', section: 'Performance Improvements' }
+          ]
+        },
+        writerOpts: {
+          groupBy: 'scope',
+          commitGroupsSort: 'title',
+          commitsSort: ['scope', 'subject'],
+          transform: (commit, context) => {
+            const allowedScopes = ['sdk', 'api', 'web'];
+            const normalizedScope = (commit.scope || '').toLowerCase();
+
+            if (!allowedScopes.includes(normalizedScope)) {
+              return;
+            }
+
+            const scopedCommit = { ...commit };
+            scopedCommit.scope = normalizedScope.toUpperCase();
+            return scopedCommit;
+          },
+          groupTitleByScope: {
+            API: 'API',
+            SDK: 'SDK',
+            WEB: 'WEB'
+          }
+        }
+      }
+    ],
+    [
+      '@semantic-release/changelog',
+      {
+        changelogFile: 'CHANGELOG.md'
+      }
+    ],
+    [
+      '@semantic-release/git',
+      {
+        assets: ['CHANGELOG.md', 'package.json'],
+        message:
+          'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+      }
+    ]
+  ]
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.5.0] - 2026-03-25
+
+### SDK
+- Added new authentication client
+- Fixed retry logic
+
+### API
+- Added new endpoint /users/me
+- Updated SDK dependency to 1.5.0
+
+### WEB
+- Updated dashboard to support new endpoint

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "longlink-release",
+  "private": true,
+  "version": "1.5.0",
+  "scripts": {
+    "release": "semantic-release"
+  },
+  "devDependencies": {
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/release-notes-generator": "^14.1.0",
+    "semantic-release": "^24.2.3"
+  }
+}


### PR DESCRIPTION
### Motivation

- Automate release creation and changelog generation using `semantic-release` on pushes to `main` so releases and version bumps follow conventional commits and are published consistently.
- Group and filter release notes by normalized scopes (`sdk`, `api`, `web`) to produce clearer, scoped changelog sections.

### Description

- Add GitHub Actions release workflow at `.github/workflows/release.yml` that checks out the repo, sets up Node.js 22, installs dependencies with `npm install`, and runs `npx semantic-release` using `GITHUB_TOKEN`.
- Add ` .releaserc.cjs` with `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, `@semantic-release/changelog`, and `@semantic-release/git` configured to use the `conventionalcommits` preset, custom release rules, scoped grouping, and scope normalization/validation.
- Add `CHANGELOG.md` with an initial `1.5.0` entry and scoped sections for `SDK`, `API`, and `WEB`.
- Add `package.json` containing `version: 1.5.0`, a `release` script (`semantic-release`), and `devDependencies` required for `semantic-release` and its plugins.

### Testing

- No automated tests were executed as part of this change; the new workflow is configured to run on `push` to `main` and will execute `npm install` and `npx semantic-release` when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b438f6408323884d960ade76e923)