### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]: "
+labels: [bug]
+assignees: []
+---
+
+## Bug description
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+What actually happened.
+
+## Screenshots / logs
+If applicable, add screenshots or logs to help explain your problem.
+
+## Environment
+- OS: 
+- Browser (if relevant): 
+- Version / commit: 
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]: "
+labels: [enhancement]
+assignees: []
+---
+
+## Problem statement
+A clear and concise description of what problem this feature would solve.
+
+## Proposed solution
+Describe the solution you'd like.
+
+## Alternatives considered
+Describe any alternative solutions or features you've considered.
+
+## Use case
+Describe how this feature would be used and by whom.
+
+## Additional context
+Add any other context, screenshots, or references about the feature request here.


### PR DESCRIPTION
### Motivation
- Provide a consistent, structured way for contributors to report bugs and request features. 
- Capture key context (reproduction steps, environment, proposed solution) up front to speed triage and implementation.

### Description
- Add a bug report template at `.github/ISSUE_TEMPLATE/bug_report.md` with front matter (`name`, `about`, `title`, `labels`, `assignees`) and sections for description, steps to reproduce, expected/actual behavior, logs/screenshots, environment, and additional context. 
- Add a feature request template at `.github/ISSUE_TEMPLATE/feature_request.md` with front matter and sections for problem statement, proposed solution, alternatives considered, use case, and additional context.

### Testing
- Verified the new files exist and printed their contents using repository/file inspection commands (`git status`, `nl`/`sed`), which completed successfully. 
- No runtime or unit tests were required for this documentation/configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d1b4ffa08323817691cb954aba84)