### PR TITLE
Add CI workflow to run API and SDK pytest suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component:
+          - api
+          - sdk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.component }}
+        run: pip install -e '.[dev]'
+
+      - name: Run tests
+        working-directory: ${{ matrix.component }}
+        run: pytest

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 dev = [
     'mypy==1.18.2',
     'ruff==0.14.0',
+    'pytest==8.4.2',
 ]
 
 [tool.setuptools]

--- a/api/src/hello.py
+++ b/api/src/hello.py
@@ -1,0 +1,2 @@
+def hello_world() -> str:
+    return 'hello world'

--- a/api/tests/test_hello.py
+++ b/api/tests/test_hello.py
@@ -1,0 +1,5 @@
+from src.hello import hello_world
+
+
+def test_hello_world() -> None:
+    assert hello_world() == 'hello world'

--- a/sdk/longlink/hello.py
+++ b/sdk/longlink/hello.py
@@ -1,0 +1,2 @@
+def hello_world() -> str:
+    return 'hello world'

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -33,6 +33,9 @@ cli = [
   "rich",
   "click",
 ]
+dev = [
+  "pytest==8.4.2",
+]
 
 [project.urls]
 Homepage = "https://example.com"

--- a/sdk/tests/test_hello.py
+++ b/sdk/tests/test_hello.py
@@ -1,0 +1,13 @@
+import os
+
+os.environ['KEY'] = 'test-key'
+os.environ['DATABASE_URL'] = 'sqlite:///test.db'
+os.environ['STORAGE_KEY'] = 'storage-key'
+os.environ['STORAGE_SECRET'] = 'storage-secret'
+os.environ['STORAGE_ENDPOINT'] = 'http://localhost:9000'
+
+from longlink.hello import hello_world
+
+
+def test_hello_world() -> None:
+    assert hello_world() == 'hello world'


### PR DESCRIPTION
### Motivation
- Ensure automated test coverage for both `api` and `sdk` packages on merges to `dev` and `main` by adding a CI workflow and minimal tests as a baseline.

### Description
- Add GitHub Actions workflow at `.github/workflows/ci.yml` that runs on pushes to `main` and `dev` and runs a matrix job for `api` and `sdk` using `python-3.12`, `pip install -e '.[dev]'`, and `pytest`.
- Add a minimal `hello_world` implementation in `api/src/hello.py` and `sdk/longlink/hello.py` to provide a simple, testable surface.
- Add corresponding tests in `api/tests/test_hello.py` and `sdk/tests/test_hello.py`, where the SDK test sets required environment variables to avoid import-time `pydantic` validation errors.
- Add `pytest==8.4.2` as a dev dependency in `api/pyproject.toml` and `sdk/pyproject.toml` so CI can install dev extras and run tests.

### Testing
- Ran `pytest` in `api` and observed `1 passed` (collected 1 item) indicating the API test succeeded.
- Ran `pytest` in `sdk` after adding environment variable setup in the test and observed `1 passed` (collected 1 item) indicating the SDK test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d28e86f883238d91d2a18707ed1f)