### PR TITLE
ci: upgrade actions/checkout to v5 and setup-python to v6 for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### Motivation
- Move CI and release workflows off Node.js 20-based action versions to avoid upcoming deprecation and prepare for the Node.js 24 runtime.

### Description
- Updated `.github/workflows/ci.yml` to use `actions/checkout@v5` and `actions/setup-python@v6`, and updated `.github/workflows/release.yml` to use `actions/checkout@v5` to align with newer action releases.

### Testing
- Verified workflow references with `rg -n "actions/checkout@|actions/setup-python@" .github/workflows` and reviewed changes with `git diff -- .github/workflows/ci.yml .github/workflows/release.yml`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3dda5f264832382d5c17cbde86a0b)