### PR TITLE
Remove `srh` folder and add Alternatives page to docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Examples', link: '/markdown-examples' }
+      { text: 'Examples', link: '/markdown-examples' },
+      { text: 'Alternatives', link: '/alternatives' }
     ],
 
     sidebar: [
@@ -16,7 +17,8 @@ export default defineConfig({
         text: 'Examples',
         items: [
           { text: 'Markdown Examples', link: '/markdown-examples' },
-          { text: 'Runtime API Examples', link: '/api-examples' }
+          { text: 'Runtime API Examples', link: '/api-examples' },
+          { text: 'Alternatives to LongLink', link: '/alternatives' }
         ]
       }
     ],

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,0 +1,15 @@
+# Alternatives to LongLink
+
+If you are evaluating LongLink, here are some widely used open-source ERP and application-platform alternatives:
+
+- [ADempiere](https://www.adempiere.io/)
+- [Apache OFBiz](https://ofbiz.apache.org/)
+- [Dolibarr](https://www.dolibarr.org/)
+- [ERP5](https://www.erp5.com/)
+- [Frappe Framework](https://frappe.io/framework)
+- [iDempiere](https://idempiere.org/)
+- [inoERP](https://docs.inoerp.com/)
+- [metasfresh](https://metasfresh.com/)
+- [Tryton](https://www.tryton.org/)
+
+> Note: each option has different trade-offs in architecture, extensibility, and deployment model.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ hero:
     - theme: alt
       text: API Examples
       link: /api-examples
+    - theme: alt
+      text: Alternatives
+      link: /alternatives
 
 features:
   - title: Feature A

--- a/srh/ADEMPIERE.md
+++ b/srh/ADEMPIERE.md
@@ -1,1 +1,0 @@
-https://www.adempiere.io/

--- a/srh/DOLIBARR.MD
+++ b/srh/DOLIBARR.MD
@@ -1,1 +1,0 @@
-https://www.dolibarr.org/

--- a/srh/ERP5.md
+++ b/srh/ERP5.md
@@ -1,1 +1,0 @@
-https://www.erp5.com/

--- a/srh/FRAPPE.md
+++ b/srh/FRAPPE.md
@@ -1,1 +1,0 @@
-https://frappe.io/framework

--- a/srh/IDEMPIERE.md
+++ b/srh/IDEMPIERE.md
@@ -1,1 +1,0 @@
-https://idempiere.org/

--- a/srh/INOERP.md
+++ b/srh/INOERP.md
@@ -1,1 +1,0 @@
-https://docs.inoerp.com/

--- a/srh/METASFRESH.md
+++ b/srh/METASFRESH.md
@@ -1,1 +1,0 @@
-https://metasfresh.com/

--- a/srh/OFBIZ.md
+++ b/srh/OFBIZ.md
@@ -1,1 +1,0 @@
-https://ofbiz.apache.org/

--- a/srh/README.md
+++ b/srh/README.md
@@ -1,5 +1,0 @@
-# State of the art in ERP Systems
-
-- Overview -> Link to the overview of the state of the art in ERP systems
-- Pricing -> Link to the pricing
-- Demo -> Link to the demo video / pages / ecc

--- a/srh/TRYTON.md
+++ b/srh/TRYTON.md
@@ -1,1 +1,0 @@
-https://www.tryton.org/


### PR DESCRIPTION
### Motivation
- Remove the legacy `srh` directory and centralize the list of ERP alternatives into the documentation to keep the repository structure cleaner.
- Provide a discoverable alternatives page in the docs so users can easily evaluate other open-source ERP and platform options.

### Description
- Deleted the entire `srh/` directory and all files contained within it.
- Added a new documentation page at `docs/alternatives.md` that lists open-source ERP and application-platform alternatives to LongLink.
- Updated `docs/.vitepress/config.ts` to include an `Alternatives` entry in the top navigation and sidebar.
- Updated `docs/index.md` to add an `Alternatives` hero action linking to the new page.

### Testing
- Validated that the new `docs/alternatives.md` file exists and contains the intended entries with no syntax errors in the file.
- Verified the VitePress config and homepage `index.md` were updated to reference the new `/alternatives` route with no reported issues.
- No unit or integration tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e68e1560832397d8c48717bfe931)