### PR TITLE
Update release workflow versioning and add contributors section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,30 @@ jobs:
               per_page: 100
             });
 
-            const previous = releases.find((release) => !release.draft && !release.prerelease);
+            const versionPattern = /^0\.0\.(\d+)$/;
+            const stableReleases = releases
+              .filter((release) => !release.draft && !release.prerelease)
+              .filter((release) => versionPattern.test(release.tag_name));
+
+            const previous = stableReleases
+              .sort((a, b) => Number(b.tag_name.match(versionPattern)[1]) - Number(a.tag_name.match(versionPattern)[1]))[0];
+
             core.setOutput('tag', previous ? previous.tag_name : '');
+
+      - name: Compute next release version
+        id: next_version
+        run: |
+          PREVIOUS_TAG="${{ steps.previous_release.outputs.tag }}"
+
+          if [[ "$PREVIOUS_TAG" =~ ^0\.0\.([0-9]+)$ ]]; then
+            NEXT_PATCH=$((BASH_REMATCH[1] + 1))
+          else
+            NEXT_PATCH=1
+          fi
+
+          NEXT_TAG="0.0.${NEXT_PATCH}"
+
+          echo "tag=${NEXT_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build release notes from commits
         id: notes
@@ -40,24 +62,33 @@ jobs:
 
           if [ -n "$PREVIOUS_TAG" ]; then
             COMMIT_LIST=$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:'- %s (%h)')
+            CONTRIBUTOR_LIST=$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:'%an' | sort -u | sed 's/^/- /')
           else
             COMMIT_LIST=$(git log --pretty=format:'- %s (%h)')
+            CONTRIBUTOR_LIST=$(git log --pretty=format:'%an' | sort -u | sed 's/^/- /')
           fi
 
           if [ -z "$COMMIT_LIST" ]; then
             COMMIT_LIST='- No new commits since the previous release.'
           fi
 
+          if [ -z "$CONTRIBUTOR_LIST" ]; then
+            CONTRIBUTOR_LIST='- No contributors found for this release.'
+          fi
+
           {
             echo "notes<<EOF"
-            echo "## Commits"
+            echo "## What's Changed"
             echo "$COMMIT_LIST"
+            echo
+            echo "## Contributors"
+            echo "$CONTRIBUTOR_LIST"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: release-${{ github.run_number }}
-          name: Release ${{ github.run_number }}
+          tag_name: ${{ steps.next_version.outputs.tag }}
+          name: Release ${{ steps.next_version.outputs.tag }}
           body: ${{ steps.notes.outputs.notes }}


### PR DESCRIPTION
### Motivation
- Keep the repository on semantic releases that retain the `0.0.` prefix and increment the patch component automatically instead of using `release-${{ github.run_number }}`.
- Make release notes clearer by replacing a raw commits list with a `## What's Changed` section and include a curated `## Contributors` list.

### Description
- Detect the latest stable release whose tag matches `^0\.0\.(\d+)$` and select the highest patch number.
- Add a `Compute next release version` step that sets the next tag to `0.0.<N>` by incrementing the previous patch or using `0.0.1` when none exists.
- Update the release notes step to emit `## What's Changed` and append a `## Contributors` section built from unique commit authors since the previous tag.
- Use the computed `0.0.x` tag for the release `tag_name` and `name` when creating the GitHub release.

### Testing
- Validated the modified workflow by reviewing the generated YAML diff and inspecting the final `.github/workflows/release.yml` contents.
- Confirmed the `notes` output structure includes both `## What's Changed` and `## Contributors` when building release notes.
- Verified the version computation yields `0.0.1` if no prior `0.0.x` exists and increments an existing patch number by one.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e7a37cc08323aca04e2fd165e5b4)