### PR TITLE
chore(api): switch API setup and Docker installs to use uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ longlink/
 ### Backend
 
 ```bash
-python -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e './api[dev]'
-pip install -e sdk
+uv pip install -e './api[dev]'
+uv pip install -e sdk
 ```
 
 Run control plane:
 
 ```bash
 cd api
-python main.py
+uv run main.py
 ```
 
 Run sample app:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,17 +5,17 @@ COPY web/ ./
 RUN npm install && npm run build
 
 # --- api ---
-FROM python:3.11
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 WORKDIR /app
 
 COPY sdk /sdk
-RUN pip install /sdk
+RUN uv pip install --system /sdk
 
 COPY api/ ./
 
 # copy built frontend into API
 COPY --from=web-build /web/dist /app/static
 
-RUN pip install -r requirements.txt
+RUN uv pip install --system .
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/README.md
+++ b/api/README.md
@@ -6,5 +6,5 @@
 ## Development setup
 
 ```bash
-pip install -e '.[dev]'
+uv sync --extra dev
 ```


### PR DESCRIPTION
### Motivation

- Standardize API development and packaging around the `uv` toolchain instead of direct `pip` usage for consistency and reproducible installs.
- Use an `uv`-provided Python base image in the API Docker build to align runtime tooling with local developer workflows.
- Update local run instructions to use `uv` so the documented workflow matches the packaging changes.

### Description

- Updated root `README.md` to create the venv with `uv venv`, install packages with `uv pip install -e ...`, and run the control plane with `uv run main.py`.
- Replaced the API development setup in `api/README.md` with `uv sync --extra dev` to use `uv` for dependency synchronization.
- Replaced the Docker base image in `api/Dockerfile` from `python:3.11` to `ghcr.io/astral-sh/uv:python3.11-bookworm-slim` and switched install steps to `uv pip install --system /sdk` and `uv pip install --system .`.
- Adjusted Dockerfile and docs so the SDK and API are installed via `uv pip` to keep container installs consistent with the developer workflow.

### Testing

- Ran `python -m compileall api/main.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3f141b4288323b9de76260968c31d)