### PR TITLE
ci: migrate SDK CI to uv and add Python 3.12-3.14 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,8 @@ on:
       - dev
 
 jobs:
-  tests:
+  api-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        component:
-          - api
-          - sdk
 
     steps:
       - name: Checkout repository
@@ -25,9 +20,40 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        working-directory: ${{ matrix.component }}
+        working-directory: api
         run: pip install -e '.[dev]'
 
       - name: Run tests
-        working-directory: ${{ matrix.component }}
+        working-directory: api
         run: pytest
+
+  sdk-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.12'
+          - '3.13'
+          - '3.14'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        working-directory: sdk
+        run: uv pip install --system -e '.[dev]'
+
+      - name: Run tests
+        working-directory: sdk
+        run: uv run pytest


### PR DESCRIPTION
### Motivation
- Ensure the SDK test job runs under `uv` so tests exercise the uv-based runtime and caching behavior.
- Expand SDK coverage to Python 3.12, 3.13 and 3.14 to validate compatibility with newer interpreters.
- Keep the API job unchanged to avoid regressions while decoupling SDK and API CI concerns.

### Description
- Split the previous combined CI job into two jobs: `api-tests` (keeps existing behavior on Python 3.12) and `sdk-tests` (new matrix for SDK).
- Added a Python matrix for `sdk-tests` covering `3.12`, `3.13`, and `3.14`.
- Integrated `astral-sh/setup-uv@v7` with `enable-cache: true` in the SDK job to enable `uv` usage and caching.
- Switched SDK dependency installation and test commands to use `uv` (`uv pip install --system -e '.[dev]'` and `uv run pytest`).

### Testing
- No automated test runs were executed as part of this PR; CI is updated to run `api-tests` (Python 3.12) and `sdk-tests` (Python 3.12, 3.13, 3.14) on push.
- Repository changes were validated via local workflow diff and commit checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4008a93648323b6f7feabd3e5b15b)