### PR TITLE
docs: update setup instructions to use uv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ All contributions must respect the core design constraints:
 ### 1. Setup Environment
 
 ```bash
-python -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e './api[dev]'
-pip install -e sdk
+uv pip install -e './api[dev]'
+uv pip install -e './sdk'
 ```
 
 Frontend:

--- a/README.md
+++ b/README.md
@@ -21,23 +21,22 @@ Install [uv](https://astral.sh/uv/) and [vp](https://viteplus.dev/):
 ### Backend
 
 ```bash
-python -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e './api[dev]'
-pip install -e sdk
+uv pip install -e './api[dev]'
+uv pip install -e './sdk'
 ```
 
 Run control plane:
 
 ```bash
-cd api
-python main.py
+uv run --project api python main.py
 ```
 
 Run sample app:
 
 ```bash
-python sdk/sample/main.py
+uv run --project sdk python sample/main.py
 ```
 
 ---

--- a/api/README.md
+++ b/api/README.md
@@ -6,5 +6,5 @@
 ## Development setup
 
 ```bash
-pip install -e '.[dev]'
+uv pip install -e '.[dev]'
 ```

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -20,11 +20,11 @@ longlink publish <module>
 ## Stanalone
 
 ```
-pip install longlink
+uv pip install longlink
 ```
 
 ```
-pip install longlink[standalone]
+uv pip install 'longlink[standalone]'
 ```
 
 before update


### PR DESCRIPTION
### Motivation
- Standardize local development and run instructions to use the `uv` wrapper for virtualenv and package/command execution.
- Make README and CONTRIBUTING instructions consistent with the recommended `uv` workflow used in the project setup notes.
- Ensure SDK and API install/run snippets reflect the same developer experience across the repo.

### Description
- Replaced `python -m venv .venv` with `uv venv` and updated editable install commands to `uv pip install -e './api[dev]'` and `uv pip install -e './sdk'` in the root `README.md` and `CONTRIBUTING.md`.
- Updated API run command to `uv run --project api python main.py` and SDK sample run command to `uv run --project sdk python sample/main.py` in `README.md`.
- Replaced `pip install` usage with `uv pip install` in `api/README.md` and `sdk/README.md`, including `uv pip install longlink` and `uv pip install 'longlink[standalone]'` in `sdk/README.md`.
- This change is documentation-only and does not modify runtime code or tests.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors and it completed successfully.
- Ran `git status --short` to confirm the intended files were modified and it completed successfully.
- No unit or integration tests were modified or required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c405e4fea88323ac9091cf7acb7a43)