### PR TITLE
sdk: add missing pydantic-settings runtime dependency

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "click",
     "uvicorn",
     "pydantic",
+    "pydantic-settings",
     "httpx",
     "fsspec",
 ]


### PR DESCRIPTION
### Motivation
- Tests and package import failed at runtime with `ModuleNotFoundError: No module named 'pydantic_settings'` because the SDK did not declare the `pydantic-settings` runtime dependency, which breaks import-time code in `longlink.envs`/`longlink.settings`.

### Description
- Add `pydantic-settings` to the SDK's `project.dependencies` in `sdk/pyproject.toml` to ensure `from pydantic_settings import BaseSettings, SettingsConfigDict` can be imported during test collection and normal package use.

### Testing
- Ran `python -m pytest` in `sdk`, which passed (`1 passed`, `1 warning`).
- Attempted `uv run pytest` but it failed in this environment due to a network/tunnel error while fetching dependencies from PyPI, so full `uv`-based validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4060a82488323a7d4b54c762d6d4f)