### PR TITLE
ci: add workflow to build and publish SDK to PyPI on release using uv

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,31 @@
+name: Build and Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build the distribution
+        working-directory: sdk
+        run: uv build
+
+      - name: Upload to PyPI
+        working-directory: sdk
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.TWINE_PASSWORD }}
+        run: uv publish dist/*


### PR DESCRIPTION
### Motivation
- Publish the Python SDK package to PyPI automatically when a GitHub Release is published, using the `uv` toolchain.
- Ensure builds and publishing run from the `sdk` directory and reuse the existing `TWINE_PASSWORD` secret for authentication.

### Description
- Add `.github/workflows/publish-sdk.yml` triggered on `release` with type `published` that checks out the repository and sets up Python 3.12.
- Install `uv` via `astral-sh/setup-uv@v5`, build the distribution in `sdk` with `uv build`, and publish artifacts with `uv publish dist/*`.
- Configure publishing to use `UV_PUBLISH_TOKEN` mapped from `secrets.TWINE_PASSWORD` and run build/publish steps from the `sdk` working directory.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4072d65188323b5cb371de7b4435b)