### PR TITLE
Publish SDK and API image on both release and manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     release:
         if: github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
+        outputs:
+            tag: ${{ steps.next_version.outputs.tag }}
 
         steps:
             - name: Checkout repository
@@ -96,7 +98,8 @@ jobs:
                   body: ${{ steps.notes.outputs.notes }}
 
     publish-sdk:
-        if: github.event_name == 'release'
+        if: always() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+        needs: [release]
         runs-on: ubuntu-latest
 
         steps:
@@ -122,7 +125,8 @@ jobs:
               run: uv publish dist/*
 
     publish-api-image:
-        if: github.event_name == 'release'
+        if: always() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+        needs: [release]
         runs-on: ubuntu-latest
 
         steps:
@@ -146,7 +150,7 @@ jobs:
                   images: ghcr.io/${{ github.repository_owner }}/longlink-api
                   tags: |
                       type=raw,value=latest
-                      type=raw,value=${{ github.event.release.tag_name }}
+                      type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || needs.release.outputs.tag }}
 
             - name: Build and push API image
               uses: docker/build-push-action@v6


### PR DESCRIPTION
### Motivation
- Ensure the SDK package and API Docker image are published whenever a release is created, including when the workflow is run manually via `workflow_dispatch`.
- Keep the release version consistent between the created GitHub release and downstream publish steps so artifacts are tagged the same.

### Description
- Expose the computed release tag from the `release` job as a job output via `outputs.tag` so downstream jobs can reuse it.
- Make `publish-sdk` and `publish-api-image` run for both `release` and `workflow_dispatch` triggers by changing their `if` conditions and adding `needs: [release]` so manual dispatch waits for the release job to compute the tag.
- Use the release-event tag when the run is a `release`, or fall back to the computed `needs.release.outputs.tag` when the run is a `workflow_dispatch`, for Docker image tagging.

### Testing
- Ran `sed -n '1,260p' .github/workflows/release.yml` to inspect the modified workflow file, which completed successfully.
- Ran `git diff -- .github/workflows/release.yml` to confirm the changes, which completed successfully.
- Committed the updated workflow with `git add` and `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42b0e5af88323a2cc43a2a29ea79d)