### PR TITLE
Move SDK version management to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,23 @@ jobs:
             - name: Install build tools
               run: python -m pip install --upgrade build
 
+            - name: Resolve SDK package version
+              id: sdk_version
+              run: |
+                  RAW_VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || needs.release.outputs.tag }}"
+                  SDK_VERSION="${RAW_VERSION#v}"
+
+                  if [[ ! "$SDK_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "Invalid SDK version: $SDK_VERSION"
+                    exit 1
+                  fi
+
+                  echo "value=$SDK_VERSION" >> "$GITHUB_OUTPUT"
+
             - name: Build the distribution
               working-directory: sdk
+              env:
+                  LONG_LINK_VERSION: ${{ steps.sdk_version.outputs.value }}
               run: python -m build
 
             - name: Publish to PyPI (OIDC)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "longlink"
-version = "0.0.0"
+dynamic = ["version"]
 dependencies = [
     "alembic",
     "click",
@@ -47,3 +47,7 @@ Changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
 
 [project.scripts]
 longlink = "longlink.__main__:main"
+
+[tool.hatch.version]
+source = "env"
+variable = "LONG_LINK_VERSION"


### PR DESCRIPTION
### Motivation
- Keep the SDK package version consistent with release tags by removing a hardcoded `version` from `sdk/pyproject.toml` and letting the CI provide the value at build time.
- Centralize version resolution in the release workflow so the same tag used for releases is injected into the SDK build for PyPI publication.

### Description
- Removed the static `version` from `sdk/pyproject.toml` and switched to `dynamic = ["version"]` so the package version is not baked into the file.
- Added `[tool.hatch.version]` configuration to `sdk/pyproject.toml` to read the version from the `LONG_LINK_VERSION` environment variable at build time.
- Updated `.github/workflows/release.yml` to compute the SDK version from the release tag (or the computed release output), validate SemVer, expose it as a step output, and pass it into the SDK build step as `LONG_LINK_VERSION`.

### Testing
- Ran a quick `python` check using `tomllib` to parse `sdk/pyproject.toml` and assert `dynamic = ["version"]` and the hatch env configuration, and it succeeded.
- Tried `LONG_LINK_VERSION=0.1.0 python -m build` to validate a local build injection, which failed in this environment because the `build` module is not installed (`No module named build`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5465b59c4832397eaa873b7fb69c5)