### PR TITLE
Use ghcr image name 'longlink' and simplify API Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ghcr.io/${{ github.repository_owner }}/longlink-api
+                  images: ghcr.io/${{ github.repository_owner }}/longlink
                   tags: |
                       type=raw,value=latest
                       type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || needs.release.outputs.tag }}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,9 +5,6 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-COPY sdk /sdk
-RUN pip install --no-cache-dir /sdk
-
 COPY api /app
 RUN pip install --no-cache-dir .
 


### PR DESCRIPTION
### Motivation
- Standardize the published GHCR image name to `longlink` and simplify the API container build by removing a separate `/sdk` install step so the image is built from the package in `/app`.

### Description
- Update `.github/workflows/release.yml` to publish the API image as `ghcr.io/${{ github.repository_owner }}/longlink` instead of `.../longlink-api`.
- Simplify `api/Dockerfile` by removing the `COPY sdk /sdk` and `pip install /sdk` steps and rely on `pip install .` after copying `api` into `/app`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c554734a40832385f569937c946dd1)