### PR TITLE
SDK-managed sample app bootstrapping and decorators

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,7 +1,40 @@
 from .ui import Page
 from .app import LongLink
 from .router import Router
+from .envs import envs
 
 from longlink.ui.textarea import Textarea
-
 from longlink.ui.select import Select
+
+
+# Global SDK-managed application instance.
+app = LongLink()
+
+
+# Route helpers managed by the SDK global app.
+def get(path: str):
+    return app.get(path)
+
+
+def post(path: str):
+    return app.post(path)
+
+
+def put(path: str):
+    return app.put(path)
+
+
+def patch(path: str):
+    return app.patch(path)
+
+
+def delete(path: str):
+    return app.delete(path)
+
+
+def page(path: str, name: str, icon: str):
+    return app.page(path, name=name, icon=icon)
+
+
+def cron(schedule: str):
+    return app.cron(schedule)

--- a/sdk/longlink/__main__.py
+++ b/sdk/longlink/__main__.py
@@ -1,5 +1,11 @@
-import click
+import importlib
+import os
+import sys
 from pathlib import Path
+
+import click
+import uvicorn
+
 from longlink.cli import setup
 
 
@@ -9,22 +15,26 @@ def main():
     pass
 
 
+def load_app():
+    importlib.import_module("main")
+    from longlink import app
+
+    return app
+
+
 # longlink dev
 @main.command()
 def dev():
-    import sys
-    import os
-    import uvicorn
-
     # add CWD to import path
     sys.path.insert(0, os.getcwd())
     os.environ["DEV"] = "True"
 
     uvicorn.run(
-        "main:app",
+        "longlink.__main__:load_app",
         host="0.0.0.0",
         port=1707,
         reload=True,
+        factory=True,
     )
 
 

--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -1,8 +1,3 @@
-# TODO: Import everything here? 
-# TODO: Settings??
-from src.app import app
-
-
 # Register routes
 import src.routes.sample
 

--- a/sdk/sample/src/app.py
+++ b/sdk/sample/src/app.py
@@ -1,7 +1,0 @@
-from longlink import LongLink
-
-app = LongLink(
-    title="FastAPI Feature Demo",
-    description="Single-file example of common FastAPI features",
-    version="1.0.0"
-)

--- a/sdk/sample/src/cron/cleanup.py
+++ b/sdk/sample/src/cron/cleanup.py
@@ -1,11 +1,7 @@
-from src.app import app
+from longlink import cron
 
 
-@app.cron("0 0 * * *")
+@cron("0 0 * * *")
 async def daily_cleanup_cron_job():
     # Logic for cleaning up old data
-    app.info("Executing daily cleanup cron job")
-    app.debug("Debugging daily cleanup cron job")
-    app.warning("Warning in daily cleanup cron job")
-    app.error("Error in daily cleanup cron job")
-    app.critical("Critical issue in daily cleanup cron job")
+    print("Executing daily cleanup cron job")

--- a/sdk/sample/src/pages/input.py
+++ b/sdk/sample/src/pages/input.py
@@ -1,8 +1,7 @@
-from src.app import app
-from longlink import Page
+from longlink import Page, page
 
 
-@app.page("/input", name="Input", icon="input")
+@page("/input", name="Input", icon="input")
 async def input_page() -> Page:
     page = Page()
 

--- a/sdk/sample/src/pages/settings.py
+++ b/sdk/sample/src/pages/settings.py
@@ -1,8 +1,7 @@
-from src.app import app
-from longlink import Page
+from longlink import Page, page
 
 
-@app.page("/settings", name="Settings", icon="settings")
+@page("/settings", name="Settings", icon="settings")
 async def settings_page() -> Page:
     page = Page()
     settings_menu = page.menu()

--- a/sdk/sample/src/pages/table.py
+++ b/sdk/sample/src/pages/table.py
@@ -1,8 +1,7 @@
-from src.app import app
-from longlink import Page
+from longlink import Page, page
 
 
-@app.page('/table', name='Table', icon='table')
+@page('/table', name='Table', icon='table')
 async def table_page() -> Page:
     page = Page()
 

--- a/sdk/sample/src/routes/sample.py
+++ b/sdk/sample/src/routes/sample.py
@@ -1,47 +1,47 @@
-from src.app import app
+from longlink import delete, get, patch, post, put
 from src.types import UserModel
 
-@app.get("/sample")
+@get("/sample")
 async def sample_get_endpoint():
     return "Sample GET endpoint received data"
 
 
-@app.post("/sample")
+@post("/sample")
 async def sample_post_endpoint():
     return "Sample POST endpoint response"
 
 
-@app.put("/sample")
+@put("/sample")
 async def sample_put_endpoint():
     return f"Sample PUT endpoint updated item"
 
 
-@app.delete("/sample")
+@delete("/sample")
 async def sample_delete_endpoint():
     return f"Sample DELETE endpoint deleted item"
 
 
 
-@app.patch("/sample")
+@patch("/sample")
 async def sample_patch_endpoint():
     return f"Sample PATCH endpoint patched item"
 
 
 # Example with dynamic URL parameter
-@app.post("/dynamic/{object}")
+@post("/dynamic/{object}")
 async def sample_post_endpoint_with_object(object: int):
     return "Sample POST endpoint response"
 
 
 # Example with params
 # Params must have a default value
-@app.post("/params/{object}?{start}&{end}")
+@post("/params/{object}?{start}&{end}")
 async def sample_post_endpoint_with_params(object: int, start: int = 0, end: int = 10):
     return "Sample POST endpoint response"
 
 
 # Example that return a Pydantic model
-@app.post("/sample/user")
+@post("/sample/user")
 async def sample_post_user_endpoint() -> UserModel:
     return UserModel(
         id=1,
@@ -54,6 +54,6 @@ async def sample_post_user_endpoint() -> UserModel:
 
 # Example with params
 # Params must have a default value
-@app.get("/params/{object}?{start}&{end}")
+@get("/params/{object}?{start}&{end}")
 async def sample_get_endpoint_with_params(object: int, start: int = 0, end: int = 10):
     return "Sample GET endpoint response"


### PR DESCRIPTION
### Motivation
- Provide a single SDK-managed application surface so sample apps do not need to define their own `app` instance. 
- Allow app authors to import route/page/cron decorators and envs directly from `longlink` (e.g. `from longlink import get, post, page, envs`).

### Description
- Added a global SDK-managed `app = LongLink()` and exported `envs` in `sdk/longlink/__init__.py`, and exposed decorator helpers `get`, `post`, `put`, `patch`, `delete`, `page`, and `cron` that forward to the global `app`.
- Changed `sdk/longlink/__main__.py` to load the user project via a `load_app()` factory which imports `main` for registration side-effects and returns the SDK-managed `app`, and started `uvicorn` with `factory=True` to use that loader.
- Updated the sample project to remove `src/app.py`, simplified `sdk/sample/main.py` to only import registration modules, and refactored route/page/cron files to use the SDK decorators (e.g. `@get(...)`, `@page(...)`, `@cron(...)`) instead of `@app.*`.
- Adjusted sample cron code to avoid referencing the removed `app` logging methods and replaced with a simple `print` for the example cron job.

### Testing
- Ran `python -m compileall sdk/longlink sdk/sample` which completed successfully (bytecode compiled without errors). 
- Performed a runtime import smoke test (`PYTHONPATH=/workspace/longlink/sdk ... import main; from longlink import app, envs`) which failed due to missing required environment variables for `Envs` in this CI-like environment, not due to the refactor itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e03d5288832395539139540f6d0d)