### PR TITLE
Add EnvsDev with dev defaults and fix storage dev flag

### DIFF
--- a/sdk/longlink/envs.py
+++ b/sdk/longlink/envs.py
@@ -1,18 +1,21 @@
+import os
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Envs(BaseSettings):
     """App specific secrets"""
+
     DEV: bool = False
 
     # LongLink internal
     # The application key, used to identify the application in the API
-    LLURL: str    # Example: "sample.longlink.ch"
-    LLKEY: str    # Example: "samplekey"
+    LLURL: str    # Example: 'sample.longlink.ch'
+    LLKEY: str    # Example: 'samplekey'
 
     # The application specific database
     DBURL: str
-    
+
     # The application specific storage
     storage_key: str
     storage_secret: str
@@ -22,4 +25,17 @@ class Envs(BaseSettings):
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 
 
-envs = Envs() # type: ignore
+class EnvsDev(Envs):
+    DEV: bool = True
+    LLURL: str = 'http://localhost:8000'
+    LLKEY: str = 'longlink-dev'
+    DBURL: str = 'sqlite:///./longlink-dev.db'
+    storage_key: str = 'dev'
+    storage_secret: str = 'dev'
+    storage_endpoint: str = 'http://localhost:9000'
+
+
+if os.getenv('DEV', '').lower() in {'1', 'true', 'yes', 'on'}:
+    envs = EnvsDev()  # type: ignore
+else:
+    envs = Envs()  # type: ignore

--- a/sdk/longlink/storage.py
+++ b/sdk/longlink/storage.py
@@ -6,7 +6,7 @@ It shall provide a space where the SDK can store data
 """
 
 
-if envs.dev:
+if envs.DEV:
     # local
     fs = fsspec.filesystem("file")
 


### PR DESCRIPTION
### Motivation
- Provide sane defaults for local development when `DEV` is enabled so `longlink dev` can run against a local control plane and local SQLite DB. 
- Ensure the SDK picks a dev configuration automatically when `DEV` is truthy to simplify developer onboarding. 
- Fix storage backend selection to read the correct `DEV` flag so local filesystem storage is used in dev.

### Description
- Added a new `EnvsDev` class in `sdk/longlink/envs.py` that inherits from `Envs` and provides development defaults including `LLURL='http://localhost:8000'`, `DBURL='sqlite:///./longlink-dev.db'`, and local storage placeholders. 
- Wired environment selection to instantiate `EnvsDev` automatically when the `DEV` environment variable is truthy (`1/true/yes/on`), otherwise fall back to `Envs`. 
- Updated `sdk/longlink/storage.py` to check `envs.DEV` (uppercase) instead of `envs.dev` so the storage initialization correctly uses `fsspec.filesystem('file')` in dev. 

### Testing
- Ran `python -m compileall sdk/longlink` to ensure module compilation succeeded, which completed without errors. 
- Ran a runtime validation with `DEV=True python - <<'PY' ...` that imported `envs` and printed `type(envs).__name__, envs.DEV, envs.DBURL, envs.LLURL`, and the output confirmed `EnvsDev True sqlite:///./longlink-dev.db http://localhost:8000` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca4f8cd11883239d77f05a2f3ebed6)