### PR TITLE
Build and package web frontend in API Docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,3 +1,11 @@
+FROM oven/bun:1 AS web-builder
+
+WORKDIR /web
+COPY web/package.json web/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY web/ ./
+RUN bun run build
+
 FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -7,6 +15,7 @@ WORKDIR /app
 
 COPY api /app
 RUN pip install --no-cache-dir .
+COPY --from=web-builder /web/dist /app/static
 
 EXPOSE 8000
 


### PR DESCRIPTION
### Motivation
- Include the compiled frontend inside the API Docker image so the FastAPI app can serve the web app from a single container.
- Simplify deployment by producing one image that contains both the backend runtime and the built static assets.

### Description
- Converted `api/Dockerfile` to a multi-stage build with a `web-builder` stage based on `oven/bun:1` that runs `bun install --frozen-lockfile` and `bun run build` for the frontend.
- Kept the final stage as `python:3.12-slim`, installed the API with `pip install --no-cache-dir .`, and added `COPY --from=web-builder /web/dist /app/static` to copy built assets into the runtime image.
- The existing FastAPI static mount in `api/main.py` will serve the copied `dist` files from `/app/static` without further code changes.

### Testing
- Attempted to build the image with `docker build -f api/Dockerfile . -t longlink:test`, but the build could not run because Docker is not available in this environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca507a222c832396e77706e415b283)