### PR TITLE
Fix `longlink dev` env loading order by lazily initializing settings

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -3,7 +3,6 @@ from .api import get, post
 from .app import LongLink
 from .organization import OrganizationSettings
 from .router import Router
-from .envs import envs
 
 from longlink.ui.textarea import Textarea
 from longlink.ui.select import Select

--- a/sdk/longlink/envs.py
+++ b/sdk/longlink/envs.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -35,7 +36,17 @@ class EnvsDev(Envs):
     storage_endpoint: str = 'http://localhost:9000'
 
 
-if os.getenv('DEV', '').lower() in {'1', 'true', 'yes', 'on'}:
-    envs = EnvsDev()  # type: ignore
-else:
-    envs = Envs()  # type: ignore
+@lru_cache(maxsize=1)
+def get_envs() -> Envs:
+    if os.getenv('DEV', '').lower() in {'1', 'true', 'yes', 'on'}:
+        return EnvsDev()  # type: ignore
+
+    return Envs()  # type: ignore
+
+
+class _LazyEnvs:
+    def __getattr__(self, item):
+        return getattr(get_envs(), item)
+
+
+envs = _LazyEnvs()


### PR DESCRIPTION
### Motivation
- The SDK constructed `envs` at import time which triggered Pydantic validation before the `longlink dev` command sets `DEV=True`, causing missing-field validation errors when no envs were present.

### Description
- Stop eagerly importing `envs` from `sdk/longlink/__init__.py` so package import won't instantiate settings during CLI startup.
- Replace the global eager settings instance in `sdk/longlink/envs.py` with a cached `get_envs()` function that evaluates `DEV` at first access using `@lru_cache`.
- Introduce a `_LazyEnvs` proxy object and expose `envs = _LazyEnvs()` so existing `envs.<field>` usage continues to work while deferring actual settings construction.

### Testing
- Ran an import smoke test: executed `import longlink.__main__` with no env vars and then set `os.environ['DEV']='True'` and accessed `from longlink.envs import envs` to verify `envs.DEV` is `True` and dev defaults (e.g. `LLURL`) are available, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca512b74b08323b95966bc1b4c4f89)