### PR TITLE
Remove development/localhost flows; add Connect app button in Applications

### DIFF
--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -1,9 +1,9 @@
 import { PlusCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import AppButton from '@/longlink/Button';
 import Hero from '@/longlink/Hero';
 import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import { Checkbox } from '@/ui/checkbox';
 import {
     DialogContent,
     DialogDescription,
@@ -11,7 +11,6 @@ import {
     DialogTitle,
 } from '@/ui/dialog';
 import { Input } from '@/ui/input';
-import { Label } from '@/ui/label';
 import {
     Table,
     TableBody,
@@ -29,20 +28,11 @@ type Application = {
     status: 'Active';
 };
 
-const developmentApplication: Application = {
-    name: 'Sample localhost application',
-    slug: 'sample-localhost-application',
-    owner: 'Development',
-    runtime: 'Localhost',
-    status: 'Active',
-};
-
 export default function Applications() {
     const [name, setName] = useState('');
     const [slug, setSlug] = useState('');
     const [owner, setOwner] = useState('');
     const [runtime, setRuntime] = useState('Python SDK');
-    const [enableDevelopment, setEnableDevelopment] = useState(false);
     const [applications, setApplications] = useState<Application[]>([]);
 
     const canCreate = useMemo(() => {
@@ -53,14 +43,6 @@ export default function Applications() {
             runtime.trim().length > 0
         );
     }, [name, owner, runtime, slug]);
-
-    const visibleApplications = useMemo(() => {
-        if (!enableDevelopment) {
-            return applications;
-        }
-
-        return [developmentApplication, ...applications];
-    }, [applications, enableDevelopment]);
 
     const onCreate = () => {
         if (!canCreate) {
@@ -90,70 +72,66 @@ export default function Applications() {
                 title="Application Settings"
                 subtitle="Control app defaults, permissions, and lifecycle settings"
                 icon="settings"
-                action="Create app"
             >
-                <DialogContent className="sm:max-w-3xl">
-                    <DialogHeader>
-                        <DialogTitle>Create application</DialogTitle>
-                        <DialogDescription>
-                            Register a new application to make it available for
-                            modules, storage bindings, and runtime deployment.
-                        </DialogDescription>
-                    </DialogHeader>
+                <div className="flex items-center gap-2">
+                    <Button variant="outline">Connect app</Button>
 
-                    <div className="grid gap-3 md:grid-cols-2">
-                        <Input
-                            placeholder="Application name"
-                            value={name}
-                            onChange={(event) => setName(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Slug"
-                            value={slug}
-                            onChange={(event) => setSlug(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Owner"
-                            value={owner}
-                            onChange={(event) => setOwner(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Runtime"
-                            value={runtime}
-                            onChange={(event) => setRuntime(event.target.value)}
-                        />
-                    </div>
+                    <AppButton variant="outline" text="Create app">
+                        <DialogContent className="sm:max-w-3xl">
+                            <DialogHeader>
+                                <DialogTitle>Create application</DialogTitle>
+                                <DialogDescription>
+                                    Register a new application to make it
+                                    available for modules, storage bindings, and
+                                    runtime deployment.
+                                </DialogDescription>
+                            </DialogHeader>
 
-                    <div className="flex justify-end">
-                        <Button
-                            variant="outline"
-                            onClick={onCreate}
-                            disabled={!canCreate}
-                        >
-                            <PlusCircle className="h-4 w-4" />
-                            Create
-                        </Button>
-                    </div>
-                </DialogContent>
-            </Hero>
+                            <div className="grid gap-3 md:grid-cols-2">
+                                <Input
+                                    placeholder="Application name"
+                                    value={name}
+                                    onChange={(event) =>
+                                        setName(event.target.value)
+                                    }
+                                />
+                                <Input
+                                    placeholder="Slug"
+                                    value={slug}
+                                    onChange={(event) =>
+                                        setSlug(event.target.value)
+                                    }
+                                />
+                                <Input
+                                    placeholder="Owner"
+                                    value={owner}
+                                    onChange={(event) =>
+                                        setOwner(event.target.value)
+                                    }
+                                />
+                                <Input
+                                    placeholder="Runtime"
+                                    value={runtime}
+                                    onChange={(event) =>
+                                        setRuntime(event.target.value)
+                                    }
+                                />
+                            </div>
 
-            <Card className="p-4">
-                <div className="flex items-center gap-3">
-                    <Checkbox
-                        id="enable-development"
-                        checked={enableDevelopment}
-                        onCheckedChange={(checked) =>
-                            setEnableDevelopment(checked === true)
-                        }
-                    />
-                    <Label
-                        htmlFor="enable-development"
-                        className="text-sm font-medium"
-                    >
-                        Enable development
-                    </Label>
+                            <div className="flex justify-end">
+                                <Button
+                                    variant="outline"
+                                    onClick={onCreate}
+                                    disabled={!canCreate}
+                                >
+                                    <PlusCircle className="h-4 w-4" />
+                                    Create
+                                </Button>
+                            </div>
+                        </DialogContent>
+                    </AppButton>
                 </div>
-            </Card>
+            </Hero>
 
             <Card className="overflow-hidden">
                 <Table>
@@ -167,7 +145,7 @@ export default function Applications() {
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {visibleApplications.length === 0 ? (
+                        {applications.length === 0 ? (
                             <TableRow>
                                 <TableCell
                                     colSpan={5}
@@ -177,7 +155,7 @@ export default function Applications() {
                                 </TableCell>
                             </TableRow>
                         ) : (
-                            visibleApplications.map((application) => (
+                            applications.map((application) => (
                                 <TableRow
                                     key={`${application.slug}-${application.owner}`}
                                 >

--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -1,4 +1,4 @@
-import { Chrome, Github, Laptop, Layers } from 'lucide-react';
+import { Chrome, Github, Layers } from 'lucide-react';
 import { Button } from '@/ui/button';
 import { Card, CardContent } from '@/ui/card';
 import { useEffect, useState } from 'react';
@@ -77,14 +77,9 @@ export default function Login() {
 
     const hasGoogleMethod = availableMethods.includes('google');
     const hasGithubMethod = availableMethods.includes('github');
-    const hasLocalhostMethod = availableMethods.includes('localhost');
 
     const handleGithubLogin = () => {
         window.location.href = `${apiBaseUrl}/login/github`;
-    };
-
-    const handleLocalhostLogin = () => {
-        window.location.href = `${apiBaseUrl}/login/localhost`;
     };
 
     return (
@@ -118,16 +113,6 @@ export default function Login() {
                             <Github className="h-4 w-4" />
                             Login with GitHub
                         </Button>
-                        {hasLocalhostMethod ? (
-                            <Button
-                                variant="secondary"
-                                className="h-11 gap-2"
-                                onClick={handleLocalhostLogin}
-                            >
-                                <Laptop className="h-4 w-4" />
-                                Localhost Login
-                            </Button>
-                        ) : null}
                     </div>
                 </CardContent>
             </Card>


### PR DESCRIPTION
### Motivation
- Remove the implicit "development" sample application and the "Enable development" toggle so the Applications table shows only explicitly created apps.
- Remove the localhost login option from the Login page to avoid offering a development-only auth path in the public UI.
- Add an explicit "Connect app" action next to the app creation action to make external app connections discoverable.

### Description
- Updated `web/src/components/settings/Applications.tsx` to remove the development sample and the `Enable development` checkbox, and to always list `applications` (user-created entries) rather than a `visibleApplications` union.
- Replaced the previous inline create-dialog wiring with a dedicated `AppButton` wrapper from `@/longlink/Button` that preserves the Create app dialog as the `AppButton` child, and added a `Connect app` `Button` next to it in the Hero actions.
- Removed unused imports (`Checkbox`, `Label`) and cleaned up the component state accordingly.
- Updated `web/src/pages/user/Login.tsx` to remove localhost-specific detection, handler, and the Localhost Login button, keeping only Google and GitHub login options.
- Formatted code after changes using the project formatter.

### Testing
- Ran project formatter with `bun run format`, which completed successfully.
- Attempted a full web build with `bun run build`, which failed due to pre-existing unrelated TypeScript errors in other parts of the repo (for example `src/ui/resizable.tsx`, `src/ui/sidebar.tsx`, and `src/pages/org/Longlink.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca52facdd883238660d49bb7c0471b)