### PR TITLE
Update Database Settings copy and remove info card

### DIFF
--- a/web/src/components/settings/Database.tsx
+++ b/web/src/components/settings/Database.tsx
@@ -1,4 +1,4 @@
-import { DatabaseIcon, PlusCircle } from 'lucide-react';
+import { PlusCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import Hero from '@/longlink/Hero';
 import { Button } from '@/ui/button';
@@ -74,7 +74,7 @@ export default function Database() {
         <div className="space-y-6">
             <Hero
                 title="Database Settings"
-                subtitle="Configure top level database servers. Each application gets its own database name on a connected server."
+                subtitle="Connect a database instance."
                 icon="settings"
                 action="Connect"
             >
@@ -175,17 +175,6 @@ export default function Database() {
                         )}
                     </TableBody>
                 </Table>
-            </Card>
-
-            <Card className="border-dashed p-4 text-sm text-muted-foreground">
-                <div className="flex items-start gap-2">
-                    <DatabaseIcon className="mt-0.5 h-4 w-4" />
-                    <p>
-                        Connected entries represent top-level database servers.
-                        Each application will create and use its own database
-                        name inside one of these servers.
-                    </p>
-                </div>
             </Card>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Clarify the Database Settings UI text and remove a redundant informational card beneath the database table.

### Description
- Updated the hero subtitle in `web/src/components/settings/Database.tsx` to `"Connect a database instance."`, removed the bottom informational `Card` JSX block, and deleted the now-unused `DatabaseIcon` import.

### Testing
- Ran `bun run format` in `web/` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca53c6f24c8323ad9b64da144ae2ed)