### PR TITLE
refactor(web): centralize dialogs into CamelCase components

### DIFF
--- a/web/src/components/dialogs/ConnectContainerRuntimeDialog.tsx
+++ b/web/src/components/dialogs/ConnectContainerRuntimeDialog.tsx
@@ -1,0 +1,94 @@
+import { PlusCircle } from 'lucide-react';
+import { Button } from '@/ui/button';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/ui/dialog';
+import { Input } from '@/ui/input';
+
+type ConnectContainerRuntimeDialogProps = {
+    runtimeName: string;
+    registry: string;
+    namespace: string;
+    cpuLimit: string;
+    apiToken: string;
+    canConnect: boolean;
+    onRuntimeNameChange: (value: string) => void;
+    onRegistryChange: (value: string) => void;
+    onNamespaceChange: (value: string) => void;
+    onCpuLimitChange: (value: string) => void;
+    onApiTokenChange: (value: string) => void;
+    onConnect: () => void;
+};
+
+export default function ConnectContainerRuntimeDialog({
+    runtimeName,
+    registry,
+    namespace,
+    cpuLimit,
+    apiToken,
+    canConnect,
+    onRuntimeNameChange,
+    onRegistryChange,
+    onNamespaceChange,
+    onCpuLimitChange,
+    onApiTokenChange,
+    onConnect,
+}: ConnectContainerRuntimeDialogProps) {
+    return (
+        <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+                <DialogTitle>Connect container runtime</DialogTitle>
+                <DialogDescription>
+                    Register a top-level container runtime. Applications can
+                    deploy their modules using one of these runtime connections.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-3 md:grid-cols-2">
+                <Input
+                    placeholder="Runtime name"
+                    value={runtimeName}
+                    onChange={(event) =>
+                        onRuntimeNameChange(event.target.value)
+                    }
+                />
+                <Input
+                    placeholder="Registry URL"
+                    value={registry}
+                    onChange={(event) => onRegistryChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Namespace"
+                    value={namespace}
+                    onChange={(event) => onNamespaceChange(event.target.value)}
+                />
+                <Input
+                    placeholder="CPU limit"
+                    value={cpuLimit}
+                    onChange={(event) => onCpuLimitChange(event.target.value)}
+                />
+                <Input
+                    type="password"
+                    placeholder="Runtime API token"
+                    value={apiToken}
+                    onChange={(event) => onApiTokenChange(event.target.value)}
+                    className="md:col-span-2"
+                />
+            </div>
+
+            <div className="flex justify-end">
+                <Button
+                    variant="outline"
+                    onClick={onConnect}
+                    disabled={!canConnect}
+                >
+                    <PlusCircle className="h-4 w-4" />
+                    Connect
+                </Button>
+            </div>
+        </DialogContent>
+    );
+}

--- a/web/src/components/dialogs/ConnectDatabaseServerDialog.tsx
+++ b/web/src/components/dialogs/ConnectDatabaseServerDialog.tsx
@@ -1,0 +1,92 @@
+import { PlusCircle } from 'lucide-react';
+import { Button } from '@/ui/button';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/ui/dialog';
+import { Input } from '@/ui/input';
+
+type ConnectDatabaseServerDialogProps = {
+    serverName: string;
+    host: string;
+    port: string;
+    username: string;
+    password: string;
+    canConnect: boolean;
+    onServerNameChange: (value: string) => void;
+    onHostChange: (value: string) => void;
+    onPortChange: (value: string) => void;
+    onUsernameChange: (value: string) => void;
+    onPasswordChange: (value: string) => void;
+    onConnect: () => void;
+};
+
+export default function ConnectDatabaseServerDialog({
+    serverName,
+    host,
+    port,
+    username,
+    password,
+    canConnect,
+    onServerNameChange,
+    onHostChange,
+    onPortChange,
+    onUsernameChange,
+    onPasswordChange,
+    onConnect,
+}: ConnectDatabaseServerDialogProps) {
+    return (
+        <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+                <DialogTitle>Connect database server</DialogTitle>
+                <DialogDescription>
+                    Register a top-level database server. New applications will
+                    create a dedicated database/name on this server.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-3 md:grid-cols-2">
+                <Input
+                    placeholder="Server name"
+                    value={serverName}
+                    onChange={(event) => onServerNameChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Host"
+                    value={host}
+                    onChange={(event) => onHostChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Port"
+                    value={port}
+                    onChange={(event) => onPortChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Username"
+                    value={username}
+                    onChange={(event) => onUsernameChange(event.target.value)}
+                />
+                <Input
+                    type="password"
+                    placeholder="Password"
+                    value={password}
+                    onChange={(event) => onPasswordChange(event.target.value)}
+                    className="md:col-span-2"
+                />
+            </div>
+
+            <div className="flex justify-end">
+                <Button
+                    variant="outline"
+                    onClick={onConnect}
+                    disabled={!canConnect}
+                >
+                    <PlusCircle className="h-4 w-4" />
+                    Connect
+                </Button>
+            </div>
+        </DialogContent>
+    );
+}

--- a/web/src/components/dialogs/ConnectStorageProviderDialog.tsx
+++ b/web/src/components/dialogs/ConnectStorageProviderDialog.tsx
@@ -1,0 +1,94 @@
+import { PlusCircle } from 'lucide-react';
+import { Button } from '@/ui/button';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/ui/dialog';
+import { Input } from '@/ui/input';
+
+type ConnectStorageProviderDialogProps = {
+    providerName: string;
+    endpoint: string;
+    bucket: string;
+    accessKey: string;
+    secretKey: string;
+    canConnect: boolean;
+    onProviderNameChange: (value: string) => void;
+    onEndpointChange: (value: string) => void;
+    onBucketChange: (value: string) => void;
+    onAccessKeyChange: (value: string) => void;
+    onSecretKeyChange: (value: string) => void;
+    onConnect: () => void;
+};
+
+export default function ConnectStorageProviderDialog({
+    providerName,
+    endpoint,
+    bucket,
+    accessKey,
+    secretKey,
+    canConnect,
+    onProviderNameChange,
+    onEndpointChange,
+    onBucketChange,
+    onAccessKeyChange,
+    onSecretKeyChange,
+    onConnect,
+}: ConnectStorageProviderDialogProps) {
+    return (
+        <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+                <DialogTitle>Connect storage provider</DialogTitle>
+                <DialogDescription>
+                    Register a top-level object storage provider. Applications
+                    can create or bind buckets from these connections.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-3 md:grid-cols-2">
+                <Input
+                    placeholder="Provider name"
+                    value={providerName}
+                    onChange={(event) =>
+                        onProviderNameChange(event.target.value)
+                    }
+                />
+                <Input
+                    placeholder="Endpoint"
+                    value={endpoint}
+                    onChange={(event) => onEndpointChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Bucket"
+                    value={bucket}
+                    onChange={(event) => onBucketChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Access key"
+                    value={accessKey}
+                    onChange={(event) => onAccessKeyChange(event.target.value)}
+                />
+                <Input
+                    type="password"
+                    placeholder="Secret key"
+                    value={secretKey}
+                    onChange={(event) => onSecretKeyChange(event.target.value)}
+                    className="md:col-span-2"
+                />
+            </div>
+
+            <div className="flex justify-end">
+                <Button
+                    variant="outline"
+                    onClick={onConnect}
+                    disabled={!canConnect}
+                >
+                    <PlusCircle className="h-4 w-4" />
+                    Connect
+                </Button>
+            </div>
+        </DialogContent>
+    );
+}

--- a/web/src/components/dialogs/CreateApplicationDialog.tsx
+++ b/web/src/components/dialogs/CreateApplicationDialog.tsx
@@ -1,0 +1,81 @@
+import { PlusCircle } from 'lucide-react';
+import { Button } from '@/ui/button';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/ui/dialog';
+import { Input } from '@/ui/input';
+
+type CreateApplicationDialogProps = {
+    name: string;
+    slug: string;
+    owner: string;
+    runtime: string;
+    canCreate: boolean;
+    onNameChange: (value: string) => void;
+    onSlugChange: (value: string) => void;
+    onOwnerChange: (value: string) => void;
+    onRuntimeChange: (value: string) => void;
+    onCreate: () => void;
+};
+
+export default function CreateApplicationDialog({
+    name,
+    slug,
+    owner,
+    runtime,
+    canCreate,
+    onNameChange,
+    onSlugChange,
+    onOwnerChange,
+    onRuntimeChange,
+    onCreate,
+}: CreateApplicationDialogProps) {
+    return (
+        <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+                <DialogTitle>Create application</DialogTitle>
+                <DialogDescription>
+                    Register a new application to make it available for modules,
+                    storage bindings, and runtime deployment.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-3 md:grid-cols-2">
+                <Input
+                    placeholder="Application name"
+                    value={name}
+                    onChange={(event) => onNameChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Slug"
+                    value={slug}
+                    onChange={(event) => onSlugChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Owner"
+                    value={owner}
+                    onChange={(event) => onOwnerChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Runtime"
+                    value={runtime}
+                    onChange={(event) => onRuntimeChange(event.target.value)}
+                />
+            </div>
+
+            <div className="flex justify-end">
+                <Button
+                    variant="outline"
+                    onClick={onCreate}
+                    disabled={!canCreate}
+                >
+                    <PlusCircle className="h-4 w-4" />
+                    Create
+                </Button>
+            </div>
+        </DialogContent>
+    );
+}

--- a/web/src/components/dialogs/CreateTeamDialog.tsx
+++ b/web/src/components/dialogs/CreateTeamDialog.tsx
@@ -1,0 +1,83 @@
+import { PlusCircle } from 'lucide-react';
+import { Button } from '@/ui/button';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/ui/dialog';
+import { Input } from '@/ui/input';
+
+type CreateTeamDialogProps = {
+    name: string;
+    description: string;
+    members: string;
+    scope: string;
+    canCreate: boolean;
+    onNameChange: (value: string) => void;
+    onDescriptionChange: (value: string) => void;
+    onMembersChange: (value: string) => void;
+    onScopeChange: (value: string) => void;
+    onCreate: () => void;
+};
+
+export default function CreateTeamDialog({
+    name,
+    description,
+    members,
+    scope,
+    canCreate,
+    onNameChange,
+    onDescriptionChange,
+    onMembersChange,
+    onScopeChange,
+    onCreate,
+}: CreateTeamDialogProps) {
+    return (
+        <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+                <DialogTitle>Create team</DialogTitle>
+                <DialogDescription>
+                    Create a team that can be assigned to modules, resources,
+                    and administration scopes.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-3 md:grid-cols-2">
+                <Input
+                    placeholder="Team name"
+                    value={name}
+                    onChange={(event) => onNameChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Description"
+                    value={description}
+                    onChange={(event) =>
+                        onDescriptionChange(event.target.value)
+                    }
+                />
+                <Input
+                    placeholder="Members"
+                    value={members}
+                    onChange={(event) => onMembersChange(event.target.value)}
+                />
+                <Input
+                    placeholder="Scope"
+                    value={scope}
+                    onChange={(event) => onScopeChange(event.target.value)}
+                />
+            </div>
+
+            <div className="flex justify-end">
+                <Button
+                    variant="outline"
+                    onClick={onCreate}
+                    disabled={!canCreate}
+                >
+                    <PlusCircle className="h-4 w-4" />
+                    Create
+                </Button>
+            </div>
+        </DialogContent>
+    );
+}

--- a/web/src/components/dialogs/CreateToolDialog.tsx
+++ b/web/src/components/dialogs/CreateToolDialog.tsx
@@ -1,0 +1,65 @@
+import { Plus } from 'lucide-react';
+import { Button } from '@/ui/button';
+import {
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/ui/dialog';
+import { Input } from '@/ui/input';
+
+type CreateToolDialogProps = {
+    name: string;
+    url: string;
+    isPending: boolean;
+    createError: string | null;
+    onNameChange: (value: string) => void;
+    onUrlChange: (value: string) => void;
+    onCreate: () => void;
+};
+
+export default function CreateToolDialog({
+    name,
+    url,
+    isPending,
+    createError,
+    onNameChange,
+    onUrlChange,
+    onCreate,
+}: CreateToolDialogProps) {
+    return (
+        <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+                <DialogTitle>Create a new tool</DialogTitle>
+                <DialogDescription>
+                    Add a name and URL to register your tool.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-3 md:grid-cols-3">
+                <Input
+                    placeholder="Tool name"
+                    value={name}
+                    onChange={(event) => onNameChange(event.target.value)}
+                />
+                <Input
+                    placeholder="http://localhost:1707/my-tool"
+                    value={url}
+                    onChange={(event) => onUrlChange(event.target.value)}
+                />
+                <Button
+                    variant="outline"
+                    onClick={onCreate}
+                    disabled={isPending}
+                >
+                    <Plus className="h-4 w-4" />
+                    New Tool
+                </Button>
+            </div>
+
+            {createError ? (
+                <p className="text-sm text-red-300">{createError}</p>
+            ) : null}
+        </DialogContent>
+    );
+}

--- a/web/src/components/dialogs/index.ts
+++ b/web/src/components/dialogs/index.ts
@@ -1,0 +1,6 @@
+export { default as ConnectContainerRuntimeDialog } from './ConnectContainerRuntimeDialog';
+export { default as ConnectDatabaseServerDialog } from './ConnectDatabaseServerDialog';
+export { default as ConnectStorageProviderDialog } from './ConnectStorageProviderDialog';
+export { default as CreateApplicationDialog } from './CreateApplicationDialog';
+export { default as CreateTeamDialog } from './CreateTeamDialog';
+export { default as CreateToolDialog } from './CreateToolDialog';

--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -1,16 +1,9 @@
-import { PlusCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { CreateApplicationDialog } from '@/components/dialogs';
 import AppButton from '@/longlink/Button';
 import Hero from '@/longlink/Hero';
 import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import {
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/ui/dialog';
-import { Input } from '@/ui/input';
 import {
     Table,
     TableBody,
@@ -77,58 +70,18 @@ export default function Applications() {
                     <Button variant="outline">Connect app</Button>
 
                     <AppButton variant="outline" text="Create app">
-                        <DialogContent className="sm:max-w-3xl">
-                            <DialogHeader>
-                                <DialogTitle>Create application</DialogTitle>
-                                <DialogDescription>
-                                    Register a new application to make it
-                                    available for modules, storage bindings, and
-                                    runtime deployment.
-                                </DialogDescription>
-                            </DialogHeader>
-
-                            <div className="grid gap-3 md:grid-cols-2">
-                                <Input
-                                    placeholder="Application name"
-                                    value={name}
-                                    onChange={(event) =>
-                                        setName(event.target.value)
-                                    }
-                                />
-                                <Input
-                                    placeholder="Slug"
-                                    value={slug}
-                                    onChange={(event) =>
-                                        setSlug(event.target.value)
-                                    }
-                                />
-                                <Input
-                                    placeholder="Owner"
-                                    value={owner}
-                                    onChange={(event) =>
-                                        setOwner(event.target.value)
-                                    }
-                                />
-                                <Input
-                                    placeholder="Runtime"
-                                    value={runtime}
-                                    onChange={(event) =>
-                                        setRuntime(event.target.value)
-                                    }
-                                />
-                            </div>
-
-                            <div className="flex justify-end">
-                                <Button
-                                    variant="outline"
-                                    onClick={onCreate}
-                                    disabled={!canCreate}
-                                >
-                                    <PlusCircle className="h-4 w-4" />
-                                    Create
-                                </Button>
-                            </div>
-                        </DialogContent>
+                        <CreateApplicationDialog
+                            name={name}
+                            slug={slug}
+                            owner={owner}
+                            runtime={runtime}
+                            canCreate={canCreate}
+                            onNameChange={setName}
+                            onSlugChange={setSlug}
+                            onOwnerChange={setOwner}
+                            onRuntimeChange={setRuntime}
+                            onCreate={onCreate}
+                        />
                     </AppButton>
                 </div>
             </Hero>

--- a/web/src/components/settings/Container.tsx
+++ b/web/src/components/settings/Container.tsx
@@ -1,15 +1,8 @@
-import { Box, PlusCircle } from 'lucide-react';
+import { Box } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { ConnectContainerRuntimeDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
-import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import {
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/ui/dialog';
-import { Input } from '@/ui/input';
 import {
     Table,
     TableBody,
@@ -78,67 +71,20 @@ export default function Container() {
                 icon="settings"
                 action="Connect"
             >
-                <DialogContent className="sm:max-w-3xl">
-                    <DialogHeader>
-                        <DialogTitle>Connect container runtime</DialogTitle>
-                        <DialogDescription>
-                            Register a top-level container runtime. Applications
-                            can deploy their modules using one of these runtime
-                            connections.
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="grid gap-3 md:grid-cols-2">
-                        <Input
-                            placeholder="Runtime name"
-                            value={runtimeName}
-                            onChange={(event) =>
-                                setRuntimeName(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="Registry URL"
-                            value={registry}
-                            onChange={(event) =>
-                                setRegistry(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="Namespace"
-                            value={namespace}
-                            onChange={(event) =>
-                                setNamespace(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="CPU limit"
-                            value={cpuLimit}
-                            onChange={(event) =>
-                                setCpuLimit(event.target.value)
-                            }
-                        />
-                        <Input
-                            type="password"
-                            placeholder="Runtime API token"
-                            value={apiToken}
-                            onChange={(event) =>
-                                setApiToken(event.target.value)
-                            }
-                            className="md:col-span-2"
-                        />
-                    </div>
-
-                    <div className="flex justify-end">
-                        <Button
-                            variant="outline"
-                            onClick={onConnect}
-                            disabled={!canConnect}
-                        >
-                            <PlusCircle className="h-4 w-4" />
-                            Connect
-                        </Button>
-                    </div>
-                </DialogContent>
+                <ConnectContainerRuntimeDialog
+                    runtimeName={runtimeName}
+                    registry={registry}
+                    namespace={namespace}
+                    cpuLimit={cpuLimit}
+                    apiToken={apiToken}
+                    canConnect={canConnect}
+                    onRuntimeNameChange={setRuntimeName}
+                    onRegistryChange={setRegistry}
+                    onNamespaceChange={setNamespace}
+                    onCpuLimitChange={setCpuLimit}
+                    onApiTokenChange={setApiToken}
+                    onConnect={onConnect}
+                />
             </Hero>
 
             <Card className="overflow-hidden">

--- a/web/src/components/settings/Database.tsx
+++ b/web/src/components/settings/Database.tsx
@@ -1,15 +1,7 @@
-import { PlusCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { ConnectDatabaseServerDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
-import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import {
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/ui/dialog';
-import { Input } from '@/ui/input';
 import {
     Table,
     TableBody,
@@ -78,63 +70,20 @@ export default function Database() {
                 icon="settings"
                 action="Connect"
             >
-                <DialogContent className="sm:max-w-3xl">
-                    <DialogHeader>
-                        <DialogTitle>Connect database server</DialogTitle>
-                        <DialogDescription>
-                            Register a top-level database server. New
-                            applications will create a dedicated database/name
-                            on this server.
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="grid gap-3 md:grid-cols-2">
-                        <Input
-                            placeholder="Server name"
-                            value={serverName}
-                            onChange={(event) =>
-                                setServerName(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="Host"
-                            value={host}
-                            onChange={(event) => setHost(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Port"
-                            value={port}
-                            onChange={(event) => setPort(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Username"
-                            value={username}
-                            onChange={(event) =>
-                                setUsername(event.target.value)
-                            }
-                        />
-                        <Input
-                            type="password"
-                            placeholder="Password"
-                            value={password}
-                            onChange={(event) =>
-                                setPassword(event.target.value)
-                            }
-                            className="md:col-span-2"
-                        />
-                    </div>
-
-                    <div className="flex justify-end">
-                        <Button
-                            variant="outline"
-                            onClick={onConnect}
-                            disabled={!canConnect}
-                        >
-                            <PlusCircle className="h-4 w-4" />
-                            Connect
-                        </Button>
-                    </div>
-                </DialogContent>
+                <ConnectDatabaseServerDialog
+                    serverName={serverName}
+                    host={host}
+                    port={port}
+                    username={username}
+                    password={password}
+                    canConnect={canConnect}
+                    onServerNameChange={setServerName}
+                    onHostChange={setHost}
+                    onPortChange={setPort}
+                    onUsernameChange={setUsername}
+                    onPasswordChange={setPassword}
+                    onConnect={onConnect}
+                />
             </Hero>
 
             <Card className="overflow-hidden">

--- a/web/src/components/settings/Permissions.tsx
+++ b/web/src/components/settings/Permissions.tsx
@@ -1,15 +1,7 @@
-import { PlusCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { CreateTeamDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
-import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import {
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/ui/dialog';
-import { Input } from '@/ui/input';
 import {
     Table,
     TableBody,
@@ -71,51 +63,18 @@ export default function Permissions() {
                 icon="settings"
                 action="Create team"
             >
-                <DialogContent className="sm:max-w-3xl">
-                    <DialogHeader>
-                        <DialogTitle>Create team</DialogTitle>
-                        <DialogDescription>
-                            Create a team that can be assigned to modules,
-                            resources, and administration scopes.
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="grid gap-3 md:grid-cols-2">
-                        <Input
-                            placeholder="Team name"
-                            value={name}
-                            onChange={(event) => setName(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Description"
-                            value={description}
-                            onChange={(event) =>
-                                setDescription(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="Members"
-                            value={members}
-                            onChange={(event) => setMembers(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Scope"
-                            value={scope}
-                            onChange={(event) => setScope(event.target.value)}
-                        />
-                    </div>
-
-                    <div className="flex justify-end">
-                        <Button
-                            variant="outline"
-                            onClick={onCreate}
-                            disabled={!canCreate}
-                        >
-                            <PlusCircle className="h-4 w-4" />
-                            Create
-                        </Button>
-                    </div>
-                </DialogContent>
+                <CreateTeamDialog
+                    name={name}
+                    description={description}
+                    members={members}
+                    scope={scope}
+                    canCreate={canCreate}
+                    onNameChange={setName}
+                    onDescriptionChange={setDescription}
+                    onMembersChange={setMembers}
+                    onScopeChange={setScope}
+                    onCreate={onCreate}
+                />
             </Hero>
 
             <Card className="overflow-hidden">

--- a/web/src/components/settings/Storage.tsx
+++ b/web/src/components/settings/Storage.tsx
@@ -1,15 +1,8 @@
-import { HardDrive, PlusCircle } from 'lucide-react';
+import { HardDrive } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { ConnectStorageProviderDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
-import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import {
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/ui/dialog';
-import { Input } from '@/ui/input';
 import {
     Table,
     TableBody,
@@ -78,65 +71,20 @@ export default function Storage() {
                 icon="settings"
                 action="Connect"
             >
-                <DialogContent className="sm:max-w-3xl">
-                    <DialogHeader>
-                        <DialogTitle>Connect storage provider</DialogTitle>
-                        <DialogDescription>
-                            Register a top-level object storage provider.
-                            Applications can create or bind buckets from these
-                            connections.
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="grid gap-3 md:grid-cols-2">
-                        <Input
-                            placeholder="Provider name"
-                            value={providerName}
-                            onChange={(event) =>
-                                setProviderName(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="Endpoint"
-                            value={endpoint}
-                            onChange={(event) =>
-                                setEndpoint(event.target.value)
-                            }
-                        />
-                        <Input
-                            placeholder="Bucket"
-                            value={bucket}
-                            onChange={(event) => setBucket(event.target.value)}
-                        />
-                        <Input
-                            placeholder="Access key"
-                            value={accessKey}
-                            onChange={(event) =>
-                                setAccessKey(event.target.value)
-                            }
-                        />
-                        <Input
-                            type="password"
-                            placeholder="Secret key"
-                            value={secretKey}
-                            onChange={(event) =>
-                                setSecretKey(event.target.value)
-                            }
-                            className="md:col-span-2"
-                        />
-                    </div>
-
-                    <div className="flex justify-end">
-                        <Button
-                            variant="outline"
-                            onClick={onConnect}
-                            disabled={!canConnect}
-                        >
-                            <PlusCircle className="h-4 w-4" />
-                            Connect
-                        </Button>
-                    </div>
-                </DialogContent>
+                <ConnectStorageProviderDialog
+                    providerName={providerName}
+                    endpoint={endpoint}
+                    bucket={bucket}
+                    accessKey={accessKey}
+                    secretKey={secretKey}
+                    canConnect={canConnect}
+                    onProviderNameChange={setProviderName}
+                    onEndpointChange={setEndpoint}
+                    onBucketChange={setBucket}
+                    onAccessKeyChange={setAccessKey}
+                    onSecretKeyChange={setSecretKey}
+                    onConnect={onConnect}
+                />
             </Hero>
 
             <Card className="overflow-hidden">

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -1,15 +1,9 @@
-import { Plus, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import { useState } from 'react';
+import { CreateToolDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
 import Table, { type ApiTableColumn } from '@/longlink/Table';
-import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
-import {
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/ui/dialog';
 import {
     Empty,
     EmptyDescription,
@@ -17,7 +11,6 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/ui/empty';
-import { Input } from '@/ui/input';
 import { useApps, useCreateApp } from '@/hooks/use-apps';
 
 const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
@@ -78,39 +71,15 @@ export default function Tools() {
                 icon="sparkles"
                 action="Create Tool"
             >
-                <DialogContent className="sm:max-w-3xl">
-                    <DialogHeader>
-                        <DialogTitle>Create a new tool</DialogTitle>
-                        <DialogDescription>
-                            Add a name and URL to register your tool.
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="grid gap-3 md:grid-cols-3">
-                        <Input
-                            placeholder="Tool name"
-                            value={name}
-                            onChange={(event) => setName(event.target.value)}
-                        />
-                        <Input
-                            placeholder="http://localhost:1707/my-tool"
-                            value={url}
-                            onChange={(event) => setUrl(event.target.value)}
-                        />
-                        <Button
-                            variant="outline"
-                            onClick={() => void onCreateApp()}
-                            disabled={isPending}
-                        >
-                            <Plus className="h-4 w-4" />
-                            New Tool
-                        </Button>
-                    </div>
-
-                    {createError ? (
-                        <p className="text-sm text-red-300">{createError}</p>
-                    ) : null}
-                </DialogContent>
+                <CreateToolDialog
+                    name={name}
+                    url={url}
+                    isPending={isPending}
+                    createError={createError}
+                    onNameChange={setName}
+                    onUrlChange={setUrl}
+                    onCreate={() => void onCreateApp()}
+                />
             </Hero>
 
             {isLoading ? (


### PR DESCRIPTION
### Motivation

- Improve reuse and consistency by extracting inline dialog markup into dedicated, reusable components with CamelCase filenames.
- Make dialog UIs easier to import and maintain across settings and pages.

### Description

- Added a new `web/src/components/dialogs` directory with the following reusable dialog components: `CreateTeamDialog`, `CreateApplicationDialog`, `ConnectDatabaseServerDialog`, `ConnectContainerRuntimeDialog`, `ConnectStorageProviderDialog`, and `CreateToolDialog`, plus a barrel file at `web/src/components/dialogs/index.ts`.
- Replaced inline dialog markup in `Permissions`, `Applications`, `Database`, `Container`, and `Storage` settings pages with the corresponding dialog components and wired their props to the existing local state and handlers.
- Updated the org `Tools` page to use `CreateToolDialog` instead of inline dialog JSX and removed now-unnecessary imports (icons/inputs) where applicable.
- Ran repository formatting so new files follow project style guidelines.

### Testing

- Ran `bun run format` in `web`, which completed successfully.
- Ran `bun run build` in `web`, which failed due to pre-existing TypeScript issues outside the changes in this PR (errors reported in `Longlink.tsx`, `ui/resizable.tsx`, `ui/scroll-area.tsx`, and a missing `@/hooks/use-mobile` import in `ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca549972648323b164b6d0c8950963)