### PR TITLE
docs(web): add code structure section to AGENTS

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -6,6 +6,16 @@ You are working on a vite tailwind shadcn project.
 - Ensure consistency across the application.
 - For static content, do not use .map(); write each JSX element explicitly inline.
 
+## Code structure
+
+- `assets`
+- `components`
+- `hooks`
+- `libs`
+- `longlink`
+- `pages`
+- `ui`
+
 ## API utilities
 
 - Use `src/lib/api.ts` for API calls; it centralizes the base URL, query params, JSON handling, and error handling.


### PR DESCRIPTION
### Motivation
- Provide a quick reference for the primary frontend directories in the `web` workspace so contributors can more easily find assets, components, hooks, libs, longlink code, pages, and UI primitives.

### Description
- Added a new `## Code structure` section to `web/AGENTS.md` listing the `assets`, `components`, `hooks`, `libs`, `longlink`, `pages`, and `ui` directories.

### Testing
- Ran formatting in the web workspace with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5775e484832381a0790e517d4936)