### PR TITLE
Refactor SDK internal endpoints into dedicated route modules

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -2,7 +2,8 @@ from typing import get_type_hints
 from pydantic import BaseModel
 from longlink.cron import Cron
 from longlink.router import Router
-from longlink.envs import Envs, envs
+from longlink.routes import register_internal_routes
+from longlink.envs import Envs
 
 
 class LongLink(Router, Cron):
@@ -13,28 +14,7 @@ class LongLink(Router, Cron):
         # self.settings = Settings()
         super().__init__()
 
-        @self.get("/")
-        async def get_app_information():
-            return {
-                "name": self.title,
-                "description": self.description,
-                "version": self.version,
-                "pages": self.pages(),
-            }
-
-        @self.get('/register')
-        async def get_registration_information():
-            return self.registration()
-
-        @self.get('/metadata.json')
-        async def get_metadata_information(key: str = ''):
-            if key != envs.KEY:
-                return {
-                    'detail': 'Invalid app key',
-                    'status': 401,
-                }
-
-            return self.metadata()
+        register_internal_routes(self)
 
     def metadata(self) -> dict[str, object]:
         return {

--- a/sdk/longlink/routes/__init__.py
+++ b/sdk/longlink/routes/__init__.py
@@ -1,3 +1,11 @@
-"""
-App routes.
-"""
+"""App route registration helpers."""
+
+from longlink.routes.metadata import register_metadata_route
+from longlink.routes.register import register_registration_route
+from longlink.routes.root import register_root_route
+
+
+def register_internal_routes(app) -> None:
+    register_root_route(app)
+    register_registration_route(app)
+    register_metadata_route(app)

--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,0 +1,15 @@
+"""Metadata route registration."""
+
+from longlink.envs import envs
+
+
+def register_metadata_route(app) -> None:
+    @app.get('/metadata.json')
+    async def get_metadata_information(key: str = ''):
+        if key != envs.KEY:
+            return {
+                'detail': 'Invalid app key',
+                'status': 401,
+            }
+
+        return app.metadata()

--- a/sdk/longlink/routes/register.py
+++ b/sdk/longlink/routes/register.py
@@ -1,0 +1,7 @@
+"""Registration route registration."""
+
+
+def register_registration_route(app) -> None:
+    @app.get('/register')
+    async def get_registration_information():
+        return app.registration()

--- a/sdk/longlink/routes/root.py
+++ b/sdk/longlink/routes/root.py
@@ -1,0 +1,12 @@
+"""Root route registration."""
+
+
+def register_root_route(app) -> None:
+    @app.get('/')
+    async def get_app_information():
+        return {
+            'name': app.title,
+            'description': app.description,
+            'version': app.version,
+            'pages': app.pages(),
+        }


### PR DESCRIPTION
### Motivation
- Keep the `LongLink` application class focused by removing inline endpoint definitions and centralizing internal route wiring. 
- Make built-in endpoints easier to maintain and extend by moving them into separate modules under `sdk/longlink/routes`.

### Description
- Moved the inline route handlers from `LongLink.__init__` into dedicated modules: `sdk/longlink/routes/root.py`, `sdk/longlink/routes/register.py`, and `sdk/longlink/routes/metadata.py`.
- Added `sdk/longlink/routes/__init__.py` which exposes `register_internal_routes(app)` to register the three internal routes.
- Updated `sdk/longlink/app.py` to call `register_internal_routes(self)` during initialization and removed the inline route definitions to keep the app class clean.
- Preserved existing behavior, including `/metadata.json` key validation and the contents returned by `/` and `/register`.

### Testing
- Ran `python -m compileall sdk/longlink` to ensure modules compile successfully, which completed without errors. 
- Performed a smoke registration check with `LongLink().match(...)` for the paths `/`, `/register`, and `/metadata.json`, and all routes were found successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6356b44083238cdd389eb7deb768)