### PR TITLE
Centralize app metadata via metadata.json and simplify LongLink initialization

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,35 +1,30 @@
 from typing import get_type_hints
+
 from pydantic import BaseModel
+
 from longlink.cron import Cron
+from longlink.envs import Envs
+from longlink.metadata import metadata
 from longlink.router import Router
 from longlink.routes import register_internal_routes
-from longlink.envs import Envs
 
 
 class LongLink(Router, Cron):
-    def __init__(self, title: str = "Sample", description: str = "Sample description", version: str = "0.0.0"):
-        self.title = title
-        self.description = description
-        self.version = version
-        # self.settings = Settings()
+    def __init__(self):
         super().__init__()
 
         register_internal_routes(self)
 
     def metadata(self) -> dict[str, object]:
         return {
-            'name': self.title,
-            'description': self.description,
-            'version': self.version,
+            **metadata.model_dump(),
             'runtime': 'python-sdk',
             'required_envs': self.required_envs(),
         }
 
     def registration(self) -> dict[str, object]:
         return {
-            "name": self.title,
-            "version": self.version,
-            "required_envs": self.required_envs(),
+            'required_envs': self.required_envs(),
         }
 
     def required_envs(self) -> list[str]:
@@ -132,5 +127,3 @@ class LongLink(Router, Cron):
             "type": "http.response.body",
             "body": body_bytes,
         })
-
-    

--- a/sdk/longlink/metadata.py
+++ b/sdk/longlink/metadata.py
@@ -1,0 +1,39 @@
+import json
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class Metadata(BaseModel):
+    name: str = 'Sample LongLink app'
+    description: str = ''
+    version: str = '0.0.0'
+
+
+@lru_cache(maxsize=1)
+def get_metadata() -> Metadata:
+    metadata_file = Path.cwd() / 'metadata.json'
+    if not metadata_file.exists():
+        return Metadata()
+
+    try:
+        payload = json.loads(metadata_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return Metadata()
+
+    if not isinstance(payload, dict):
+        return Metadata()
+
+    return Metadata.model_validate(payload)
+
+
+class _LazyMetadata:
+    def __getattr__(self, item):
+        return getattr(get_metadata(), item)
+
+    def model_dump(self) -> dict[str, object]:
+        return get_metadata().model_dump()
+
+
+metadata = _LazyMetadata()

--- a/sdk/longlink/routes/root.py
+++ b/sdk/longlink/routes/root.py
@@ -4,9 +4,10 @@
 def register_root_route(app) -> None:
     @app.get('/')
     async def get_app_information():
+        metadata = app.metadata()
         return {
-            'name': app.title,
-            'description': app.description,
-            'version': app.version,
+            'name': metadata.get('name', ''),
+            'description': metadata.get('description', ''),
+            'version': metadata.get('version', ''),
             'pages': app.pages(),
         }

--- a/sdk/sample/metadata.json
+++ b/sdk/sample/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sample LongLink app",
+  "description": "The project showcases a lightweight operational system as an example of how to use LongLink SDK.",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
### Motivation

- Centralize application metadata in a single `metadata.json` file and avoid duplicating `title`/`description`/`version` on the `LongLink` instance.
- Provide a safe, lazy-loaded accessor for metadata with sensible defaults and resilient JSON parsing.

### Description

- Add `sdk/longlink/metadata.py` which introduces a `Metadata` model, a `get_metadata()` loader that reads `metadata.json`, and a `_LazyMetadata` proxy exposed as `metadata` with `model_dump()` support.
- Refactor `sdk/longlink/app.py` to remove `LongLink` constructor metadata parameters and to use `metadata.model_dump()` for the app `metadata()` output and keep `registration()` focused on required envs.
- Update `sdk/longlink/routes/root.py` to read application details from `app.metadata()` instead of `app.title`, `app.description`, and `app.version`.
- Add a sample `sdk/sample/metadata.json` file with example `name`, `description`, and `version` values.

### Testing

- Ran the project test suite with `pytest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca65f0048c83239799eabeccc73acd)