### PR TITLE
Show organization name in header breadcrumb and remove icon

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,11 +1,5 @@
 import { Loader2, PanelTop } from 'lucide-react';
-import {
-    Link,
-    Outlet,
-    useLocation,
-    useNavigate,
-    useParams,
-} from 'react-router';
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { UserProfile } from '@/components/Profile';
 import { Card } from '@/ui/card';
@@ -22,7 +16,6 @@ import {
     getActiveTabConfig,
     getAppTabsFromPages,
     getTabsConfig,
-    NavigationIcon,
     type AppNavigationPage,
 } from '@/lib/navigation';
 
@@ -110,12 +103,6 @@ export function Navigation({
                 <div className="mx-auto w-full px-6 pb-2 pt-4">
                     <div className="flex items-center justify-between gap-4 text-white/80">
                         <div className="flex items-center gap-4">
-                            <Link
-                                to="/"
-                                className="flex h-9 w-9 items-center justify-center rounded-full bg-white/5 text-blue-300 transition hover:bg-white/10"
-                            >
-                                <NavigationIcon className="h-5 w-5" />
-                            </Link>
                             <Breadcrumb />
                         </div>
                         <UserProfile />

--- a/web/src/components/breadcrumb.tsx
+++ b/web/src/components/breadcrumb.tsx
@@ -6,14 +6,25 @@ import {
     BreadcrumbSeparator,
 } from '@/ui/breadcrumb';
 import { formatAppName } from '@/lib/navigation';
+import { useApiData } from '@/hooks/use-data';
 import { Link, useLocation, useParams } from 'react-router';
+
+type SettingResponse = {
+    key: string;
+    value: string;
+    app_id: number | null;
+};
 
 export function Breadcrumb() {
     const { app } = useParams();
     const location = useLocation();
+    const { data: organizationNameData } =
+        useApiData<SettingResponse>('/settings/ORG_NAME');
 
     const appName = app ? formatAppName(app) : undefined;
     const isProfileView = location.pathname.startsWith('/profile');
+    const organizationName =
+        organizationNameData?.value.trim() || 'Organization';
 
     return (
         <UIBreadcrumb>
@@ -26,7 +37,7 @@ export function Breadcrumb() {
                                 to="/"
                                 className="text-sm font-semibold text-white/70"
                             >
-                                Organization
+                                {organizationName}
                             </Link>
                         )}
                     />


### PR DESCRIPTION
### Motivation
- Replace the static "Organization" label with the actual organization name from settings and remove the circular org icon to match the intended header UX.

### Description
- Updated `web/src/components/breadcrumb.tsx` to fetch `/settings/ORG_NAME` via `useApiData` and render the organization name with a fallback to "Organization"; added a `SettingResponse` type.
- Removed the circular organization icon button from the left of the header and simplified imports in `web/src/Layout.tsx` so the breadcrumb starts the header content.
- Small import/cleanup adjustments to reflect the removed icon.

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bun run build`, which failed due to pre-existing TypeScript errors in unrelated files (e.g. `src/pages/org/Longlink.tsx`, `src/ui/resizable.tsx`, `src/ui/scroll-area.tsx`, `src/ui/sidebar.tsx`) and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca684d85908323943999c89565b10b)