### PR TITLE
Refactor SDK internal GET routes and slim LongLink ASGI app

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -39,3 +39,7 @@ def page(path: str, name: str, icon: str):
 
 def cron(schedule: str):
     return app.cron(schedule)
+
+
+# Import internal routes for side-effect registration on the global app.
+import longlink.routes  # noqa: E402,F401

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -3,46 +3,18 @@ from typing import get_type_hints
 from pydantic import BaseModel
 
 from longlink.cron import Cron
-from longlink.envs import Envs
-from longlink.metadata import metadata
 from longlink.router import Router
-from longlink.routes import register_internal_routes
 
 
 class LongLink(Router, Cron):
-    def __init__(self):
-        super().__init__()
-
-        register_internal_routes(self)
-
-    def metadata(self) -> dict[str, object]:
-        return {
-            **metadata.model_dump(),
-            'runtime': 'python-sdk',
-            'required_envs': self.required_envs(),
-        }
-
-    def registration(self) -> dict[str, object]:
-        return {
-            'required_envs': self.required_envs(),
-        }
-
-    def required_envs(self) -> list[str]:
-        required_fields = [
-            name
-            for name, field in Envs.model_fields.items()
-            if field.is_required()
-        ]
-        return [field_name.upper() for field_name in required_fields]
-
     async def __call__(self, scope, receive, send):
-        if scope["type"] != "http":
+        if scope['type'] != 'http':
             return
 
-        method = scope["method"]
-        path = scope["path"]
+        method = scope['method']
+        path = scope['path']
 
-        query_string = scope.get("query_string", b"")
+        query_string = scope.get('query_string', b'')
         if isinstance(query_string, bytes):
             query_string = query_string.decode()
 
@@ -50,13 +22,13 @@ class LongLink(Router, Cron):
 
         if not handler:
             await send({
-                "type": "http.response.start",
-                "status": 404,
-                "headers": [],
+                'type': 'http.response.start',
+                'status': 404,
+                'headers': [],
             })
             await send({
-                "type": "http.response.body",
-                "body": b"Not Found",
+                'type': 'http.response.body',
+                'body': b'Not Found',
             })
             return
 
@@ -67,63 +39,63 @@ class LongLink(Router, Cron):
 
         is_page_handler = any(route.handler is handler for route in self._pages)
 
-        return_type = get_type_hints(handler).get("return")
+        return_type = get_type_hints(handler).get('return')
         if is_page_handler:
             from longlink.ui import Page
             import json
 
             if return_type is not Page or not isinstance(body, Page):
                 await send({
-                    "type": "http.response.start",
-                    "status": 500,
-                    "headers": [(b"content-type", b"text/plain")],
+                    'type': 'http.response.start',
+                    'status': 500,
+                    'headers': [(b'content-type', b'text/plain')],
                 })
                 await send({
-                    "type": "http.response.body",
-                    "body": b"Invalid response type. Page routes must return longlink.ui.Page.",
+                    'type': 'http.response.body',
+                    'body': b'Invalid response type. Page routes must return longlink.ui.Page.',
                 })
                 return
 
-            headers = [(b"content-type", b"application/json")]
+            headers = [(b'content-type', b'application/json')]
             body_bytes = json.dumps(list(body)).encode()
         elif return_type and isinstance(return_type, type) and issubclass(return_type, BaseModel):
             if not isinstance(body, return_type):
                 await send({
-                    "type": "http.response.start",
-                    "status": 500,
-                    "headers": [(b"content-type", b"text/plain")],
+                    'type': 'http.response.start',
+                    'status': 500,
+                    'headers': [(b'content-type', b'text/plain')],
                 })
                 await send({
-                    "type": "http.response.body",
-                    "body": f"Invalid response type. Expected {return_type.__name__}.".encode(),
+                    'type': 'http.response.body',
+                    'body': f'Invalid response type. Expected {return_type.__name__}.'.encode(),
                 })
                 return
 
-            if hasattr(body, "model_dump_json"):
+            if hasattr(body, 'model_dump_json'):
                 response_body = body.model_dump_json()
             else:
                 response_body = body.json()
-            headers = [(b"content-type", b"application/json")]
+            headers = [(b'content-type', b'application/json')]
             body_bytes = response_body.encode()
         else:
             if isinstance(body, dict):
                 import json
 
-                headers = [(b"content-type", b"application/json")]
+                headers = [(b'content-type', b'application/json')]
                 body_bytes = json.dumps(body).encode()
             else:
-                headers = [(b"content-type", b"text/plain")]
+                headers = [(b'content-type', b'text/plain')]
                 if isinstance(body, bytes):
                     body_bytes = body
                 else:
                     body_bytes = str(body).encode()
 
         await send({
-            "type": "http.response.start",
-            "status": 200,
-            "headers": headers,
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': headers,
         })
         await send({
-            "type": "http.response.body",
-            "body": body_bytes,
+            'type': 'http.response.body',
+            'body': body_bytes,
         })

--- a/sdk/longlink/routes/__init__.py
+++ b/sdk/longlink/routes/__init__.py
@@ -1,11 +1,6 @@
-"""App route registration helpers."""
+"""Register SDK internal routes."""
 
-from longlink.routes.metadata import register_metadata_route
-from longlink.routes.register import register_registration_route
-from longlink.routes.root import register_root_route
+from . import metadata, register, root
 
 
-def register_internal_routes(app) -> None:
-    register_root_route(app)
-    register_registration_route(app)
-    register_metadata_route(app)
+__all__ = ['metadata', 'register', 'root']

--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,15 +1,29 @@
-"""Metadata route registration."""
+"""Metadata route."""
 
-from longlink.envs import envs
+from longlink import get
+
+from longlink.envs import Envs, envs
+from longlink.metadata import metadata
 
 
-def register_metadata_route(app) -> None:
-    @app.get('/metadata.json')
-    async def get_metadata_information(key: str = ''):
-        if key != envs.KEY:
-            return {
-                'detail': 'Invalid app key',
-                'status': 401,
-            }
+def _required_envs() -> list[str]:
+    return [
+        field_name.upper()
+        for field_name, field in Envs.model_fields.items()
+        if field.is_required()
+    ]
 
-        return app.metadata()
+
+@get('/metadata.json')
+async def get_metadata_information(key: str = ''):
+    if key != envs.KEY:
+        return {
+            'detail': 'Invalid app key',
+            'status': 401,
+        }
+
+    return {
+        **metadata.model_dump(),
+        'runtime': 'python-sdk',
+        'required_envs': _required_envs(),
+    }

--- a/sdk/longlink/routes/register.py
+++ b/sdk/longlink/routes/register.py
@@ -1,7 +1,20 @@
-"""Registration route registration."""
+"""Registration route."""
+
+from longlink import get
+
+from longlink.envs import Envs
 
 
-def register_registration_route(app) -> None:
-    @app.get('/register')
-    async def get_registration_information():
-        return app.registration()
+def _required_envs() -> list[str]:
+    return [
+        field_name.upper()
+        for field_name, field in Envs.model_fields.items()
+        if field.is_required()
+    ]
+
+
+@get('/register')
+async def get_registration_information():
+    return {
+        'required_envs': _required_envs(),
+    }

--- a/sdk/longlink/routes/root.py
+++ b/sdk/longlink/routes/root.py
@@ -1,13 +1,14 @@
-"""Root route registration."""
+"""Root route."""
+
+from longlink import app, get
+from longlink.metadata import metadata
 
 
-def register_root_route(app) -> None:
-    @app.get('/')
-    async def get_app_information():
-        metadata = app.metadata()
-        return {
-            'name': metadata.get('name', ''),
-            'description': metadata.get('description', ''),
-            'version': metadata.get('version', ''),
-            'pages': app.pages(),
-        }
+@get('/')
+async def get_app_information():
+    return {
+        'name': metadata.name,
+        'description': metadata.description,
+        'version': metadata.version,
+        'pages': app.pages(),
+    }


### PR DESCRIPTION
### Motivation
- Consolidate SDK internal HTTP endpoints so they register themselves with the global SDK app instead of relying on `LongLink` instance helpers. 
- Keep the `LongLink` class focused on ASGI request dispatching and remove non-ASGI helper methods to simplify responsibilities. 
- Make route implementations explicit and self-contained so metadata and registration payloads are constructed where the HTTP contract lives.

### Description
- Replace `register_*_route(app)` wrappers with direct route decorators using `@get(...)` in `sdk/longlink/routes/{register,metadata,root}.py`, and move `required_envs`/metadata payload construction into those modules. 
- Remove `metadata`, `registration`, and `required_envs` methods and the internal route registration call from `LongLink` so the class only implements ASGI dispatch (`sdk/longlink/app.py`). 
- Ensure internal routes are imported for side effects by adding `import longlink.routes` to `sdk/longlink/__init__.py` so the global `app` instance receives the route registrations. 
- Update `sdk/longlink/routes/__init__.py` to expose the new route modules and normalize route return values to use the relocated metadata helpers.

### Testing
- Ran `python -m compileall sdk/longlink` to ensure the package compiles and it completed successfully. 
- Performed a quick runtime import check with a small Python snippet that loads `sdk` on `sys.path`, confirms `longlink.app` type, verifies the internal routes `['/', '/register', '/metadata.json']` are present, and confirms the removed helper methods are no longer attributes on `LongLink`; this check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca68d663fc83239664269ab3fe4655)