### PR TITLE
Rename Container settings to Compute and remove bottom info banner

### DIFF
--- a/web/src/components/settings/Container.tsx
+++ b/web/src/components/settings/Container.tsx
@@ -1,4 +1,3 @@
-import { Box } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { ConnectContainerRuntimeDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
@@ -66,9 +65,9 @@ export default function Container() {
     return (
         <div className="space-y-6">
             <Hero
-                title="Container Settings"
-                subtitle="Configure container runtimes, registries, and compute quotas"
-                icon="settings"
+                title="Compute Settings"
+                subtitle="Configure compute runtimes, registries, and quotas"
+                icon="cpu"
                 action="Connect"
             >
                 <ConnectContainerRuntimeDialog
@@ -125,18 +124,6 @@ export default function Container() {
                         )}
                     </TableBody>
                 </Table>
-            </Card>
-
-            <Card className="border-dashed p-4 text-sm text-muted-foreground">
-                <div className="flex items-start gap-2">
-                    <Box className="mt-0.5 h-4 w-4" />
-                    <p>
-                        Connected runtimes represent shared container
-                        infrastructure. Applications can set image tags,
-                        environment variables, and scaling policies on top of
-                        these runtime connections.
-                    </p>
-                </div>
             </Card>
         </div>
     );

--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -15,7 +15,7 @@ import {
     ShieldIcon,
     UnplugIcon,
     UsersRoundIcon,
-    WrenchIcon,
+    CpuIcon,
 } from 'lucide-react';
 
 export default function SettingsPage() {
@@ -50,8 +50,8 @@ export default function SettingsPage() {
                     />
                     <MenuSection
                         value="container"
-                        label="Container"
-                        icon={WrenchIcon}
+                        label="Compute"
+                        icon={CpuIcon}
                     />
                     <MenuSection
                         value="security"


### PR DESCRIPTION
### Motivation

- Make the settings UI use more accurate terminology for compute-related runtimes by renaming the Container section to Compute. 
- Use a more appropriate icon for compute functionality. 
- Remove an informational banner at the bottom of the panel to simplify the Compute settings view.

### Description

- Updated the Settings sidebar label from `Container` to `Compute` and swapped the icon import from `WrenchIcon` to `CpuIcon` in `web/src/pages/org/Settings.tsx`.
- Updated the settings page hero in `web/src/components/settings/Container.tsx` to `title="Compute Settings"`, refined the subtitle, and changed the hero icon to `cpu`.
- Removed the bottom dashed informational `Card` (and its `Box` import) from `web/src/components/settings/Container.tsx` so the page now shows only the hero and runtimes table.

### Testing

- Ran formatter with `bun run format` which completed successfully. 
- Ran the build with `bun run build` which failed due to pre-existing TypeScript errors in unrelated files (errors in `src/pages/org/Longlink.tsx` and several `src/ui/*` files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca69180da88323b562afeeabe81ecd)