### PR TITLE
Simplify SDK metadata initialization at startup

### DIFF
--- a/sdk/longlink/metadata.py
+++ b/sdk/longlink/metadata.py
@@ -1,5 +1,4 @@
 import json
-from functools import lru_cache
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -11,10 +10,11 @@ class Metadata(BaseModel):
     version: str = '0.0.0'
 
 
-@lru_cache(maxsize=1)
-def get_metadata() -> Metadata:
+def load_metadata() -> Metadata:
     metadata_file = Path.cwd() / 'metadata.json'
+
     if not metadata_file.exists():
+        print('Warning: metadata.json is missing. Using default metadata values.')
         return Metadata()
 
     try:
@@ -28,12 +28,4 @@ def get_metadata() -> Metadata:
     return Metadata.model_validate(payload)
 
 
-class _LazyMetadata:
-    def __getattr__(self, item):
-        return getattr(get_metadata(), item)
-
-    def model_dump(self) -> dict[str, object]:
-        return get_metadata().model_dump()
-
-
-metadata = _LazyMetadata()
+metadata = load_metadata()


### PR DESCRIPTION
### Motivation

- Ensure `Metadata` is created eagerly when the app starts rather than via a lazy proxy and cached getter, and provide a clear warning if the `metadata.json` file is missing.

### Description

- Replaced the `lru_cache`-backed `get_metadata()` and the `_LazyMetadata` proxy with an eager `load_metadata()` function and `metadata = load_metadata()` module-level assignment in `sdk/longlink/metadata.py`.
- Added a console warning via `print` when `metadata.json` does not exist and the code falls back to default/dummy `Metadata` values.
- Preserved existing fallback behavior for invalid JSON, read errors, or non-object payloads by returning `Metadata()` defaults.

### Testing

- Ran `python -m compileall sdk/longlink/metadata.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6aca9e648323828342da32352794)