### PR TITLE
web: remove extra vertical padding around settings tables

### DIFF
--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -136,7 +136,7 @@ export default function Applications() {
                 </div>
             </Hero>
 
-            <Card className="overflow-hidden">
+            <Card className="gap-0 overflow-hidden py-0">
                 <Table>
                     <TableHeader>
                         <TableRow>

--- a/web/src/components/settings/Container.tsx
+++ b/web/src/components/settings/Container.tsx
@@ -86,7 +86,7 @@ export default function Container() {
                 />
             </Hero>
 
-            <Card className="overflow-hidden">
+            <Card className="gap-0 overflow-hidden py-0">
                 <Table>
                     <TableHeader>
                         <TableRow>

--- a/web/src/components/settings/Database.tsx
+++ b/web/src/components/settings/Database.tsx
@@ -86,7 +86,7 @@ export default function Database() {
                 />
             </Hero>
 
-            <Card className="overflow-hidden">
+            <Card className="gap-0 overflow-hidden py-0">
                 <Table>
                     <TableHeader>
                         <TableRow>

--- a/web/src/components/settings/Permissions.tsx
+++ b/web/src/components/settings/Permissions.tsx
@@ -77,7 +77,7 @@ export default function Permissions() {
                 />
             </Hero>
 
-            <Card className="overflow-hidden">
+            <Card className="gap-0 overflow-hidden py-0">
                 <Table>
                     <TableHeader>
                         <TableRow>

--- a/web/src/components/settings/Storage.tsx
+++ b/web/src/components/settings/Storage.tsx
@@ -87,7 +87,7 @@ export default function Storage() {
                 />
             </Hero>
 
-            <Card className="overflow-hidden">
+            <Card className="gap-0 overflow-hidden py-0">
                 <Table>
                     <TableHeader>
                         <TableRow>


### PR DESCRIPTION
### Motivation
- Settings pages showed small unwanted vertical gaps above table headers and below table content because the `Card` wrapper had default vertical padding.
- The intent is to make table headers and rows sit flush with the card borders across all settings pages for consistent alignment.

### Description
- Replace `className="overflow-hidden"` with `className="gap-0 overflow-hidden py-0"` on the table `Card` wrappers to remove top/bottom padding in settings tables.
- This change was applied to the Applications, Permissions, Database, Storage, and Compute (Container) settings components (`web/src/components/settings/Applications.tsx`, `Permissions.tsx`, `Database.tsx`, `Storage.tsx`, `Container.tsx`).
- No changes were made to the `Table` or `Card` component implementations, only the usage sites for settings tables.

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bun run build` which failed due to pre-existing TypeScript errors unrelated to these UI changes (errors reported in `src/pages/org/Longlink.tsx`, `src/ui/resizable.tsx`, `src/ui/scroll-area.tsx`, and `src/ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6c8d508483239711dd83b161d8c7)