### PR TITLE
Sync organization settings to apps; add SDK organization routes and improve request body handling

### DIFF
--- a/api/src/apps/organization.py
+++ b/api/src/apps/organization.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Final
+
+import httpx
+
+import src.db as db
+
+
+ORGANIZATION_SETTINGS_KEYS: Final[tuple[str, ...]] = (
+    'ORG_NAME',
+    'ORG_NAME_LEGAL',
+    'ORG_TAX_ID',
+    'ORG_PHONE',
+    'ORG_MAIL_CONTACT',
+    'ORG_MAIL_SUPPORT',
+    'ORG_WEBSITE',
+    'ORG_ADDRESS',
+)
+
+
+async def organization_settings_payload() -> dict[str, str]:
+    payload: dict[str, str] = {}
+
+    for key in ORGANIZATION_SETTINGS_KEYS:
+        setting = await db.settings.get(key, app_id=None)
+        payload[key] = setting.value if setting is not None else ''
+
+    return payload
+
+
+async def notify_app_organization_settings(url: str, payload: dict[str, str]) -> None:
+    endpoint = f'{url.rstrip('/')}/organization'
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.put(endpoint, json=payload)
+            if response.status_code >= 400:
+                await client.post(endpoint, json=payload)
+    except httpx.RequestError:
+        return
+
+
+async def notify_all_apps_organization_settings() -> None:
+    apps = await db.apps.list()
+    payload = await organization_settings_payload()
+
+    for app in apps:
+        await notify_app_organization_settings(app.url, payload)

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException, Request, Response
 from pydantic import BaseModel
 
 import src.db as db
+from src.apps.organization import notify_app_organization_settings, organization_settings_payload
 from src.models.apps import AppCreate, AppResponse
 from src.router import router
 
@@ -153,6 +154,9 @@ async def create_app(payload: AppCreate) -> AppResponse:
         )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    organization_payload = await organization_settings_payload()
+    await notify_app_organization_settings(app.url, organization_payload)
 
     return AppResponse(
         id=app.id,

--- a/api/src/routes/settings.py
+++ b/api/src/routes/settings.py
@@ -3,6 +3,7 @@ from typing import List
 from fastapi import HTTPException, Query
 
 import src.db as db
+from src.apps.organization import notify_all_apps_organization_settings
 from src.models.settings import SettingResponse, SettingSet, SettingSetItem
 from src.router import router
 
@@ -53,6 +54,8 @@ async def set_settings(payload: List[SettingSetItem]) -> List[SettingResponse]:
             )
         )
 
+    await notify_all_apps_organization_settings()
+
     return results
 
 
@@ -80,6 +83,8 @@ async def post_setting(key: str, payload: SettingSet) -> SettingResponse:
     except ValueError as error:
         raise _invalid_key_error(error) from error
 
+    await notify_all_apps_organization_settings()
+
     return SettingResponse(
         key=setting.key,
         value=setting.value,
@@ -93,6 +98,8 @@ async def set_setting(key: str, payload: SettingSet) -> SettingResponse:
         setting = await db.settings.set(key, payload.value, app_id=None)
     except ValueError as error:
         raise _invalid_key_error(error) from error
+
+    await notify_all_apps_organization_settings()
 
     return SettingResponse(
         key=setting.key,

--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,6 +1,6 @@
 from .ui import Page
 from .app import LongLink
-from .organization import OrganizationSettings
+from .organization import OrganizationSettings, organization
 from .router import Router
 
 from longlink.ui.textarea import Textarea

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,4 +1,6 @@
-from typing import get_type_hints
+import inspect
+import json
+from typing import Any, get_type_hints
 
 from pydantic import BaseModel
 
@@ -32,8 +34,11 @@ class LongLink(Router, Cron):
             })
             return
 
-        if params:
-            body = await handler(**params)
+        body_payload = await self._read_json_body(scope, receive)
+        call_params = self._merge_body_params(handler, params, body_payload)
+
+        if call_params:
+            body = await handler(**call_params)
         else:
             body = await handler()
 
@@ -42,7 +47,6 @@ class LongLink(Router, Cron):
         return_type = get_type_hints(handler).get('return')
         if is_page_handler:
             from longlink.ui import Page
-            import json
 
             if return_type is not Page or not isinstance(body, Page):
                 await send({
@@ -79,8 +83,6 @@ class LongLink(Router, Cron):
             body_bytes = response_body.encode()
         else:
             if isinstance(body, dict):
-                import json
-
                 headers = [(b'content-type', b'application/json')]
                 body_bytes = json.dumps(body).encode()
             else:
@@ -99,3 +101,57 @@ class LongLink(Router, Cron):
             'type': 'http.response.body',
             'body': body_bytes,
         })
+
+    async def _read_json_body(self, scope, receive) -> dict[str, Any] | None:
+        method = scope.get('method', '').upper()
+        if method in {'GET', 'HEAD', 'OPTIONS'}:
+            return None
+
+        body = b''
+        more_body = True
+        while more_body:
+            message = await receive()
+            if message.get('type') != 'http.request':
+                continue
+
+            body += message.get('body', b'')
+            more_body = message.get('more_body', False)
+
+        if body == b'':
+            return None
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        return payload
+
+    def _merge_body_params(self, handler, params: dict[str, Any], payload: dict[str, Any] | None) -> dict[str, Any]:
+        if payload is None:
+            return params
+
+        merged_params = dict(params)
+        signature = inspect.signature(handler)
+        annotations = get_type_hints(handler)
+
+        missing_parameters = [
+            name for name in signature.parameters
+            if name not in merged_params
+        ]
+
+        if len(missing_parameters) == 1:
+            candidate = missing_parameters[0]
+            annotation = annotations.get(candidate)
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                merged_params[candidate] = annotation.model_validate(payload)
+                return merged_params
+
+        for key, value in payload.items():
+            if key in signature.parameters and key not in merged_params:
+                merged_params[key] = value
+
+        return merged_params

--- a/sdk/longlink/organization.py
+++ b/sdk/longlink/organization.py
@@ -2,11 +2,14 @@ from pydantic import BaseModel
 
 
 class OrganizationSettings(BaseModel):
-    organization_name: str = ''
-    legal_name: str = ''
-    registration_tax_id: str = ''
-    phone_number: str = ''
-    primary_contact_email: str = ''
-    support_email: str = ''
-    website: str = ''
-    physical_address: str = ''
+    ORG_NAME: str = ''
+    ORG_NAME_LEGAL: str = ''
+    ORG_TAX_ID: str = ''
+    ORG_PHONE: str = ''
+    ORG_MAIL_CONTACT: str = ''
+    ORG_MAIL_SUPPORT: str = ''
+    ORG_WEBSITE: str = ''
+    ORG_ADDRESS: str = ''
+
+
+organization = OrganizationSettings()

--- a/sdk/longlink/routes/__init__.py
+++ b/sdk/longlink/routes/__init__.py
@@ -1,6 +1,6 @@
 """Register SDK internal routes."""
 
-from . import metadata, register, root
+from . import metadata, organization, register, root
 
 
-__all__ = ['metadata', 'register', 'root']
+__all__ = ['metadata', 'organization', 'register', 'root']

--- a/sdk/longlink/routes/organization.py
+++ b/sdk/longlink/routes/organization.py
@@ -1,0 +1,15 @@
+"""Organization synchronization routes."""
+
+from longlink import post, put
+from longlink.organization import OrganizationSettings, organization
+
+
+@post('/organization')
+@put('/organization')
+async def update_organization_settings(payload: OrganizationSettings) -> OrganizationSettings:
+    updated_settings = payload.model_dump()
+
+    for key, value in updated_settings.items():
+        setattr(organization, key, value)
+
+    return organization


### PR DESCRIPTION
### Motivation
- Propagate central organization settings to all registered downstream apps whenever settings change or an app is registered.
- Provide an SDK-side representation and HTTP endpoints so apps can receive and apply organization settings.
- Improve the SDK `LongLink` application runner to properly read JSON request bodies and bind them to handler parameters and Pydantic models.

### Description
- Add `api/src/apps/organization.py` with `ORGANIZATION_SETTINGS_KEYS` and helper functions `organization_settings_payload`, `notify_app_organization_settings`, and `notify_all_apps_organization_settings` to build payloads and send `PUT`/`POST` to apps.
- Call organization notification after app creation in `routes/apps.py` by invoking `organization_settings_payload` and `notify_app_organization_settings` for the new app URL.
- Trigger `notify_all_apps_organization_settings()` after settings changes in `routes/settings.py` for bulk `PUT` and single `POST`/`PUT` endpoints so updates are pushed to all apps.
- Update SDK model in `sdk/longlink/organization.py` to use the backend key names (`ORG_*`) and add a global `organization` instance, and export it via `sdk/longlink/__init__.py`.
- Add `sdk/longlink/routes/organization.py` with `@post('/organization')` and `@put('/organization')` handlers that update the SDK `organization` instance from incoming `OrganizationSettings` payloads.
- Enhance `sdk/longlink/app.py` to read JSON request bodies via `_read_json_body`, merge payloads into handler calls with `_merge_body_params`, and support binding a single Pydantic model parameter from the JSON payload.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6c4f78a08323b5905ac849cfeb76)