### PR TITLE
web: replace Security section with Logging settings placeholder

### DIFF
--- a/web/src/components/settings/Logging.tsx
+++ b/web/src/components/settings/Logging.tsx
@@ -1,0 +1,5 @@
+import Hero from '@/longlink/Hero';
+
+export default function Logging() {
+    return <Hero title="Logging Setup" subtitle="" icon="settings" />;
+}

--- a/web/src/pages/org/Settings.tsx
+++ b/web/src/pages/org/Settings.tsx
@@ -3,8 +3,8 @@ import Database from '@/components/settings/Database';
 import General from '@/components/settings/General';
 import Container from '@/components/settings/Container';
 import Integrations from '@/components/settings/Integrations';
+import Logging from '@/components/settings/Logging';
 import Permissions from '@/components/settings/Permissions';
-import Security from '@/components/settings/Security';
 import Storage from '@/components/settings/Storage';
 import { Menu, MenuContent, MenuList, MenuSection } from '@/ui/menu';
 import {
@@ -12,7 +12,7 @@ import {
     DatabaseIcon,
     GlobeIcon,
     HardDriveIcon,
-    ShieldIcon,
+    FileTextIcon,
     UnplugIcon,
     UsersRoundIcon,
     CpuIcon,
@@ -54,9 +54,9 @@ export default function SettingsPage() {
                         icon={CpuIcon}
                     />
                     <MenuSection
-                        value="security"
-                        label="Security"
-                        icon={ShieldIcon}
+                        value="logging"
+                        label="Logging"
+                        icon={FileTextIcon}
                     />
                     <MenuSection
                         value="integrations"
@@ -82,8 +82,8 @@ export default function SettingsPage() {
                 <MenuContent value="container">
                     <Container />
                 </MenuContent>
-                <MenuContent value="security">
-                    <Security />
+                <MenuContent value="logging">
+                    <Logging />
                 </MenuContent>
                 <MenuContent value="integrations">
                     <Integrations />


### PR DESCRIPTION
### Motivation
- Replace the existing Security settings section with a new Logging settings area to prepare for logging configuration UI.

### Description
- Removed the `Security` menu entry and content from `web/src/pages/org/Settings.tsx` and added a `Logging` entry immediately after `Compute`.
- Added a new component `web/src/components/settings/Logging.tsx` which renders a placeholder `Hero` titled `Logging Setup` with an empty subtitle.
- Swapped the icon import to use `FileTextIcon` for the new Logging menu entry in `web/src/pages/org/Settings.tsx`.

### Testing
- Ran `bun run format` in `web` and it completed successfully.
- Ran `bun run build` in `web` and it failed due to existing TypeScript errors in other files unrelated to this change (errors surfaced in `Longlink.tsx`, `ui/resizable.tsx`, `ui/scroll-area.tsx`, and `ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6dc8e17083239395ba6bb1fc31d6)