### PR TITLE
Use `type` in app metadata (tool|space|process) instead of `version`

### DIFF
--- a/sdk/longlink/metadata.py
+++ b/sdk/longlink/metadata.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -7,7 +8,7 @@ from pydantic import BaseModel
 class Metadata(BaseModel):
     name: str = 'Sample LongLink app'
     description: str = ''
-    version: str = '0.0.0'
+    type: Literal['tool', 'space', 'process'] = 'tool'
 
 
 def load_metadata() -> Metadata:

--- a/sdk/longlink/routes/root.py
+++ b/sdk/longlink/routes/root.py
@@ -9,6 +9,6 @@ async def get_app_information():
     return {
         'name': metadata.name,
         'description': metadata.description,
-        'version': metadata.version,
+        'type': metadata.type,
         'pages': app.pages(),
     }

--- a/sdk/sample/metadata.json
+++ b/sdk/sample/metadata.json
@@ -1,5 +1,5 @@
 {
   "name": "Sample LongLink app",
   "description": "The project showcases a lightweight operational system as an example of how to use LongLink SDK.",
-  "version": "0.0.1"
+  "type": "tool"
 }


### PR DESCRIPTION
### Motivation
- Align SDK app metadata with the platform contract by removing the `version` field and exposing only `name`, `description`, and a constrained `type` (`'tool' | 'space' | 'process'`).

### Description
- Replaced `version` with `type: Literal['tool','space','process']` in `sdk/longlink/metadata.py`, updated the root endpoint to return `type` instead of `version` in `sdk/longlink/routes/root.py`, and adjusted the sample `metadata.json` to use `type`.

### Testing
- Ran `python -m compileall sdk/longlink`, which completed successfully (a pre-existing `SyntaxWarning` in `sdk/longlink/ui/__init__.py` was emitted but unrelated to the metadata change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7045f2a88323a8576600c23a4e4b)