### PR TITLE
Trim app URL and key before connect request

### DIFF
--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -72,6 +72,9 @@ export default function Applications() {
             return;
         }
 
+        const normalizedUrl = connectUrl.trim();
+        const normalizedToken = connectToken.trim();
+
         setConnectError(null);
         setIsConnectPending(true);
 
@@ -79,8 +82,8 @@ export default function Applications() {
             await apiFetch<Application>('/apps', {
                 method: 'POST',
                 body: {
-                    url: connectUrl,
-                    token: connectToken,
+                    url: normalizedUrl,
+                    token: normalizedToken,
                 },
             });
 


### PR DESCRIPTION
### Motivation
- Prevent valid app keys from being rejected when users paste values with leading or trailing whitespace by normalizing inputs before the connect request.

### Description
- Trim `connectUrl` and `connectToken` inside `onConnect` in `web/src/components/settings/Applications.tsx` and send the normalized values in the `POST /apps` request.

### Testing
- Ran `bun run format` in `web/` which succeeded. 
- Ran `bun run build` in `web/` which failed due to pre-existing TypeScript errors in unrelated files (e.g. `src/pages/org/Longlink.tsx`, `src/ui/resizable.tsx`, `src/ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca70af3f5c8323902a437526f8f05a)