### PR TITLE
Improve invalid app key handling when fetching app metadata

### DIFF
--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -60,20 +60,41 @@ async def fetch_app_metadata(url: str, token: str) -> AppMetadata:
             detail=f'Could not fetch app metadata: {exc}',
         ) from exc
 
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail='Invalid metadata.json response') from exc
+
     if response.status_code >= 400:
+        if isinstance(payload, dict):
+            detail = payload.get('detail')
+            status = payload.get('status')
+
+            if isinstance(status, int) and status == 401:
+                raise HTTPException(status_code=401, detail='Invalid app key')
+
+            if isinstance(detail, str) and 'invalid app key' in detail.lower():
+                raise HTTPException(status_code=401, detail='Invalid app key')
+
         raise HTTPException(
             status_code=400,
             detail='App metadata endpoint returned an error',
         )
 
-    try:
-        payload = response.json()
-        if isinstance(payload, dict) and payload.get('detail') == 'Invalid app key':
+    if isinstance(payload, dict):
+        detail = payload.get('detail')
+        status = payload.get('status')
+
+        if isinstance(status, int) and status == 401:
             raise HTTPException(status_code=401, detail='Invalid app key')
 
+        if isinstance(detail, str) and 'invalid app key' in detail.lower():
+            raise HTTPException(status_code=401, detail='Invalid app key')
+
+    try:
         return AppMetadata.model_validate(payload)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=400, detail='Invalid metadata.json response')
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=400, detail='Invalid metadata.json response') from exc
 
 
 async def proxy_request(req: Request, app_name: str, full_path: str = '') -> Response:


### PR DESCRIPTION
### Motivation
- App runtimes may return authorization failures in JSON payloads (e.g., `status: 401` or `detail: 'Invalid app key'`) or with non-standard status handling, which caused the registration flow to misclassify auth errors.
- The metadata fetch path needs to reliably detect authentication failures so `/apps` creation surfaces `401` when the provided app key is invalid.

### Description
- Parse the metadata response JSON before handling HTTP status so structured error payloads can be inspected. (`api/src/routes/apps.py`)
- Treat payloads that include `status: 401` or a `detail` string containing `invalid app key` (case-insensitive) as authentication failures and raise `HTTPException(status_code=401)` accordingly. (`api/src/routes/apps.py`)
- Preserve previous behavior for generic upstream errors by returning `400` for non-auth errors and explicitly map malformed or invalid metadata to `400 Invalid metadata.json response` with exception chaining for parse/validation failures. (`api/src/routes/apps.py`)

### Testing
- Ran `python -m compileall src` from the `api/` folder and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca726379c48323adcfce094b51d79a)