### PR TITLE
Use UUID app IDs and add app lookup by UUID

### DIFF
--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -1,14 +1,17 @@
 from datetime import datetime
-from sqlalchemy import DateTime, Integer, String, func
+import uuid
+
+from sqlalchemy import DateTime, String, func
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db.models.__base__ import Base
 
 
 class App(Base):
-    """Represent an application installed in the platform."""
+    '''Represent an application installed in the platform.'''
     __tablename__ = 'apps'
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     url: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/api/src/db/models/envs.py
+++ b/api/src/db/models/envs.py
@@ -1,11 +1,13 @@
 from datetime import datetime
+
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db.models.__base__ import Base
 
 
 class Env(Base):
-    '''Represent an application secret environment variable. 
+    '''Represent an application secret environment variable.
     Envs are stored as secrets and injected in the app container as environment variables.
     '''
     __tablename__ = 'envs'
@@ -15,7 +17,7 @@ class Env(Base):
     # Propriety
     key: Mapped[str] = mapped_column(String(128), nullable=False)
     value: Mapped[str] = mapped_column(Text, nullable=False)
-    appid: Mapped[int] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=False)
+    appid: Mapped[str] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=False)
 
     # Timestamp informations
     date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())

--- a/api/src/db/models/settings.py
+++ b/api/src/db/models/settings.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db.models.__base__ import Base
 
 
@@ -9,11 +11,11 @@ class Setting(Base):
     __tablename__ = 'settings'
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    
+
     # Propriety
     key: Mapped[str] = mapped_column(String(128), nullable=False)
     value: Mapped[str] = mapped_column(Text, nullable=False)
-    appid: Mapped[int | None] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=True)
+    appid: Mapped[str | None] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=True)
 
     # Timestamp informations
     date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())

--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -14,6 +14,15 @@ class AppsService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
+    async def get_by_uuid(self, app_uuid: str) -> App | None:
+        '''Return a registered app by UUID.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(App).where(App.id == app_uuid)
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
     async def get_by_name(self, name: str) -> App | None:
         '''Return a registered app by name.'''
 

--- a/api/src/db/services/envs.py
+++ b/api/src/db/services/envs.py
@@ -1,10 +1,11 @@
 from sqlalchemy import select
+
 from src.db.models import Env
 from src.db.session import get_session
 
 
 class EnvsService:
-    async def list(self, app_id: int) -> list[Env]:
+    async def list(self, app_id: str) -> list[Env]:
         '''Return all env secrets for an app.'''
         Session = await get_session()
         async with Session() as session:
@@ -12,7 +13,7 @@ class EnvsService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
-    async def get(self, key: str, app_id: int) -> Env | None:
+    async def get(self, key: str, app_id: str) -> Env | None:
         '''Return an env secret by key and app scope.'''
         Session = await get_session()
         async with Session() as session:
@@ -20,7 +21,7 @@ class EnvsService:
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def set(self, key: str, value: str, app_id: int) -> Env:
+    async def set(self, key: str, value: str, app_id: str) -> Env:
         '''Create or update an env secret by key and app scope.'''
         Session = await get_session()
         async with Session() as session:
@@ -36,6 +37,5 @@ class EnvsService:
 
             await session.commit()
             await session.refresh(env)
-
 
             return env

--- a/api/src/db/services/settings.py
+++ b/api/src/db/services/settings.py
@@ -1,11 +1,12 @@
 from sqlalchemy import select
+
 from src.config import config
 from src.db.models import Setting
 from src.db.session import get_session
 
 
 class SettingsService:
-    async def list(self, *, app_id: int | None = None) -> list[Setting]:
+    async def list(self, *, app_id: str | None = None) -> list[Setting]:
         '''Return all settings for the selected scope.'''
         Session = await get_session()
         async with Session() as session:
@@ -18,7 +19,7 @@ class SettingsService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
-    async def get(self, key: str, *, app_id: int | None = None) -> Setting | None:
+    async def get(self, key: str, *, app_id: str | None = None) -> Setting | None:
         '''Return a setting by key and scope.'''
         normalized_key = config.normalize_key(key)
         Session = await get_session()
@@ -32,7 +33,7 @@ class SettingsService:
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def set(self, key: str, value: str, *, app_id: int | None = None) -> Setting:
+    async def set(self, key: str, value: str, *, app_id: str | None = None) -> Setting:
         '''Create or update a setting by key and scope.'''
         normalized_key = config.normalize_key(key)
         Session = await get_session()

--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -2,11 +2,12 @@ from pydantic import BaseModel
 
 
 class AppCreate(BaseModel):
+    appid: str
     url: str
     token: str
 
 
 class AppResponse(BaseModel):
-    id: int
+    id: str
     name: str
     url: str

--- a/api/src/models/settings.py
+++ b/api/src/models/settings.py
@@ -13,4 +13,4 @@ class SettingSetItem(BaseModel):
 class SettingResponse(BaseModel):
     key: str
     value: str
-    app_id: int | None = None
+    app_id: str | None = None

--- a/api/src/utils/apps.py
+++ b/api/src/utils/apps.py
@@ -1,6 +1,7 @@
 import httpx
-import src.db as db
 from typing import Any
+
+import src.db as db
 
 
 async def raw(url: str, method: str = 'GET', params: dict[str, str] | None = None, json: dict[str, Any] | None = None, timeout: float = 30.0) -> httpx.Response:
@@ -10,19 +11,18 @@ async def raw(url: str, method: str = 'GET', params: dict[str, str] | None = Non
         elif method.upper() == 'POST':
             return await client.post(url, params=params, json=json)
         else:
-            raise ValueError(f"Unsupported HTTP method: {method}")
+            raise ValueError(f'Unsupported HTTP method: {method}')
 
 
-
-async def get(appid: str, url: str, params: dict[str, str] | None = None) -> httpx.Response:
-    app = await db.apps.get_by_id(appid)
+async def get(app_uuid: str, url: str, params: dict[str, str] | None = None) -> httpx.Response:
+    app = await db.apps.get_by_uuid(app_uuid)
     if app is None:
-        raise ValueError("App not found")
+        raise ValueError('App not found')
     return await raw(url, method='GET', params=params)
 
 
-async def post(appid: str, url: str, params: dict[str, str], json: dict[str, Any] | None = None, timeout: float = 30.0) -> httpx.Response:
-    app = await db.apps.get_by_id(appid)
+async def post(app_uuid: str, url: str, params: dict[str, str], json: dict[str, Any] | None = None, timeout: float = 30.0) -> httpx.Response:
+    app = await db.apps.get_by_uuid(app_uuid)
     if app is None:
-        raise ValueError("App not found")
+        raise ValueError('App not found')
     return await raw(url, method='POST', params=params, json=json, timeout=timeout)


### PR DESCRIPTION
### Motivation
- Switch application identifiers to random UUIDs so `app.id` is no longer an auto-increment integer and new apps receive a generated UUID by default. 
- Provide a direct lookup by UUID for proxy/utility code that needs to contact apps. 
- Propagate the ID type change across models, services and API schemas so foreign keys and request/response shapes remain consistent.

### Description
- Changed the `App` DB model to use a string UUID primary key with default `lambda: str(uuid.uuid4())` (`api/src/db/models/apps.py`).
- Added `AppsService.get_by_uuid(app_uuid: str)` to query apps by their UUID (`api/src/db/services/apps.py`).
- Updated app proxy helpers to use `get_by_uuid()` and renamed parameters to `app_uuid` (`api/src/utils/apps.py`).
- Aligned related FK types and service signatures to use string UUIDs for `envs.appid` and `settings.appid`, and updated Pydantic schemas (`AppCreate.appid`, `AppResponse.id`, `SettingResponse.app_id`) to strings (`api/src/db/models/envs.py`, `api/src/db/models/settings.py`, `api/src/models/apps.py`, `api/src/models/settings.py`, `api/src/db/services/envs.py`, `api/src/db/services/settings.py`).

### Testing
- Ran `python -m compileall api/src` to validate the updated modules and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8a40dbd48323b7c12f1a2b31d9c5)