### PR TITLE
Fix app bootstrap creation by using raw metadata requests

### DIFF
--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -2,7 +2,6 @@ from pydantic import BaseModel
 
 
 class AppCreate(BaseModel):
-    appid: str
     url: str
     token: str
 

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -22,10 +22,28 @@ async def create_app(payload: AppCreate) -> AppResponse:
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    metadata = await apps.get(payload.appid, "metadata.json", params={'token': payload.token})
+    metadata_response = await apps.raw(
+        f'{app_url.rstrip("/")}/metadata.json',
+        method='GET',
+        params={'key': payload.token},
+    )
+    if not metadata_response.is_success:
+        raise HTTPException(
+            status_code=400,
+            detail=f'Unable to fetch metadata.json ({metadata_response.status_code})',
+        )
 
     try:
-        app = await db.apps.create(metadata.name, url=app_url, token=payload.token)
+        metadata = metadata_response.json()
+        app_name = metadata['name']
+    except (ValueError, KeyError, TypeError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail='App metadata response is invalid',
+        ) from exc
+
+    try:
+        app = await db.apps.create(app_name, url=app_url, token=payload.token)
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 

--- a/api/src/utils/apps.py
+++ b/api/src/utils/apps.py
@@ -17,11 +17,17 @@ async def get(app_uuid: str, url: str, params: dict[str, str] | None = None) -> 
     app = await db.apps.get_by_uuid(app_uuid)
     if app is None:
         raise ValueError('App not found')
-    return await raw(url, method='GET', params=params)
+    return await raw(f"{app.url.rstrip('/')}/{url.lstrip('/')}", method='GET', params=params)
 
 
 async def post(app_uuid: str, url: str, params: dict[str, str], json: dict[str, Any] | None = None, timeout: float = 30.0) -> httpx.Response:
     app = await db.apps.get_by_uuid(app_uuid)
     if app is None:
         raise ValueError('App not found')
-    return await raw(url, method='POST', params=params, json=json, timeout=timeout)
+    return await raw(
+        f"{app.url.rstrip('/')}/{url.lstrip('/')}",
+        method='POST',
+        params=params,
+        json=json,
+        timeout=timeout,
+    )

--- a/web/src/components/dialogs/CreateApplicationDialog.tsx
+++ b/web/src/components/dialogs/CreateApplicationDialog.tsx
@@ -9,28 +9,24 @@ import {
 import { Input } from '@/ui/input';
 
 type CreateApplicationDialogProps = {
-    name: string;
-    slug: string;
-    owner: string;
-    runtime: string;
+    url: string;
+    token: string;
     canCreate: boolean;
-    onNameChange: (value: string) => void;
-    onSlugChange: (value: string) => void;
-    onOwnerChange: (value: string) => void;
-    onRuntimeChange: (value: string) => void;
+    isPending: boolean;
+    error: string | null;
+    onUrlChange: (value: string) => void;
+    onTokenChange: (value: string) => void;
     onCreate: () => void;
 };
 
 export default function CreateApplicationDialog({
-    name,
-    slug,
-    owner,
-    runtime,
+    url,
+    token,
     canCreate,
-    onNameChange,
-    onSlugChange,
-    onOwnerChange,
-    onRuntimeChange,
+    isPending,
+    error,
+    onUrlChange,
+    onTokenChange,
     onCreate,
 }: CreateApplicationDialogProps) {
     return (
@@ -38,31 +34,22 @@ export default function CreateApplicationDialog({
             <DialogHeader>
                 <DialogTitle>Create application</DialogTitle>
                 <DialogDescription>
-                    Register a new application to make it available for modules,
-                    storage bindings, and runtime deployment.
+                    Add the app URL and app key so LongLink can fetch
+                    /metadata.json and register the app.
                 </DialogDescription>
             </DialogHeader>
 
             <div className="grid gap-3 md:grid-cols-2">
                 <Input
-                    placeholder="Application name"
-                    value={name}
-                    onChange={(event) => onNameChange(event.target.value)}
+                    placeholder="localhost:1707"
+                    value={url}
+                    onChange={(event) => onUrlChange(event.target.value)}
                 />
                 <Input
-                    placeholder="Slug"
-                    value={slug}
-                    onChange={(event) => onSlugChange(event.target.value)}
-                />
-                <Input
-                    placeholder="Owner"
-                    value={owner}
-                    onChange={(event) => onOwnerChange(event.target.value)}
-                />
-                <Input
-                    placeholder="Runtime"
-                    value={runtime}
-                    onChange={(event) => onRuntimeChange(event.target.value)}
+                    type="password"
+                    placeholder="App key"
+                    value={token}
+                    onChange={(event) => onTokenChange(event.target.value)}
                 />
             </div>
 
@@ -70,12 +57,14 @@ export default function CreateApplicationDialog({
                 <Button
                     variant="outline"
                     onClick={onCreate}
-                    disabled={!canCreate}
+                    disabled={!canCreate || isPending}
                 >
                     <PlusCircle className="h-4 w-4" />
-                    Create
+                    {isPending ? 'Creating...' : 'Create'}
                 </Button>
             </div>
+
+            {error ? <p className="text-sm text-red-300">{error}</p> : null}
         </DialogContent>
     );
 }

--- a/web/src/components/dialogs/CreateToolDialog.tsx
+++ b/web/src/components/dialogs/CreateToolDialog.tsx
@@ -9,22 +9,22 @@ import {
 import { Input } from '@/ui/input';
 
 type CreateToolDialogProps = {
-    name: string;
     url: string;
+    token: string;
     isPending: boolean;
     createError: string | null;
-    onNameChange: (value: string) => void;
     onUrlChange: (value: string) => void;
+    onTokenChange: (value: string) => void;
     onCreate: () => void;
 };
 
 export default function CreateToolDialog({
-    name,
     url,
+    token,
     isPending,
     createError,
-    onNameChange,
     onUrlChange,
+    onTokenChange,
     onCreate,
 }: CreateToolDialogProps) {
     return (
@@ -38,14 +38,15 @@ export default function CreateToolDialog({
 
             <div className="grid gap-3 md:grid-cols-3">
                 <Input
-                    placeholder="Tool name"
-                    value={name}
-                    onChange={(event) => onNameChange(event.target.value)}
-                />
-                <Input
                     placeholder="http://localhost:1707/my-tool"
                     value={url}
                     onChange={(event) => onUrlChange(event.target.value)}
+                />
+                <Input
+                    type="password"
+                    placeholder="App key"
+                    value={token}
+                    onChange={(event) => onTokenChange(event.target.value)}
                 />
                 <Button
                     variant="outline"

--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -23,10 +23,10 @@ type Application = {
 };
 
 export default function Applications() {
-    const [name, setName] = useState('');
-    const [slug, setSlug] = useState('');
-    const [owner, setOwner] = useState('');
-    const [runtime, setRuntime] = useState('Python SDK');
+    const [createUrl, setCreateUrl] = useState('');
+    const [createToken, setCreateToken] = useState('');
+    const [createError, setCreateError] = useState<string | null>(null);
+    const [isCreatePending, setIsCreatePending] = useState(false);
     const [applications, setApplications] = useState<Application[]>([]);
 
     const [connectUrl, setConnectUrl] = useState('');
@@ -35,13 +35,8 @@ export default function Applications() {
     const [isConnectPending, setIsConnectPending] = useState(false);
 
     const canCreate = useMemo(() => {
-        return (
-            name.trim().length > 0 &&
-            slug.trim().length > 0 &&
-            owner.trim().length > 0 &&
-            runtime.trim().length > 0
-        );
-    }, [name, owner, runtime, slug]);
+        return createUrl.trim().length > 0 && createToken.trim().length > 0;
+    }, [createToken, createUrl]);
 
     const canConnect = useMemo(() => {
         return connectUrl.trim().length > 0 && connectToken.trim().length > 0;
@@ -56,15 +51,33 @@ export default function Applications() {
         void loadApps();
     }, []);
 
-    const onCreate = () => {
-        if (!canCreate) {
+    const onCreate = async () => {
+        if (!canCreate || isCreatePending) {
             return;
         }
 
-        setName('');
-        setSlug('');
-        setOwner('');
-        setRuntime('Python SDK');
+        setCreateError(null);
+        setIsCreatePending(true);
+
+        try {
+            await apiFetch<Application>('/apps', {
+                method: 'POST',
+                body: {
+                    url: createUrl.trim(),
+                    token: createToken.trim(),
+                },
+            });
+
+            setCreateUrl('');
+            setCreateToken('');
+            await loadApps();
+        } catch (error) {
+            setCreateError(
+                error instanceof Error ? error.message : 'Could not create app'
+            );
+        } finally {
+            setIsCreatePending(false);
+        }
     };
 
     const onConnect = async () => {
@@ -124,16 +137,16 @@ export default function Applications() {
 
                     <AppButton variant="outline" text="Create app">
                         <CreateApplicationDialog
-                            name={name}
-                            slug={slug}
-                            owner={owner}
-                            runtime={runtime}
+                            url={createUrl}
+                            token={createToken}
                             canCreate={canCreate}
-                            onNameChange={setName}
-                            onSlugChange={setSlug}
-                            onOwnerChange={setOwner}
-                            onRuntimeChange={setRuntime}
-                            onCreate={onCreate}
+                            isPending={isCreatePending}
+                            error={createError}
+                            onUrlChange={setCreateUrl}
+                            onTokenChange={setCreateToken}
+                            onCreate={() => {
+                                void onCreate();
+                            }}
                         />
                     </AppButton>
                 </div>

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -9,8 +9,8 @@ export type App = {
 };
 
 type CreateAppPayload = {
-    name: string;
     url: string;
+    token: string;
 };
 
 export function useApps() {

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -37,25 +37,25 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
 export default function Tools() {
     const { data: apps = [], isLoading, error } = useApps();
     const { mutateAsync: createApp, isPending } = useCreateApp();
-    const [name, setName] = useState('');
     const [url, setUrl] = useState('');
+    const [token, setToken] = useState('');
     const [createError, setCreateError] = useState<string | null>(null);
     const loadErrorMessage =
         error instanceof Error ? error.message : 'Failed to load tools';
 
     const onCreateApp = async () => {
-        if (!name.trim() || !url.trim()) {
+        if (!url.trim() || !token.trim()) {
             return;
         }
 
         try {
             setCreateError(null);
             await createApp({
-                name: name.trim(),
                 url: url.trim(),
+                token: token.trim(),
             });
-            setName('');
             setUrl('');
+            setToken('');
         } catch (err) {
             setCreateError(
                 err instanceof Error ? err.message : 'Failed to create tool'
@@ -72,12 +72,12 @@ export default function Tools() {
                 action="Create Tool"
             >
                 <CreateToolDialog
-                    name={name}
                     url={url}
+                    token={token}
                     isPending={isPending}
                     createError={createError}
-                    onNameChange={setName}
                     onUrlChange={setUrl}
+                    onTokenChange={setToken}
                     onCreate={() => void onCreateApp()}
                 />
             </Hero>


### PR DESCRIPTION
### Motivation

- App creation previously required an `appid` and attempted to contact the app through helpers before the remote app was initialized, which prevents registering a fresh app; the intent is to support raw creation from a URL + app key. 
- The frontend dialogs and hooks were mismatched with the backend payload shape, so the UI could not submit a proper create request. 
- Helper utilities built target paths incorrectly, causing proxied requests to use wrong URLs.

### Description

- Backend: removed `appid` from the `AppCreate` model (`api/src/models/apps.py`) and changed `/apps` creation to fetch `metadata.json` directly from the provided `url` with a raw HTTP GET using `key=<token>`, validate the response, and use `metadata['name']` when creating the DB record (`api/src/routes/apps.py`).
- Backend: fixed app URL joining for helper functions so `get` and `post` build full upstream URLs correctly (`api/src/utils/apps.py`).
- Frontend: updated create hooks and payloads to submit `{ url, token }` (`web/src/hooks/use-apps.ts`) and updated the Tools page to collect and send an app key (`web/src/pages/org/Tools.tsx`).
- Frontend: updated Create Tool and Create Application dialogs to request `URL` + `App key`, to show pending/error state, and wired the Settings → Applications create action to call the API and refresh the list (`web/src/components/dialogs/CreateToolDialog.tsx`, `web/src/components/dialogs/CreateApplicationDialog.tsx`, `web/src/components/settings/Applications.tsx`).

### Testing

- Ran format with `cd web && bun run format` and it completed successfully. 
- Ran ESLint on modified web files with `cd web && bunx eslint src/hooks/use-apps.ts src/pages/org/Tools.tsx src/components/dialogs/CreateToolDialog.tsx src/components/dialogs/CreateApplicationDialog.tsx src/components/settings/Applications.tsx` and it completed successfully. 
- Performed Python syntax checks with `cd api && python -m py_compile src/models/apps.py src/routes/apps.py src/utils/apps.py` and they compiled successfully. 
- `cd api && pytest -q` failed during collection due to a pre-existing missing module `src.hello` (unrelated to these changes). 
- `cd web && bun run build` failed due to unrelated TypeScript errors elsewhere in the repo (pre-existing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca936a288c8323b7a6c12e3dc6d83e)