### PR TITLE
Align org hero icons with navigation icons

### DIFF
--- a/web/src/pages/org/Overview.tsx
+++ b/web/src/pages/org/Overview.tsx
@@ -19,7 +19,7 @@ export default function Overview() {
             <Hero
                 title="Overview"
                 subtitle="A high-level snapshot of your organization workspace."
-                icon="layout-dashboard"
+                icon="bar-chart-3"
             />
 
             <div className="grid gap-4 md:grid-cols-3">

--- a/web/src/pages/org/Spaces.tsx
+++ b/web/src/pages/org/Spaces.tsx
@@ -15,7 +15,7 @@ export default function Spaces() {
             <Hero
                 title="Spaces"
                 subtitle="Create dedicated work areas for teams, projects, and context."
-                icon="panels-top-left"
+                icon="folder-kanban"
             />
 
             <Card className="p-10 text-center">

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -68,7 +68,7 @@ export default function Tools() {
             <Hero
                 title="Tools"
                 subtitle={`${apps.length} tools`}
-                icon="sparkles"
+                icon="blocks"
                 action="Create Tool"
             >
                 <CreateToolDialog


### PR DESCRIPTION
### Motivation
- Ensure visual consistency by making the hero icons on organization pages match the icons used in the top navigation.

### Description
- Updated the `icon` prop passed to `Hero` in `web/src/pages/org/Overview.tsx`, `web/src/pages/org/Tools.tsx`, and `web/src/pages/org/Spaces.tsx` to use `bar-chart-3`, `blocks`, and `folder-kanban` respectively.

### Testing
- Ran `bun run format` in `web/` and the formatter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca98959c888323b1ecc1c3207ddbdf)