### PR TITLE
Add app key/type support and typed listing endpoints

### DIFF
--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -65,7 +65,7 @@ async def authapp(request: Request) -> db.App:
     if not token:
         raise HTTPException(401, 'Missing app token')
 
-    app = await db.apps.get_by_token(token)
+    app = await db.apps.get_by_key(token)
     if app is None:
         raise HTTPException(401, 'Invalid app token')
 

--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -12,7 +12,8 @@ class App(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     url: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
-    token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    type: Mapped[str] = mapped_column(String(16), nullable=False, default='tool')
 
     # Timestamp informations
     date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())

--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -13,6 +13,15 @@ class AppsService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
+    async def list_by_type(self, app_type: str) -> list[App]:
+        '''Return all registered apps matching a type.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(App).where(App.type == app_type)
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
     async def get_by_uuid(self, app_uuid: str) -> App | None:
         '''Return a registered app by UUID.'''
 
@@ -31,16 +40,16 @@ class AppsService:
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def get_by_token(self, token: str) -> App | None:
-        '''Return a registered app by token.'''
+    async def get_by_key(self, key: str) -> App | None:
+        '''Return a registered app by key.'''
 
         Session = await get_session()
         async with Session() as session:
-            statement = select(App).where(App.token == token)
+            statement = select(App).where(App.key == key)
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def create(self, name: str, url: str, token: str) -> App:
+    async def create(self, name: str, url: str, key: str, app_type: str) -> App:
         '''Add a new app to the database.'''
 
         Session = await get_session()
@@ -52,13 +61,13 @@ class AppsService:
             if existing_app is not None:
                 raise ValueError('App URL already exists')
 
-            token_statement = select(App).where(App.token == token)
-            token_result = await session.execute(token_statement)
-            existing_token = token_result.scalar_one_or_none()
-            if existing_token is not None:
-                raise ValueError('App token already exists')
+            key_statement = select(App).where(App.key == key)
+            key_result = await session.execute(key_statement)
+            existing_key = key_result.scalar_one_or_none()
+            if existing_key is not None:
+                raise ValueError('App key already exists')
 
-            app = App(name=name, url=url, token=token)
+            app = App(name=name, url=url, key=key, type=app_type)
             session.add(app)
             await session.commit()
             await session.refresh(app)

--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -3,10 +3,11 @@ from pydantic import BaseModel
 
 class AppCreate(BaseModel):
     url: str
-    token: str
+    key: str
 
 
 class AppResponse(BaseModel):
     id: str
     name: str
     url: str
+    type: str

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -7,11 +7,38 @@ from src.apps.organization import (organization_settings_payload,
                                    notify_app_organization_settings)
 
 
+def serialize_app(app: db.App) -> AppResponse:
+    return AppResponse(id=app.id, name=app.name, url=app.url, type=app.type)
+
+
+async def list_apps_by_type(app_type: str) -> list[AppResponse]:
+    registered_apps = await db.apps.list_by_type(app_type)
+    return [serialize_app(app) for app in registered_apps]
+
+
 @router.get('/apps')
 async def list_apps() -> list[AppResponse]:
     """List all registered apps."""
-    apps = await db.apps.list()
-    return [AppResponse(id=app.id, name=app.name, url=app.url) for app in apps ]
+    registered_apps = await db.apps.list()
+    return [serialize_app(app) for app in registered_apps]
+
+
+@router.get('/tools')
+async def list_tools() -> list[AppResponse]:
+    """List all tools apps."""
+    return await list_apps_by_type('tool')
+
+
+@router.get('/spaces')
+async def list_spaces() -> list[AppResponse]:
+    """List all spaces apps."""
+    return await list_apps_by_type('space')
+
+
+@router.get('/processes')
+async def list_processes() -> list[AppResponse]:
+    """List all processes apps."""
+    return await list_apps_by_type('process')
 
 
 @router.post('/apps')
@@ -25,7 +52,7 @@ async def create_app(payload: AppCreate) -> AppResponse:
     metadata_response = await apps.raw(
         f'{app_url.rstrip("/")}/metadata.json',
         method='GET',
-        params={'key': payload.token},
+        params={'key': payload.key},
     )
     if not metadata_response.is_success:
         raise HTTPException(
@@ -35,20 +62,31 @@ async def create_app(payload: AppCreate) -> AppResponse:
 
     try:
         metadata = metadata_response.json()
-        print(metadata)
         app_name = metadata['name']
+        app_type = metadata.get('type', 'tool')
     except (ValueError, KeyError, TypeError) as exc:
         raise HTTPException(
             status_code=400,
             detail='App metadata response is invalid',
         ) from exc
 
+    if app_type not in {'tool', 'space', 'process'}:
+        raise HTTPException(
+            status_code=400,
+            detail='App metadata type must be one of: tool, space, process',
+        )
+
     try:
-        app = await db.apps.create(app_name, url=app_url, token=payload.token)
+        app = await db.apps.create(
+            app_name,
+            url=app_url,
+            key=payload.key,
+            app_type=app_type,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     organization_payload = await organization_settings_payload()
     await notify_app_organization_settings(app.url, organization_payload)
 
-    return AppResponse(id=app.id, name=app.name, url=app.url)
+    return serialize_app(app)

--- a/web/src/components/dialogs/CreateToolDialog.tsx
+++ b/web/src/components/dialogs/CreateToolDialog.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/ui/input';
 
 type CreateToolDialogProps = {
     url: string;
-    token: string;
+    keyValue: string;
     isPending: boolean;
     createError: string | null;
     onUrlChange: (value: string) => void;
@@ -20,7 +20,7 @@ type CreateToolDialogProps = {
 
 export default function CreateToolDialog({
     url,
-    token,
+    keyValue,
     isPending,
     createError,
     onUrlChange,
@@ -45,7 +45,7 @@ export default function CreateToolDialog({
                 <Input
                     type="password"
                     placeholder="App key"
-                    value={token}
+                    value={keyValue}
                     onChange={(event) => onTokenChange(event.target.value)}
                 />
                 <Button

--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -64,7 +64,7 @@ export default function Applications() {
                 method: 'POST',
                 body: {
                     url: createUrl.trim(),
-                    token: createToken.trim(),
+                    key: createToken.trim(),
                 },
             });
 
@@ -96,7 +96,7 @@ export default function Applications() {
                 method: 'POST',
                 body: {
                     url: normalizedUrl,
-                    token: normalizedToken,
+                    key: normalizedToken,
                 },
             });
 

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -3,14 +3,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 
 export type App = {
-    id: number;
+    id: string;
     name: string;
     url: string;
+    type: 'tool' | 'space' | 'process';
 };
 
 type CreateAppPayload = {
     url: string;
-    token: string;
+    key: string;
 };
 
 export function useApps() {
@@ -32,5 +33,26 @@ export function useCreateApp() {
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: ['apps'] });
         },
+    });
+}
+
+export function useTools() {
+    return useQuery({
+        queryKey: ['tools'],
+        queryFn: () => apiFetch<App[]>('/tools'),
+    });
+}
+
+export function useSpaces() {
+    return useQuery({
+        queryKey: ['spaces'],
+        queryFn: () => apiFetch<App[]>('/spaces'),
+    });
+}
+
+export function useProcesses() {
+    return useQuery({
+        queryKey: ['processes'],
+        queryFn: () => apiFetch<App[]>('/processes'),
     });
 }

--- a/web/src/pages/org/Processes.tsx
+++ b/web/src/pages/org/Processes.tsx
@@ -1,5 +1,7 @@
 import { Workflow } from 'lucide-react';
 import Hero from '@/longlink/Hero';
+import Table, { type ApiTableColumn } from '@/longlink/Table';
+import { useProcesses } from '@/hooks/use-apps';
 import { Card } from '@/ui/card';
 import {
     Empty,
@@ -9,29 +11,71 @@ import {
     EmptyTitle,
 } from '@/ui/empty';
 
+const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
+    title: 'Processes',
+    schema: {
+        columns: [
+            {
+                key: 'name',
+                label: 'Name',
+                content: {
+                    value: '{name}',
+                    link: '/apps/{name}',
+                },
+            },
+            {
+                key: 'url',
+                label: 'URL',
+                value: '{url}',
+            },
+            {
+                key: 'type',
+                label: 'Type',
+                value: '{type}',
+            },
+        ],
+    },
+};
+
 export default function Processes() {
+    const { data: processes = [], isLoading, error } = useProcesses();
+    const loadErrorMessage =
+        error instanceof Error ? error.message : 'Failed to load processes';
+
     return (
         <div className="space-y-6">
             <Hero
                 title="Processes"
-                subtitle="Document and automate the operational flows your teams rely on."
+                subtitle={`${processes.length} processes`}
                 icon="workflow"
             />
 
-            <Card className="p-10 text-center">
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <Workflow className="h-5 w-5" />
-                        </EmptyMedia>
-                        <EmptyTitle>No Processes Yet</EmptyTitle>
-                        <EmptyDescription>
-                            Processes will surface reusable workflows and
-                            playbooks for your organization.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
-            </Card>
+            {isLoading ? (
+                <Card className="p-10 text-center text-white/60">
+                    Loading processes...
+                </Card>
+            ) : error ? (
+                <Card className="p-10 text-center text-red-300">
+                    {loadErrorMessage}
+                </Card>
+            ) : processes.length === 0 ? (
+                <Card className="p-10 text-center">
+                    <Empty>
+                        <EmptyHeader>
+                            <EmptyMedia variant="icon">
+                                <Workflow className="h-5 w-5" />
+                            </EmptyMedia>
+                            <EmptyTitle>No Processes Yet</EmptyTitle>
+                            <EmptyDescription>
+                                Processes will surface reusable workflows and
+                                playbooks for your organization.
+                            </EmptyDescription>
+                        </EmptyHeader>
+                    </Empty>
+                </Card>
+            ) : (
+                <Table endpoint="/processes" schema={tableSchema} />
+            )}
         </div>
     );
 }

--- a/web/src/pages/org/Spaces.tsx
+++ b/web/src/pages/org/Spaces.tsx
@@ -1,5 +1,7 @@
 import { PanelsTopLeft } from 'lucide-react';
 import Hero from '@/longlink/Hero';
+import Table, { type ApiTableColumn } from '@/longlink/Table';
+import { useSpaces } from '@/hooks/use-apps';
 import { Card } from '@/ui/card';
 import {
     Empty,
@@ -9,29 +11,71 @@ import {
     EmptyTitle,
 } from '@/ui/empty';
 
+const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
+    title: 'Spaces',
+    schema: {
+        columns: [
+            {
+                key: 'name',
+                label: 'Name',
+                content: {
+                    value: '{name}',
+                    link: '/apps/{name}',
+                },
+            },
+            {
+                key: 'url',
+                label: 'URL',
+                value: '{url}',
+            },
+            {
+                key: 'type',
+                label: 'Type',
+                value: '{type}',
+            },
+        ],
+    },
+};
+
 export default function Spaces() {
+    const { data: spaces = [], isLoading, error } = useSpaces();
+    const loadErrorMessage =
+        error instanceof Error ? error.message : 'Failed to load spaces';
+
     return (
         <div className="space-y-6">
             <Hero
                 title="Spaces"
-                subtitle="Create dedicated work areas for teams, projects, and context."
+                subtitle={`${spaces.length} spaces`}
                 icon="folder-kanban"
             />
 
-            <Card className="p-10 text-center">
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                            <PanelsTopLeft className="h-5 w-5" />
-                        </EmptyMedia>
-                        <EmptyTitle>No Spaces Yet</EmptyTitle>
-                        <EmptyDescription>
-                            Spaces will help organize work into focused
-                            environments for your organization.
-                        </EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
-            </Card>
+            {isLoading ? (
+                <Card className="p-10 text-center text-white/60">
+                    Loading spaces...
+                </Card>
+            ) : error ? (
+                <Card className="p-10 text-center text-red-300">
+                    {loadErrorMessage}
+                </Card>
+            ) : spaces.length === 0 ? (
+                <Card className="p-10 text-center">
+                    <Empty>
+                        <EmptyHeader>
+                            <EmptyMedia variant="icon">
+                                <PanelsTopLeft className="h-5 w-5" />
+                            </EmptyMedia>
+                            <EmptyTitle>No Spaces Yet</EmptyTitle>
+                            <EmptyDescription>
+                                Spaces will help organize work into focused
+                                environments for your organization.
+                            </EmptyDescription>
+                        </EmptyHeader>
+                    </Empty>
+                </Card>
+            ) : (
+                <Table endpoint="/spaces" schema={tableSchema} />
+            )}
         </div>
     );
 }

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -11,7 +11,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/ui/empty';
-import { useApps, useCreateApp } from '@/hooks/use-apps';
+import { useCreateApp, useTools } from '@/hooks/use-apps';
 
 const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
     title: 'Tools',
@@ -30,21 +30,26 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
                 label: 'URL',
                 value: '{url}',
             },
+            {
+                key: 'type',
+                label: 'Type',
+                value: '{type}',
+            },
         ],
     },
 };
 
 export default function Tools() {
-    const { data: apps = [], isLoading, error } = useApps();
+    const { data: tools = [], isLoading, error } = useTools();
     const { mutateAsync: createApp, isPending } = useCreateApp();
     const [url, setUrl] = useState('');
-    const [token, setToken] = useState('');
+    const [key, setKey] = useState('');
     const [createError, setCreateError] = useState<string | null>(null);
     const loadErrorMessage =
         error instanceof Error ? error.message : 'Failed to load tools';
 
     const onCreateApp = async () => {
-        if (!url.trim() || !token.trim()) {
+        if (!url.trim() || !key.trim()) {
             return;
         }
 
@@ -52,10 +57,10 @@ export default function Tools() {
             setCreateError(null);
             await createApp({
                 url: url.trim(),
-                token: token.trim(),
+                key: key.trim(),
             });
             setUrl('');
-            setToken('');
+            setKey('');
         } catch (err) {
             setCreateError(
                 err instanceof Error ? err.message : 'Failed to create tool'
@@ -67,17 +72,17 @@ export default function Tools() {
         <div className="space-y-6">
             <Hero
                 title="Tools"
-                subtitle={`${apps.length} tools`}
+                subtitle={`${tools.length} tools`}
                 icon="blocks"
                 action="Create Tool"
             >
                 <CreateToolDialog
                     url={url}
-                    token={token}
+                    keyValue={key}
                     isPending={isPending}
                     createError={createError}
                     onUrlChange={setUrl}
-                    onTokenChange={setToken}
+                    onTokenChange={setKey}
                     onCreate={() => void onCreateApp()}
                 />
             </Hero>
@@ -90,7 +95,7 @@ export default function Tools() {
                 <Card className="p-10 text-center text-red-300">
                     {loadErrorMessage}
                 </Card>
-            ) : apps.length === 0 ? (
+            ) : tools.length === 0 ? (
                 <Card className="p-10 text-center">
                     <Empty>
                         <EmptyHeader>
@@ -106,7 +111,7 @@ export default function Tools() {
                     </Empty>
                 </Card>
             ) : (
-                <Table endpoint="/apps" schema={tableSchema} />
+                <Table endpoint="/tools" schema={tableSchema} />
             )}
         </div>
     );


### PR DESCRIPTION
### Motivation
- Standardize app authentication by renaming the external `token` field to `key` and persist the key on the app record.
- Introduce an explicit app `type` so different kinds of installed apps (tools, spaces, processes) can be queried and rendered separately.
- Surface typed lists in the UI so the frontend can show `tools`, `spaces`, and `processes` as distinct sections.

### Description
- Changed the app API contract: `AppCreate` now expects `key` and `AppResponse` includes a `type` string, and the app creation route reads `metadata.json` with `params={'key': payload.key}` and extracts `type` (default `tool`) with validation for `tool|space|process`.
- Added typed read endpoints in the backend: `GET /tools`, `GET /spaces`, and `GET /processes`, and refactored `/apps` to include `type` in responses via a `serialize_app` helper.
- Updated database model and services to store `key` and `type`, added `list_by_type(...)`, replaced `get_by_token` with `get_by_key`, and updated `create(...)` to accept `key` and `app_type` while checking key uniqueness.
- Updated app auth to use `db.apps.get_by_key(...)`, and updated web code including `use-apps` hooks, the Create dialogs, and the org pages to send `key` (not `token`), fetch `/tools`, `/spaces`, `/processes`, and render the returned `type` in the tables.

### Testing
- Ran frontend formatting with `cd web && bun run format`, which completed successfully.
- Ran backend import sorting with `cd api && isort .`, which completed successfully.
- Compiled Python sources with `cd api && python -m compileall src`, which completed successfully.
- Attempted a frontend build with `cd web && bun run build`, which failed due to pre-existing unrelated TypeScript errors in the repo (errors in `src/ui/resizable.tsx`, `src/ui/sidebar.tsx`, and `src/pages/org/Longlink.tsx`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9a98dc208323b3c652fb073e41bc)