### PR TITLE
Add `longlink build` command to generate Dockerfile and manifest

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,6 +12,7 @@ Used to build and publish LongLink appliations.
 
 ```
 longlink init <module>
+longlink build
 longlink login
 longlink logout
 longlink publish <module>

--- a/sdk/longlink/__main__.py
+++ b/sdk/longlink/__main__.py
@@ -5,6 +5,7 @@ import uvicorn
 import importlib
 from pathlib import Path
 from longlink.cli import setup
+from longlink.cli.build import build_command
 
 
 @click.group()
@@ -43,6 +44,9 @@ def init(folder: str):
     """Initialize a new longlink project"""
     folder_path = Path(folder)
     setup(folder_path)
+
+
+main.add_command(build_command)
 
 
 

--- a/sdk/longlink/cli/__init__.py
+++ b/sdk/longlink/cli/__init__.py
@@ -1,1 +1,2 @@
 from .init import setup
+from .build import build_app, build_command

--- a/sdk/longlink/cli/build.py
+++ b/sdk/longlink/cli/build.py
@@ -1,0 +1,52 @@
+import json
+import click
+from pathlib import Path
+from datetime import UTC, datetime
+from longlink.metadata import load_metadata
+
+DOCKERFILE_TEMPLATE = """FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 1707
+
+CMD [\"longlink\", \"dev\"]
+"""
+
+
+def create_version() -> str:
+    return datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+
+
+def build_app(base_path: Path | None = None) -> tuple[Path, Path, str]:
+    root = (base_path or Path.cwd()).resolve()
+    version = create_version()
+    metadata = load_metadata().model_dump()
+
+    dockerfile_path = root / "Dockerfile"
+    dockerfile_path.write_text(DOCKERFILE_TEMPLATE)
+
+    manifest = {
+        "version": version,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "metadata": metadata,
+        "dockerfile": dockerfile_path.name,
+    }
+
+    manifest_path = root / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+
+    return dockerfile_path, manifest_path, version
+
+
+@click.command(name="build")
+def build_command():
+    """Create Dockerfile and manifest metadata for deployment."""
+    dockerfile_path, manifest_path, version = build_app()
+    click.echo(f"Build artifacts created for version {version}")
+    click.echo(f"- Dockerfile: {dockerfile_path}")
+    click.echo(f"- Manifest: {manifest_path}")


### PR DESCRIPTION
### Motivation
- Provide a simple SDK command to produce deployment artifacts (Dockerfile + manifest) for an app directory with an immutable timestamped version.

### Description
- Add `sdk/longlink/cli/build.py` which implements `build_app()` to write a `Dockerfile` and `manifest.json` and a `build` Click command that exposes the functionality.
- Generate a version string in `YYYYMMDD_HHMMSS` format and include `generated_at`, loaded app metadata, and the dockerfile name in `manifest.json`.
- Register the new command in the CLI entrypoint by adding `main.add_command(build_command)` to `sdk/longlink/__main__.py` and export the functions from `sdk/longlink/cli/__init__.py`.
- Document the new CLI command in `sdk/README.md`.

### Testing
- Ran `isort` on modified files which completed successfully.
- Used `click.testing.CliRunner` to verify `--help` lists the new `build` command and the invocation returned exit code `0`.
- Executed `longlink build` in a temporary directory with a sample `metadata.json` and verified that `Dockerfile` and `manifest.json` were created, the `version` field matched the regex `\d{8}_\d{6}`, and the manifest contains the provided metadata; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9b0144688323a14386a46c7fc54c)