### PR TITLE
Refactor SDK CLI entrypoint and command modules

### DIFF
--- a/sdk/longlink/__main__.py
+++ b/sdk/longlink/__main__.py
@@ -1,55 +1,5 @@
-import os
-import sys
-import click
-import uvicorn
-import importlib
-from pathlib import Path
-from longlink.cli import setup
-from longlink.cli.build import build_command
+from longlink.cli.main import main
 
 
-@click.group()
-def main():
-    """longlink command line interface"""
-    pass
-
-
-def load_app():
-    importlib.import_module("main")
-    from longlink import app
-
-    return app
-
-
-# longlink dev
-@main.command()
-def dev():
-    # add CWD to import path
-    sys.path.insert(0, os.getcwd())
-    os.environ["DEV"] = "True"
-
-    uvicorn.run(
-        "longlink.__main__:load_app",
-        host="0.0.0.0",
-        port=1707,
-        reload=True,
-        factory=True,
-    )
-
-
-# longlink init --folder sample
-@main.command()
-@click.option('--folder', prompt='Enter folder name', help='Folder to initialize')
-def init(folder: str):
-    """Initialize a new longlink project"""
-    folder_path = Path(folder)
-    setup(folder_path)
-
-
-main.add_command(build_command)
-
-
-
-# TODO: Add commands for database migration using Alembic
-# alembic revision --autogenerate
-# alembic upgrade head
+if __name__ == "__main__":
+    main()

--- a/sdk/longlink/cli/__init__.py
+++ b/sdk/longlink/cli/__init__.py
@@ -1,2 +1,4 @@
-from .init import setup
 from .build import build_app, build_command
+from .dev import dev_command, load_app
+from .init import init_command, setup
+from .main import main

--- a/sdk/longlink/cli/dev.py
+++ b/sdk/longlink/cli/dev.py
@@ -1,0 +1,28 @@
+import importlib
+import os
+import sys
+
+import click
+import uvicorn
+
+
+def load_app():
+    importlib.import_module("main")
+    from longlink import app
+
+    return app
+
+
+@click.command(name="dev")
+def dev_command():
+    """Run the LongLink app locally with auto-reload."""
+    sys.path.insert(0, os.getcwd())
+    os.environ["DEV"] = "True"
+
+    uvicorn.run(
+        "longlink.cli.dev:load_app",
+        host="0.0.0.0",
+        port=1707,
+        reload=True,
+        factory=True,
+    )

--- a/sdk/longlink/cli/init.py
+++ b/sdk/longlink/cli/init.py
@@ -1,13 +1,23 @@
 import os
-import click
 import shutil
 from pathlib import Path
+
+import click
+
 from longlink.constants import PATH
 
 
 def setup(folder: Path):
-    """Initialize a new longlink project"""
+    """Initialize a new longlink project."""
     sample_path = PATH / "sample"
     os.makedirs(folder, exist_ok=True)
     shutil.copytree(sample_path, folder, dirs_exist_ok=True)
     click.echo(f"Project initialized in {folder}")
+
+
+@click.command(name="init")
+@click.option("--folder", prompt="Enter folder name", help="Folder to initialize")
+def init_command(folder: str):
+    """Initialize a new longlink project."""
+    folder_path = Path(folder)
+    setup(folder_path)

--- a/sdk/longlink/cli/main.py
+++ b/sdk/longlink/cli/main.py
@@ -1,0 +1,15 @@
+import click
+
+from longlink.cli.build import build_command
+from longlink.cli.dev import dev_command
+from longlink.cli.init import init_command
+
+
+@click.group()
+def main():
+    """longlink command line interface"""
+
+
+main.add_command(dev_command)
+main.add_command(init_command)
+main.add_command(build_command)


### PR DESCRIPTION
### Motivation
- Simplify the SDK CLI entrypoint so `__main__` only delegates to a central Click group and keep command implementations modular.
- Make CLI commands easier to maintain and test by moving each command into its own file following the `build.py` pattern.

### Description
- Replace the previous monolithic `sdk/longlink/__main__.py` with a minimal delegating file that calls the CLI group from `longlink.cli.main`.
- Add `sdk/longlink/cli/main.py` as the central Click group which registers `dev`, `init`, and `build` commands.
- Move the `dev` command into `sdk/longlink/cli/dev.py` and implement `load_app`/`dev_command` there (starts `uvicorn` with factory reload).
- Refactor `sdk/longlink/cli/init.py` to expose `init_command` and keep `setup()` as reusable initialization logic; update `sdk/longlink/cli/__init__.py` exports to include new modules.

### Testing
- Ran `cd sdk && python -m longlink --help` and confirmed the CLI lists the grouped commands `build`, `dev`, and `init`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9cafdc8c83238f0967c743386eab)