### PR TITLE
Fix AppsService import crash caused by annotation evaluation

### DIFF
--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import select
 from src.db.models import App
 from src.db.session import get_session


### PR DESCRIPTION
### Motivation
- Prevent import-time evaluation of class-level type annotations that caused `TypeError: 'function' object is not subscriptable` when the method `list` shadowed the builtin `list` during module import.

### Description
- Add `from __future__ import annotations` at the top of `api/src/db/services/apps.py` to postpone annotation evaluation and avoid resolving `list[App]` against the `AppsService.list` method.

### Testing
- Ran `python - <<'PY'\nfrom src.db.services.apps import AppsService\nprint('ok', AppsService)\nPY` in `api/` to verify the module imports successfully (succeeded).
- Ran `isort .` in `api/` for import formatting (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9cd1d5208323acf7ee18025b300c)