### PR TITLE
Normalize app URL scheme and auto-close Connect modal

### DIFF
--- a/api/src/utils/url.py
+++ b/api/src/utils/url.py
@@ -3,14 +3,17 @@ from urllib.parse import urlparse
 
 def normalize(url: str) -> str:
     """Normalize an app URL by ensuring it has a scheme and no trailing slash."""
-    
+
     cleaned_url = url.strip().rstrip('/')
     if cleaned_url == '':
         raise ValueError('App URL is required')
 
     parsed = urlparse(cleaned_url)
     if parsed.scheme == '':
-        cleaned_url = f'http://{cleaned_url}'
+        local_hosts = {'localhost', '127.0.0.1', '::1'}
+        host = cleaned_url.split('/', 1)[0].split(':', 1)[0].strip('[]').lower()
+        default_scheme = 'http' if host in local_hosts else 'https'
+        cleaned_url = f'{default_scheme}://{cleaned_url}'
         parsed = urlparse(cleaned_url)
 
     if parsed.netloc == '':

--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -33,6 +33,7 @@ export default function Applications() {
     const [connectToken, setConnectToken] = useState('');
     const [connectError, setConnectError] = useState<string | null>(null);
     const [isConnectPending, setIsConnectPending] = useState(false);
+    const [connectCloseSignal, setConnectCloseSignal] = useState(0);
 
     const canCreate = useMemo(() => {
         return createUrl.trim().length > 0 && createToken.trim().length > 0;
@@ -102,6 +103,7 @@ export default function Applications() {
 
             setConnectUrl('');
             setConnectToken('');
+            setConnectCloseSignal((currentSignal) => currentSignal + 1);
             await loadApps();
         } catch (error) {
             setConnectError(
@@ -120,7 +122,11 @@ export default function Applications() {
                 icon="settings"
             >
                 <div className="flex items-center gap-2">
-                    <AppButton variant="outline" text="Connect app">
+                    <AppButton
+                        variant="outline"
+                        text="Connect app"
+                        closeSignal={connectCloseSignal}
+                    >
                         <ConnectApplicationDialog
                             url={connectUrl}
                             token={connectToken}

--- a/web/src/longlink/Button.tsx
+++ b/web/src/longlink/Button.tsx
@@ -1,4 +1,9 @@
-import { useState, type ComponentProps, type ReactNode } from 'react';
+import {
+    useEffect,
+    useState,
+    type ComponentProps,
+    type ReactNode,
+} from 'react';
 import { useParams } from 'react-router';
 import { Button as UIButton } from '@/ui/button';
 import { Dialog } from '@/ui/dialog';
@@ -9,6 +14,7 @@ type ButtonProps = {
     variant?: ComponentProps<typeof UIButton>['variant'];
     url?: string;
     children?: ReactNode;
+    closeSignal?: number;
 };
 
 const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
@@ -18,11 +24,18 @@ export function Button({
     variant = 'default',
     url,
     children,
+    closeSignal,
 }: ButtonProps) {
     const [open, setOpen] = useState(false);
     const { app } = useParams();
     const hasDialog = Boolean(children);
     const normalizedUrl = normalizePath(url ?? '');
+
+    useEffect(() => {
+        if (hasDialog) {
+            setOpen(false);
+        }
+    }, [closeSignal, hasDialog]);
 
     const handleClick = async () => {
         if (hasDialog) {


### PR DESCRIPTION
### Motivation
- Ensure scheme-less app URLs are normalized correctly so `localhost:1707` becomes `http://localhost:1707` while public hosts default to `https://`, and make the Connect dialog close automatically after a successful connection. 

### Description
- Updated URL normalization in `api/src/utils/url.py` so scheme-less inputs default to `https://`, and added an exception for `localhost`, `127.0.0.1`, and `::1` to default to `http://` instead. 
- Added a `closeSignal` prop to the shared `AppButton` wrapper (`web/src/longlink/Button.tsx`) that listens for changes and programmatically closes any nested dialog. 
- Wired the connect flow in `web/src/components/settings/Applications.tsx` to increment `connectCloseSignal` after a successful `/apps` POST so the `ConnectApplicationDialog` closes automatically. 

### Testing
- Ran `bun run format` in `web` to format frontend files, which completed successfully. 
- Ran `python -m compileall src` in `api` to verify Python code compiles, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9e1a392c8323bd2c912c93d21876)