### PR TITLE
sdk: return only metadata payload from metadata endpoint

### DIFF
--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,22 +1,9 @@
 """Metadata route."""
 
 from longlink import get
-from longlink.envs import Envs, envs
 from longlink.metadata import metadata
-
-
-def _required_envs() -> list[str]:
-    return [
-        field_name.upper()
-        for field_name, field in Envs.model_fields.items()
-        if field.is_required()
-    ]
 
 
 @get('/metadata.json')
 async def get_metadata_information() -> dict:
-    return {
-        **metadata.model_dump(),
-        'runtime': 'python-sdk',
-        'required_envs': _required_envs(),
-    }
+    return metadata.model_dump()


### PR DESCRIPTION
### Motivation
- The `/metadata.json` route should expose only the SDK metadata payload and not include runtime or environment helper data, so consumers receive the plain metadata object.

### Description
- Removed the `Envs`/`envs` import and the `_required_envs` helper and changed the `/metadata.json` handler to return `metadata.model_dump()` directly.

### Testing
- Compiled the modified module with `python -m compileall sdk/longlink/routes/metadata.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cadc90b1848323b02022c42f3223bc)