### PR TITLE
sdk: switch global app to official Starlette instance

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,42 +1,51 @@
-from .ui import Page
-from .app import LongLink
-from .router import Router
+from .app import create_app
+from .cron import Cron
 from .organization import OrganizationSettings, organization
+from .router import Router
+from .ui import Page
 from longlink.ui.select import Select
 from longlink.ui.textarea import Textarea
 
-# Global SDK-managed application instance.
-app = LongLink()
+# Global SDK-managed routing and scheduling registries.
+router = Router()
+cron_manager = Cron()
+
+# Official Starlette application instance.
+app = create_app(router)
 
 
-# Route helpers managed by the SDK global app.
+# Route helpers managed by the SDK global router.
 def get(path: str):
-    return app.get(path)
+    return router.get(path)
 
 
 def post(path: str):
-    return app.post(path)
+    return router.post(path)
 
 
 def put(path: str):
-    return app.put(path)
+    return router.put(path)
 
 
 def patch(path: str):
-    return app.patch(path)
+    return router.patch(path)
 
 
 def delete(path: str):
-    return app.delete(path)
+    return router.delete(path)
 
 
 def page(path: str, name: str, icon: str):
-    return app.page(path, name=name, icon=icon)
+    return router.page(path, name=name, icon=icon)
+
+
+def pages() -> list[dict[str, str]]:
+    return router.pages()
 
 
 def cron(schedule: str):
-    return app.cron(schedule)
+    return cron_manager.cron(schedule)
 
 
-# Import internal routes for side-effect registration on the global app.
+# Import internal routes for side-effect registration on the global router.
 import longlink.routes  # noqa: E402,F401

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,118 +1,125 @@
-import json
 import inspect
+import json
 from typing import Any, get_type_hints
+
 from pydantic import BaseModel
-from longlink.cron import Cron
-from longlink.router import Router
-from starlette.routing import Route
-from starlette.requests import Request
-from starlette.responses import Response, JSONResponse, PlainTextResponse
 from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.routing import Route
+
+from longlink.router import Router
 
 
-class LongLink(Router, Cron):
-    def __init__(self) -> None:
-        super().__init__()
-        self._starlette = Starlette(
-            routes=[Route("/{full_path:path}", self._dispatch, methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"])]
-        )
+def create_app(router: Router) -> Starlette:
+    async def endpoint(request: Request) -> Response:
+        return await dispatch_request(request, router)
 
-    async def __call__(self, scope, receive, send):
-        await self._starlette(scope, receive, send)
-
-    async def _dispatch(self, request: Request) -> Response:
-        method = request.method
-        path = request.url.path
-        query_string = request.url.query
-
-        handler, params = self.match(method, path, query_string=query_string)
-
-        if not handler:
-            return PlainTextResponse("Not Found", status_code=404)
-
-        body_payload = await self._read_json_body(request)
-        call_params = self._merge_body_params(handler, params, body_payload)
-
-        if call_params:
-            body = await handler(**call_params)
-        else:
-            body = await handler()
-
-        is_page_handler = any(route.handler is handler for route in self._pages)
-
-        return_type = get_type_hints(handler).get('return')
-        if is_page_handler:
-            from longlink.ui import Page
-
-            if return_type is not Page or not isinstance(body, Page):
-                return PlainTextResponse(
-                    "Invalid response type. Page routes must return longlink.ui.Page.",
-                    status_code=500,
-                )
-
-            return JSONResponse(list(body))
-        elif return_type and isinstance(return_type, type) and issubclass(return_type, BaseModel):
-            if not isinstance(body, return_type):
-                return PlainTextResponse(
-                    f"Invalid response type. Expected {return_type.__name__}.",
-                    status_code=500,
-                )
-
-            if hasattr(body, 'model_dump_json'):
-                response_body = body.model_dump_json()
-            else:
-                response_body = body.json()
-            return Response(content=response_body, media_type="application/json")
-        else:
-            if isinstance(body, dict):
-                return JSONResponse(body)
-
-            if isinstance(body, bytes):
-                return Response(content=body, media_type="text/plain")
-
-            return PlainTextResponse(str(body))
-
-    async def _read_json_body(self, request: Request) -> dict[str, Any] | None:
-        method = request.method.upper()
-        if method in {'GET', 'HEAD', 'OPTIONS'}:
-            return None
-
-        body = await request.body()
-        if body == b'':
-            return None
-
-        try:
-            payload = json.loads(body)
-        except json.JSONDecodeError:
-            return None
-
-        if not isinstance(payload, dict):
-            return None
-
-        return payload
-
-    def _merge_body_params(self, handler, params: dict[str, Any], payload: dict[str, Any] | None) -> dict[str, Any]:
-        if payload is None:
-            return params
-
-        merged_params = dict(params)
-        signature = inspect.signature(handler)
-        annotations = get_type_hints(handler)
-
-        missing_parameters = [
-            name for name in signature.parameters
-            if name not in merged_params
+    return Starlette(
+        routes=[
+            Route(
+                "/{full_path:path}",
+                endpoint,
+                methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+            )
         ]
+    )
 
-        if len(missing_parameters) == 1:
-            candidate = missing_parameters[0]
-            annotation = annotations.get(candidate)
-            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-                merged_params[candidate] = annotation.model_validate(payload)
-                return merged_params
 
-        for key, value in payload.items():
-            if key in signature.parameters and key not in merged_params:
-                merged_params[key] = value
+async def dispatch_request(request: Request, router: Router) -> Response:
+    method = request.method
+    path = request.url.path
+    query_string = request.url.query
 
-        return merged_params
+    handler, params = router.match(method, path, query_string=query_string)
+
+    if not handler:
+        return PlainTextResponse("Not Found", status_code=404)
+
+    body_payload = await read_json_body(request)
+    call_params = merge_body_params(handler, params, body_payload)
+
+    if call_params:
+        body = await handler(**call_params)
+    else:
+        body = await handler()
+
+    is_page_handler = any(route.handler is handler for route in router._pages)
+
+    return_type = get_type_hints(handler).get("return")
+    if is_page_handler:
+        from longlink.ui import Page
+
+        if return_type is not Page or not isinstance(body, Page):
+            return PlainTextResponse(
+                "Invalid response type. Page routes must return longlink.ui.Page.",
+                status_code=500,
+            )
+
+        return JSONResponse(list(body))
+
+    if return_type and isinstance(return_type, type) and issubclass(return_type, BaseModel):
+        if not isinstance(body, return_type):
+            return PlainTextResponse(
+                f"Invalid response type. Expected {return_type.__name__}.",
+                status_code=500,
+            )
+
+        if hasattr(body, "model_dump_json"):
+            response_body = body.model_dump_json()
+        else:
+            response_body = body.json()
+
+        return Response(content=response_body, media_type="application/json")
+
+    if isinstance(body, dict):
+        return JSONResponse(body)
+
+    if isinstance(body, bytes):
+        return Response(content=body, media_type="text/plain")
+
+    return PlainTextResponse(str(body))
+
+
+async def read_json_body(request: Request) -> dict[str, Any] | None:
+    method = request.method.upper()
+    if method in {"GET", "HEAD", "OPTIONS"}:
+        return None
+
+    body = await request.body()
+    if body == b"":
+        return None
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    return payload
+
+
+def merge_body_params(handler, params: dict[str, Any], payload: dict[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return params
+
+    merged_params = dict(params)
+    signature = inspect.signature(handler)
+    annotations = get_type_hints(handler)
+
+    missing_parameters = [name for name in signature.parameters if name not in merged_params]
+
+    if len(missing_parameters) == 1:
+        candidate = missing_parameters[0]
+        annotation = annotations.get(candidate)
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            merged_params[candidate] = annotation.model_validate(payload)
+            return merged_params
+
+    for key, value in payload.items():
+        if key in signature.parameters and key not in merged_params:
+            merged_params[key] = value
+
+    return merged_params

--- a/sdk/longlink/routes/pages.py
+++ b/sdk/longlink/routes/pages.py
@@ -1,8 +1,8 @@
 """Pages route."""
 
-from longlink import app, get
+from longlink import get, pages
 
 
 @get('/pages')
 async def get_available_pages() -> list[dict[str, str]]:
-    return app.pages()
+    return pages()


### PR DESCRIPTION
### Motivation
- Replace the SDK-specific `LongLink` application wrapper with the official Starlette application to align with standard ASGI usage and simplify SDK app wiring.
- Keep the existing route and cron helper surface so existing SDK code continues to register routes and pages without changing callsites.

### Description
- Introduced `create_app(router: Router) -> Starlette` and moved dispatch, body-parsing, and parameter-merge logic into `sdk/longlink/app.py` as standalone functions used by the Starlette route.
- Replaced the SDK global `LongLink()` instance with separate registries `router = Router()` and `cron_manager = Cron()` and created the official Starlette application with `app = create_app(router)` in `sdk/longlink/__init__.py`.
- Updated helper APIs (`get`, `post`, `put`, `patch`, `delete`, `page`, `cron`) to operate on the global `router`/`cron_manager` and added a `pages()` helper that returns `router.pages()`.
- Adjusted the pages route to call the new `pages()` helper instead of `app.pages()` in `sdk/longlink/routes/pages.py`.

### Testing
- Ran `python -m compileall sdk/longlink` which completed successfully and compiled the package modules.
- The compilation emitted an existing `SyntaxWarning` from `sdk/longlink/ui/__init__.py` but there were no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae16294f48323bac6079ffb7c8631)