### PR TITLE
Replace Router class with module-level registries and simplify app initialization

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,46 +1,16 @@
 from .app import create_app
 from .cron import Cron
 from .organization import OrganizationSettings, organization
-from .router import Router
+from .router import delete, get, page, pages, patch, post, put, route
 from .ui import Page
 from longlink.ui.select import Select
 from longlink.ui.textarea import Textarea
 
-# Global SDK-managed routing and scheduling registries.
-router = Router()
+# Global SDK-managed scheduling registry.
 cron_manager = Cron()
 
 # Official Starlette application instance.
-app = create_app(router)
-
-
-# Route helpers managed by the SDK global router.
-def get(path: str):
-    return router.get(path)
-
-
-def post(path: str):
-    return router.post(path)
-
-
-def put(path: str):
-    return router.put(path)
-
-
-def patch(path: str):
-    return router.patch(path)
-
-
-def delete(path: str):
-    return router.delete(path)
-
-
-def page(path: str, name: str, icon: str):
-    return router.page(path, name=name, icon=icon)
-
-
-def pages() -> list[dict[str, str]]:
-    return router.pages()
+app = create_app()
 
 
 def cron(schedule: str):

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -8,12 +8,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Route
 
-from longlink.router import Router
+import longlink.router as router
 
 
-def create_app(router: Router) -> Starlette:
+def create_app() -> Starlette:
     async def endpoint(request: Request) -> Response:
-        return await dispatch_request(request, router)
+        return await dispatch_request(request)
 
     return Starlette(
         routes=[
@@ -26,7 +26,7 @@ def create_app(router: Router) -> Starlette:
     )
 
 
-async def dispatch_request(request: Request, router: Router) -> Response:
+async def dispatch_request(request: Request) -> Response:
     method = request.method
     path = request.url.path
     query_string = request.url.query
@@ -44,7 +44,7 @@ async def dispatch_request(request: Request, router: Router) -> Response:
     else:
         body = await handler()
 
-    is_page_handler = any(route.handler is handler for route in router._pages)
+    is_page_handler = router.is_page_handler(handler)
 
     return_type = get_type_hints(handler).get("return")
     if is_page_handler:

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -1,89 +1,67 @@
 import inspect
-from typing import Any, Callable, Awaitable
-from .route import Route, PageRoute
-from longlink.ui import Page
+from typing import Any, Awaitable, Callable
+
+from .route import PageRoute, Route
 
 Handler = Callable[..., Awaitable[Any]]
 
-
-class Router:
-    def __init__(self) -> None:
-        self._routes: list[Route] = []
-        self._pages: list[PageRoute] = []
-
-    def register(self, router: "Router") -> None:
-        self._routes.extend(router._routes)
-        self._pages.extend(router._pages)
-
-    def _route(self, method: str, path: str):
-        def decorator(func: Handler) -> Handler:
-            self._routes.append(Route(method.upper(), path, func))
-            return func
-        return decorator
-
-    def page(self, path: str, name: str, icon: str):
-        def decorator(func: Handler) -> Handler:
-            self._pages.append(PageRoute(path, func, name=name, icon=icon))
-            self._routes.append(self._pages[-1])
-            return func
-        return decorator
-
-    def pages(self) -> list[dict[str, str]]:
-        return [{"path": page.template, "name": page.name, "icon": page.icon} for page in self._pages]
-
-    def match(self, method: str, path: str, query_string: str = "") -> tuple[Handler | None, dict[str, Any]]:
-        full_path = path
-        if query_string:
-            separator = "&" if "?" in path else "?"
-            full_path = f"{path}{separator}{query_string}"
-
-        for route in self._routes:
-            if route.method != method.upper():
-                continue
-
-            params = route.match(full_path)
-            if params is None:
-                continue
-
-            sig = inspect.signature(route.handler)
-            filtered = {name: value for name, value in params.items() if name in sig.parameters}
-            bound = sig.bind_partial(**filtered)
-            bound.apply_defaults()
-            return route.handler, bound.arguments
-
-        return None, {}
-
-    def _match(self, method: str, path: str, query_string: str = "") -> Handler | None:
-        handler, params = self.match(method, path, query_string=query_string)
-        if handler is None:
-            return None
-
-        async def wrapper(*_):
-            return await handler(**params)
-
-        wrapper.__name__ = handler.__name__
-        return wrapper
-
-    def get(self, path: str): return self._route("GET", path)
-    def post(self, path: str): return self._route("POST", path)
-    def put(self, path: str): return self._route("PUT", path)
-    def patch(self, path: str): return self._route("PATCH", path)
-    def delete(self, path: str): return self._route("DELETE", path)
+_routes: list[Route] = []
+_pages: list[PageRoute] = []
 
 
-if __name__ == "__main__":
-    router = Router()
+def route(path: str, methods: list[str] | None = None):
+    normalized_methods = methods or ["GET"]
 
-    @router.get("/users/{user_id}/posts?{filter}&sort={sort_order}")
-    async def get_user_posts(user_id: str, filter: str = "", sort_order: str = "asc"):
-        return {"user_id": user_id, "filter": filter, "sort": sort_order}
+    def decorator(func: Handler) -> Handler:
+        for method in normalized_methods:
+            _routes.append(Route(method.upper(), path, func))
+        return func
 
-    @router.page("/settings", name="Settings", icon="settings")
-    async def settings_page() -> Page:
-        return Page()
+    return decorator
 
-    fn, params = router.match("GET", "/users/admin/posts", query_string="filter=any&sort=desc")
-    assert fn is not None, "Handler not found for registered route"
-    assert fn.__name__ == "get_user_posts", "Handler function name does not match expected"
-    assert params == {"user_id": "admin", "filter": "any", "sort_order": "desc"}
-    assert router.pages() == [{"path": "/settings", "name": "Settings", "icon": "settings"}]
+
+def page(path: str, name: str, icon: str):
+    def decorator(func: Handler) -> Handler:
+        _pages.append(PageRoute(path, func, name=name, icon=icon))
+        _routes.append(_pages[-1])
+        return func
+
+    return decorator
+
+
+def pages() -> list[dict[str, str]]:
+    return [{"path": page.template, "name": page.name, "icon": page.icon} for page in _pages]
+
+
+def match(method: str, path: str, query_string: str = "") -> tuple[Handler | None, dict[str, Any]]:
+    full_path = path
+    if query_string:
+        separator = "&" if "?" in path else "?"
+        full_path = f"{path}{separator}{query_string}"
+
+    for registered_route in _routes:
+        if registered_route.method != method.upper():
+            continue
+
+        params = registered_route.match(full_path)
+        if params is None:
+            continue
+
+        sig = inspect.signature(registered_route.handler)
+        filtered = {name: value for name, value in params.items() if name in sig.parameters}
+        bound = sig.bind_partial(**filtered)
+        bound.apply_defaults()
+        return registered_route.handler, bound.arguments
+
+    return None, {}
+
+
+def is_page_handler(handler: Handler) -> bool:
+    return any(route.handler is handler for route in _pages)
+
+
+def get(path: str): return route(path, ["GET"])
+def post(path: str): return route(path, ["POST"])
+def put(path: str): return route(path, ["PUT"])
+def patch(path: str): return route(path, ["PATCH"])
+def delete(path: str): return route(path, ["DELETE"])


### PR DESCRIPTION
### Motivation
- Simplify routing by moving from an SDK-managed `Router` instance to module-level registries so routes can be registered via simple decorators. 
- Decouple application creation from an injected router instance to reduce boilerplate when creating the official `app` and enable a single global routing surface. 
- Preserve page route metadata and cron scheduling while exposing route decorators directly from the SDK surface. 

### Description
- Removed the `Router` class and its instance-managed state and replaced it with module-level lists `_routes` and `_pages` and functional APIs `route`, `page`, `match`, `pages`, and `is_page_handler` in `sdk/longlink/router/__init__.py`.
- Added convenience helpers `get`, `post`, `put`, `patch`, and `delete` that wrap `route` with common HTTP methods.
- Updated `create_app` in `sdk/longlink/app.py` to no longer accept a router argument, to import the router module directly, and to call `router.match` and `router.is_page_handler` from the module-level API.
- Updated `sdk/longlink/__init__.py` to export the route decorators from the `router` module, initialize the `cron_manager`, and instantiate the official `app` via the simplified `create_app()` signature; removed the previous SDK-local wrapper functions around routes.

### Testing
- Ran the test suite with `pytest -q`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae55aed448323be4dcbc809df1bb3)