### PR TITLE
Refactor proxy handler to use apps client, limit methods, and return pages metadata

### DIFF
--- a/api/src/routes/proxies.py
+++ b/api/src/routes/proxies.py
@@ -1,9 +1,11 @@
 import httpx
 import src.db as db
 from fastapi import Request, Response, HTTPException
+from src.utils import apps
 from src.router import router
+from fastapi.responses import JSONResponse
 
-ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+ALLOWED_METHODS = ['GET', 'POST']
 
 
 async def proxy_request(req: Request, app_name: str, full_path: str = '') -> Response:
@@ -11,22 +13,43 @@ async def proxy_request(req: Request, app_name: str, full_path: str = '') -> Res
     if not app:
         raise HTTPException(status_code=404, detail=f"App '{app_name}' not found")
 
-    # Build target URL
     path = full_path.lstrip('/')
-    target_url = app.url.rstrip('/')
-    if path:
-        target_url = f"{target_url}/{path}"
+    is_metadata_request = req.method == 'GET' and path == ''
+
+    if is_metadata_request:
+        path = 'pages'
+
+    query_params = dict(req.query_params)
+    query_params.setdefault('key', app.key)
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            upstream = await client.request(
-                method=req.method,
-                url=target_url,
-                params=req.query_params,
-                content=await req.body() if req.method in ['POST', 'PUT', 'PATCH'] else None,
-            )
+        method = req.method.upper()
+        if method == 'GET':
+            upstream = await apps.get(app.id, path, params=query_params)
+        elif method == 'POST':
+            json_payload = await req.json() if req.headers.get('content-type', '').startswith('application/json') else None
+            upstream = await apps.post(app.id, path, params=query_params, json=json_payload)
+        else:
+            raise HTTPException(status_code=405, detail=f"Method '{method}' is not allowed")
 
-        return Response(content=upstream.content, status_code=upstream.status_code )
+        if is_metadata_request:
+            if not upstream.is_success:
+                raise HTTPException(
+                    status_code=upstream.status_code,
+                    detail='Unable to fetch pages from the app',
+                )
+
+            try:
+                pages = upstream.json()
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail='Invalid pages response from app',
+                ) from exc
+
+            return JSONResponse(content={'pages': pages}, status_code=200)
+
+        return Response(content=upstream.content, status_code=upstream.status_code)
 
     except httpx.RequestError:
         raise HTTPException(status_code=502, detail="Upstream request failed")


### PR DESCRIPTION
### Motivation

- Centralize upstream app HTTP interactions through the `apps` helper instead of direct `httpx` calls to simplify logic and reuse common behavior.
- Restrict the proxy to only supported methods (`GET` and `POST`) and explicitly reject others.
- Provide a structured pages metadata response for a root `GET` on an app so callers get `{pages: [...]}` instead of raw upstream content.

### Description

- Imported `apps` from `src.utils` and `JSONResponse` to route upstream requests and return structured JSON for metadata responses.
- Reduced `ALLOWED_METHODS` to `['GET', 'POST']` and updated the router to use the same set of methods.
- Reworked `proxy_request` to detect a root `GET` as a metadata request, set `path` to `pages`, build `query_params` with a default `key` from `app.key`, and call `apps.get`/`apps.post` instead of using an `httpx.AsyncClient` directly.
- Added handling for JSON POST payloads based on `content-type`, explicit 405 responses for unsupported methods, parsing and validation of the pages response with a `JSONResponse` return, and preserved returning upstream content as a `Response`; kept upstream failures mapped to HTTP 502 and missing apps mapped to HTTP 404.

### Testing

- Ran unit tests with `pytest` which include proxy route tests and they completed successfully. 
- Ran API integration tests for proxy behavior (including root metadata GET and POST flows) and they passed. 
- No automated tests failed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae57cbd9c8323af5717b217f767a7)