### PR TITLE
Route app pages by UUID and fix app tab rendering

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,7 +37,7 @@ const router = createBrowserRouter([
             { path: 'people', element: <People /> },
             { path: 'settings', element: <SettingsPage /> },
             {
-                path: 'apps/:app/*',
+                path: ':appId/*',
                 element: <Longlink />,
             },
         ],

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -31,12 +31,12 @@ type NavigationProps = {
 };
 
 export default function Layout() {
-    const { app } = useParams();
-    const appMetadataEndpoint = app ? `/apps/${app}` : null;
+    const { appId } = useParams();
+    const appMetadataEndpoint = appId ? `/apps/${appId}` : null;
 
     const { data: appMetadata, isLoading: isAppMetadataLoading } =
         useApiData<AppMetadata>(appMetadataEndpoint);
-    const appTabs = app
+    const appTabs = appId
         ? isAppMetadataLoading
             ? [
                   {
@@ -51,19 +51,19 @@ export default function Layout() {
 
     const { tabs, basePathSuffix } = getTabsConfig({
         section: 'organization',
-        app,
+        appId,
         appTabs,
     });
 
     const showEmptyAppSection = Boolean(
-        app && !isAppMetadataLoading && tabs.length === 0
+        appId && !isAppMetadataLoading && tabs.length === 0
     );
 
     return (
         <Navigation
             tabs={tabs}
             basePathSuffix={basePathSuffix}
-            isTabsLoading={Boolean(app && isAppMetadataLoading)}
+            isTabsLoading={Boolean(appId && isAppMetadataLoading)}
             showEmptyAppSection={showEmptyAppSection}
         />
     );
@@ -75,12 +75,12 @@ export function Navigation({
     isTabsLoading,
     showEmptyAppSection,
 }: NavigationProps) {
-    const { app } = useParams();
+    const { appId } = useParams();
     const location = useLocation();
     const navigate = useNavigate();
 
     const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
-    const basePath = app
+    const basePath = appId
         ? normalizedSuffix
             ? `/${normalizedSuffix}`
             : '/'

--- a/web/src/components/breadcrumb.tsx
+++ b/web/src/components/breadcrumb.tsx
@@ -16,12 +16,17 @@ type SettingResponse = {
 };
 
 export function Breadcrumb() {
-    const { app } = useParams();
+    const { appId } = useParams();
     const location = useLocation();
     const { data: organizationNameData } =
         useApiData<SettingResponse>('/settings/ORG_NAME');
+    const { data: appMetadata } = useApiData<{ name?: string }>(
+        appId ? `/apps/${appId}` : null
+    );
 
-    const appName = app ? formatAppName(app) : undefined;
+    const appName = appId
+        ? appMetadata?.name?.trim() || formatAppName(appId)
+        : undefined;
     const isProfileView = location.pathname.startsWith('/profile');
     const organizationName =
         organizationNameData?.value.trim() || 'Organization';
@@ -42,7 +47,7 @@ export function Breadcrumb() {
                         )}
                     />
                 </BreadcrumbItem>
-                {appName ? (
+                {appName && appId ? (
                     <>
                         <BreadcrumbSeparator />
                         <BreadcrumbItem>
@@ -50,7 +55,7 @@ export function Breadcrumb() {
                                 render={(props) => (
                                     <Link
                                         {...props}
-                                        to={`/apps/${app}`}
+                                        to={`/${appId}`}
                                         className="text-sm font-semibold text-white/70"
                                     >
                                         {appName}

--- a/web/src/lib/navigation.ts
+++ b/web/src/lib/navigation.ts
@@ -75,15 +75,15 @@ export type TabsConfig = {
 
 export function getTabsConfig({
     section: _section,
-    app,
+    appId,
     appTabs,
 }: {
     section: 'account' | 'organization';
-    app?: string;
+    appId?: string;
     appTabs?: NavigationTab[];
 }): TabsConfig {
-    const tabs = app ? (appTabs ?? []) : organizationTabs;
-    const basePathSuffix = app ? `apps/${app}` : undefined;
+    const tabs = appId ? (appTabs ?? []) : organizationTabs;
+    const basePathSuffix = appId;
 
     return { tabs, basePathSuffix };
 }

--- a/web/src/longlink/Button.tsx
+++ b/web/src/longlink/Button.tsx
@@ -27,7 +27,7 @@ export function Button({
     closeSignal,
 }: ButtonProps) {
     const [open, setOpen] = useState(false);
-    const { app } = useParams();
+    const { appId } = useParams();
     const hasDialog = Boolean(children);
     const normalizedUrl = normalizePath(url ?? '');
 
@@ -42,11 +42,11 @@ export function Button({
             setOpen(true);
         }
 
-        if (!app || !normalizedUrl) {
+        if (!appId || !normalizedUrl) {
             return;
         }
 
-        await apiFetch(`/apps/${app}/${normalizedUrl}`, {
+        await apiFetch(`/apps/${appId}/${normalizedUrl}`, {
             method: 'POST',
         });
     };

--- a/web/src/longlink/Input.tsx
+++ b/web/src/longlink/Input.tsx
@@ -65,7 +65,7 @@ export function Input({
     disabled,
     submit,
 }: InputProps) {
-    const { app } = useParams();
+    const { appId } = useParams();
     const defaultFieldValue = useMemo(() => {
         if (typeof value === 'string' || typeof value === 'number') {
             return String(value);
@@ -88,8 +88,8 @@ export function Input({
     const submitPath = submit?.startsWith('/')
         ? submit
         : normalizedSubmitPath
-          ? app
-              ? `/apps/${app}/${normalizedSubmitPath}`
+          ? appId
+              ? `/${appId}/${normalizedSubmitPath}`
               : `/${normalizedSubmitPath}`
           : '';
 

--- a/web/src/pages/org/Longlink.tsx
+++ b/web/src/pages/org/Longlink.tsx
@@ -11,12 +11,12 @@ type AppMetadata = {
 const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
 
 export default function Longlink() {
-    const { app, '*': wildcardPath } = useParams();
+    const { appId, '*': wildcardPath } = useParams();
     const normalizedRoutePath = normalizePath(wildcardPath ?? '');
 
     const { data: appMetadata, isLoading: isAppMetadataLoading } =
         useApiData<AppMetadata>(
-            app && normalizedRoutePath.length === 0 ? `/apps/${app}` : null
+            appId && normalizedRoutePath.length === 0 ? `/apps/${appId}` : null
         );
 
     const fallbackPagePath = useMemo(() => {
@@ -28,9 +28,9 @@ export default function Longlink() {
     }, [appMetadata?.pages]);
 
     const activePagePath = normalizedRoutePath || fallbackPagePath;
-    const pageEndpoint = app
+    const pageEndpoint = appId
         ? activePagePath.length > 0
-            ? `/apps/${app}/${activePagePath}`
+            ? `/apps/${appId}/${activePagePath}`
             : null
         : null;
 
@@ -41,7 +41,7 @@ export default function Longlink() {
         : [];
 
     if (error) {
-        return <div>{error}</div>;
+        return <div>{error.message}</div>;
     }
 
     if (isAppMetadataLoading || isLoading) {

--- a/web/src/pages/org/Processes.tsx
+++ b/web/src/pages/org/Processes.tsx
@@ -20,7 +20,7 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
                 label: 'Name',
                 content: {
                     value: '{name}',
-                    link: '/apps/{name}',
+                    link: '/{id}',
                 },
             },
             {

--- a/web/src/pages/org/Spaces.tsx
+++ b/web/src/pages/org/Spaces.tsx
@@ -20,7 +20,7 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
                 label: 'Name',
                 content: {
                     value: '{name}',
-                    link: '/apps/{name}',
+                    link: '/{id}',
                 },
             },
             {

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -20,7 +20,7 @@ const tableSchema: { title: string; schema: { columns: ApiTableColumn[] } } = {
                 label: 'Name',
                 content: {
                     value: '{name}',
-                    link: '/apps/{name}',
+                    link: '/{id}',
                 },
             },
             {


### PR DESCRIPTION
### Motivation
- The app pages were fetched by the API but not appearing in the UI because routes and navigation were using a name-based path (`/apps/:app/*`) which did not match the intended UUID-based URLs.

### Description
- Change top-level route from `'/apps/:app/*'` to `':appId/*'` so app pages are addressed as `http://localhost:5173/<uuid>` and switch all route param reads from `app` to `appId` (e.g. `src/App.tsx`, `src/Layout.tsx`, `src/pages/org/Longlink.tsx`).
- Make tab/navigation logic use `appId` and compute tab base paths from the UUID route root by updating `getTabsConfig` to accept `appId` and using it as `basePathSuffix` (`src/lib/navigation.ts`).
- Update breadcrumb to link to `/${appId}` and resolve display name from `/apps/{appId}` metadata when available (`src/components/breadcrumb.tsx`).
- Fix Longlink page loading and page endpoint construction to consistently fetch metadata and page content under `/apps/{appId}` while using the new route param (`src/pages/org/Longlink.tsx`).
- Update list/table links for Tools/Spaces/Processes to point to `/{id}` instead of `/apps/{name}` so items navigate by UUID (`src/pages/org/Tools.tsx`, `src/pages/org/Spaces.tsx`, `src/pages/org/Processes.tsx`).
- Update in-app action components to use `appId` for client-side submit paths and API calls (`src/longlink/Input.tsx`, `src/longlink/Button.tsx`).

### Testing
- Ran formatter: `bun run format` which completed successfully.
- Attempted build: `bun run build` which fails due to pre-existing unrelated TypeScript issues in `src/ui/resizable.tsx`, `src/ui/scroll-area.tsx`, and `src/ui/sidebar.tsx`, so the routing changes themselves did not block formatting but the full build currently fails.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caebe81c6c83239f2ad09a014b7af2)