### PR TITLE
Add `longlink migrate` CLI command to SDK

### DIFF
--- a/sdk/longlink/cli/main.py
+++ b/sdk/longlink/cli/main.py
@@ -1,7 +1,8 @@
 import click
+from longlink.cli.build import build_command
 from longlink.cli.dev import dev_command
 from longlink.cli.init import init_command
-from longlink.cli.build import build_command
+from longlink.cli.migrate import migrate_command
 
 
 @click.group()
@@ -12,3 +13,4 @@ def main():
 main.add_command(dev_command)
 main.add_command(init_command)
 main.add_command(build_command)
+main.add_command(migrate_command)

--- a/sdk/longlink/cli/migrate.py
+++ b/sdk/longlink/cli/migrate.py
@@ -1,0 +1,11 @@
+import click
+
+from longlink.database.migrations import make_migrations, migrate
+
+
+@click.command(name="migrate")
+def migrate_command():
+    """Generate and apply database migrations for the current app."""
+    make_migrations()
+    migrate()
+    click.echo("Migrations generated and applied successfully.")


### PR DESCRIPTION
### Motivation
- Provide a simple CLI entrypoint so SDK users can generate and apply Alembic migrations from the project root via `longlink migrate` and ensure the SDK-managed `Base` metadata is used for migrations.

### Description
- Added `sdk/longlink/cli/migrate.py` which defines a Click `migrate` command that calls `make_migrations()` and `migrate()` from `longlink.database.migrations`, and registered the command in `sdk/longlink/cli/main.py` so it is available as a top-level command.

### Testing
- Ran `cd sdk && python -m longlink --help` and confirmed the `migrate` command is listed in the CLI commands (test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caec9c1e988323b98a77953c0005bd)