### PR TITLE
Add development Docker Compose configurations

### DIFF
--- a/dev/docker-compose.minio.yml
+++ b/dev/docker-compose.minio.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadminpassword
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web console
+
+volumes:
+  minio_data:

--- a/dev/docker-compose.podman.yml
+++ b/dev/docker-compose.podman.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+
+services:
+  podman:
+    image: quay.io/podman/stable:latest
+    container_name: podman
+    privileged: true
+    restart: unless-stopped
+    command: >
+      sh -c "podman system service --time=0 tcp:0.0.0.0:8080"
+    volumes:
+      - podman_data:/var/lib/containers
+    ports:
+      - "8080:8080"   # Podman API
+
+volumes:
+  podman_data:

--- a/dev/docker-compose.postgres.yml
+++ b/dev/docker-compose.postgres.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: superuser
+      POSTGRES_PASSWORD: superpassword
+      POSTGRES_DB: appdb
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  postgres_data:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: superuser
+      POSTGRES_PASSWORD: superpassword
+      POSTGRES_DB: appdb
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadminpassword
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web console
+
+  podman:
+    image: quay.io/podman/stable:latest
+    container_name: podman
+    privileged: true
+    restart: unless-stopped
+    command: >
+      sh -c "podman system service --time=0 tcp:0.0.0.0:8080"
+    volumes:
+      - podman_data:/var/lib/containers
+    ports:
+      - "8080:8080"   # Podman API
+
+volumes:
+  postgres_data:
+  minio_data:
+  podman_data:


### PR DESCRIPTION
### Motivation
- Provide a simple local development environment with Postgres, MinIO, and Podman services to match the requested dev setup. 
- Allow flexible startup of individual services by providing both a combined compose file and service-specific compose files. 

### Description
- Added a new `dev/` folder containing a combined Compose file `dev/docker-compose.yml` with `postgres`, `minio`, and `podman` services and shared volumes. 
- Added service-specific Compose files `dev/docker-compose.postgres.yml`, `dev/docker-compose.minio.yml`, and `dev/docker-compose.podman.yml` for starting services independently. 
- All files use Compose version `3.9` and include the requested images, environment variables, exposed ports, volumes, and `podman` service command. 

### Testing
- Ran `docker compose -f dev/docker-compose.yml config` which failed due to the environment missing the `docker` CLI (test failed for environmental reasons). 
- Ran `git status --short` which succeeded and confirms the new `dev/` files are staged/committed in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caee8cd3c8832396912276e044a363)