### PR TITLE
Fix app proxy lookup for UUID-based routes

### DIFF
--- a/api/src/routes/proxies.py
+++ b/api/src/routes/proxies.py
@@ -9,7 +9,9 @@ ALLOWED_METHODS = ['GET', 'POST']
 
 
 async def proxy_request(req: Request, app_name: str, full_path: str = '') -> Response:
-    app = await db.apps.get_by_name(app_name)
+    app = await db.apps.get_by_uuid(app_name)
+    if not app:
+        app = await db.apps.get_by_name(app_name)
     if not app:
         raise HTTPException(status_code=404, detail=f"App '{app_name}' not found")
 


### PR DESCRIPTION
### Motivation
- Frontend app routes use app UUIDs at `/apps/{id}` so the proxy must resolve apps by UUID to fetch metadata/pages; resolving only by name caused metadata requests to fail and tabs to be empty.

### Description
- Update `api/src/routes/proxies.py` to call `db.apps.get_by_uuid(app_name)` first and fall back to `db.apps.get_by_name(app_name)` when not found, preserving name-based compatibility.

### Testing
- Ran `isort api/src/routes/proxies.py` and `python -m compileall -q api/src/routes/proxies.py`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc02667ec832394a9337c4ec57152)