### PR TITLE
Use environment URL for auth redirect targets

### DIFF
--- a/api/src/env.py
+++ b/api/src/env.py
@@ -14,6 +14,9 @@ class Env(BaseSettings):
     ENV_GITHUB_CLIENT_ID: str | None = None
     ENV_GITHUB_CLIENT_SECRET: str | None = None
 
+    # Web URL used for auth redirects
+    URL: str = 'http://localhost:5173'
+
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 
 
@@ -27,6 +30,9 @@ class DevEnv(Env):
     # OAuth credentials
     ENV_GITHUB_CLIENT_ID: str | None = None
     ENV_GITHUB_CLIENT_SECRET: str | None = None
+
+    # Web URL used for auth redirects
+    URL: str = 'http://localhost:5173'
 
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -7,8 +7,6 @@ from src.router import router
 from fastapi.responses import RedirectResponse
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
 
-URL = 'http://localhost:5173'
-
 
 @router.get('/login')
 async def login_methods() -> list[str]:
@@ -66,7 +64,7 @@ async def auth_github(request: Request):
     )
 
     request.session['userid'] = user.id
-    return RedirectResponse(URL)
+    return RedirectResponse(env.URL)
 
 
 @router.get('/login/localhost')
@@ -95,7 +93,7 @@ async def login_localhost(request: Request):
             user = updated_user
 
     request.session['userid'] = user.id
-    return RedirectResponse(URL)
+    return RedirectResponse(env.URL)
 
 
 @router.get('/logout')


### PR DESCRIPTION
### Motivation
- Make post-auth redirect targets configurable through environment settings instead of a hardcoded frontend URL.
- Support different deployment environments (dev/staging/prod) by allowing the frontend URL to come from env configuration.

### Description
- Added a new `URL` setting to the API environment model in `api/src/env.py` with a default of `http://localhost:5173` for both `Env` and `DevEnv`.
- Updated auth routes in `api/src/routes/auth.py` to return `RedirectResponse(env.URL)` after successful login instead of using a hardcoded `URL` constant.
- Kept existing behavior for available auth methods and local development checks unchanged.

### Testing
- Ran import/formatting checks with `cd api && isort src/env.py src/routes/auth.py` which completed successfully.
- Verified backend modules compile by running `cd api && python -m compileall src`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc0bf54e08323ba429e1c26a357e6)