### PR TITLE
Add per-app user permissions table and PermissionsService

### DIFF
--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,11 +1,12 @@
-from .models import App, Env, User, Setting, Storage, Database
+from .models import App, Env, User, Setting, Storage, Database, Permission
 from .services import (AppsService, EnvsService, UsersService, SettingsService,
-                       StoragesService, DatabasesService)
+                       StoragesService, DatabasesService, PermissionsService)
 
 apps = AppsService()
 databases = DatabasesService()
 envs = EnvsService()
 settings = SettingsService()
 users = UsersService()
+permissions = PermissionsService()
 
 storages = StoragesService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -6,3 +6,4 @@ from .__base__ import Base
 from .settings import Setting
 from .storages import Storage
 from .databases import Database
+from .permissions import Permission

--- a/api/src/db/models/permissions.py
+++ b/api/src/db/models/permissions.py
@@ -1,0 +1,22 @@
+import uuid
+from datetime import datetime
+from sqlalchemy import String, Integer, DateTime, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class Permission(Base):
+    '''Represent the access level granted to one user for one app.'''
+    __tablename__ = 'permissions'
+    __table_args__ = (
+        UniqueConstraint('user_id', 'app_id', name='uq_permissions_user_app'),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    app_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    level: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    # Timestamp informations
+    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -4,3 +4,4 @@ from .users import UsersService
 from .settings import SettingsService
 from .storages import StoragesService
 from .databases import DatabasesService
+from .permissions import PermissionsService

--- a/api/src/db/services/permissions.py
+++ b/api/src/db/services/permissions.py
@@ -1,0 +1,57 @@
+from sqlalchemy import select
+from src.db.models import Permission
+from src.db.session import get_session
+
+ALLOWED_PERMISSION_LEVELS = {'read', 'write', 'maintain', 'admin'}
+
+
+class PermissionsService:
+    async def list(self) -> list[Permission]:
+        '''Return all user/app permissions.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(Permission))
+            return list(result.scalars().all())
+
+    async def get(self, user_id: int, app_id: str) -> Permission | None:
+        '''Return the permission for one user/app pair.'''
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Permission).where(
+                Permission.user_id == user_id,
+                Permission.app_id == app_id,
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def set(self, user_id: int, app_id: str, level: str) -> Permission:
+        '''Create or update the permission for one user/app pair.'''
+
+        normalized_level = level.strip().lower()
+        if normalized_level not in ALLOWED_PERMISSION_LEVELS:
+            raise ValueError(f'Invalid permission level: {level}')
+
+        Session = await get_session()
+        async with Session() as session:
+            statement = select(Permission).where(
+                Permission.user_id == user_id,
+                Permission.app_id == app_id,
+            )
+            result = await session.execute(statement)
+            permission = result.scalar_one_or_none()
+
+            if permission is None:
+                permission = Permission(
+                    user_id=user_id,
+                    app_id=app_id,
+                    level=normalized_level,
+                )
+                session.add(permission)
+            else:
+                permission.level = normalized_level
+
+            await session.commit()
+            await session.refresh(permission)
+            return permission


### PR DESCRIPTION
### Motivation
- Introduce a persistent way to record which user has which permission for each app using a dedicated table. 
- Support the four required permission levels: `read`, `write`, `maintain`, and `admin`.

### Description
- Add a new ORM model `Permission` in `api/src/db/models/permissions.py` with a UUID primary key, `user_id`, `app_id`, `level`, a unique constraint on `(user_id, app_id)`, and creation/update timestamps. 
- Add `PermissionsService` in `api/src/db/services/permissions.py` providing `list()`, `get(user_id, app_id)`, and `set(user_id, app_id, level)` methods with validation against allowed levels. 
- Export the new model and service via `src/db/models/__init__.py`, `src/db/services/__init__.py`, and `src/db/__init__.py` so callers can access `db.permissions`.

### Testing
- Ran `cd api && isort .` which completed successfully. 
- Ran `cd api && python -m compileall src` which completed successfully and verified modules compile. 
- Ran `cd api && pytest -q` which failed during test collection due to an existing repository issue (`ModuleNotFoundError: No module named 'src.hello'` in `tests/test_hello.py`), the failure is unrelated to the permission model changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc1250dec832398e31f5ea7421338)