### PR TITLE
Add Docker and Podman compute adapters

### DIFF
--- a/api/src/compute/__init__.py
+++ b/api/src/compute/__init__.py
@@ -1,10 +1,12 @@
 """
-This folder contains the compute provider adapters
+Compute provider adapters for control-plane integrations.
 
-Podman
-Docker
-
-Google Cloud Run
-AWS Fargate
-Azure Container Apps
+- Docker
+- Podman
 """
+
+from src.compute.docker import Docker
+from src.compute.podman import Podman
+from src.compute.__root__ import Compute
+
+__all__ = ['Compute', 'Docker', 'Podman']

--- a/api/src/compute/__root__.py
+++ b/api/src/compute/__root__.py
@@ -1,11 +1,14 @@
-
-
 class Compute:
-    def create(self, app_id: str) -> ComputeEnv:
-        pass
+    """Base class for compute management adapters."""
 
-    def deploy(self, app_id: str, image: str):
-        pass
+    def create(self, app_id: str) -> str:
+        raise NotImplementedError
 
-    def delete(self, app_id: str):
-        pass
+    def deploy(self, app_id: str, image: str) -> str:
+        raise NotImplementedError
+
+    def delete(self, app_id: str) -> None:
+        raise NotImplementedError
+
+    def credentials(self, app_id: str) -> dict[str, str | int]:
+        raise NotImplementedError

--- a/api/src/compute/docker.py
+++ b/api/src/compute/docker.py
@@ -1,0 +1,104 @@
+import re
+import httpx
+import hashlib
+from src.compute.__root__ import Compute
+
+
+class Docker(Compute):
+    def __init__(
+        self,
+        *,
+        host: str = 'localhost',
+        port: int = 2375,
+        use_tls: bool = False,
+        unix_socket: str | None = None,
+        network: str | None = None,
+    ):
+        self.host = host
+        self.port = port
+        self.use_tls = use_tls
+        self.unix_socket = unix_socket
+        self.network = network
+
+    @property
+    def control_plane_url(self) -> str:
+        if self.unix_socket:
+            return f'unix://{self.unix_socket}'
+
+        scheme = 'https' if self.use_tls else 'http'
+        return f'{scheme}://{self.host}:{self.port}'
+
+    def create(self, app_id: str) -> str:
+        return self._container_name(app_id)
+
+    def deploy(self, app_id: str, image: str) -> str:
+        container_name = self._container_name(app_id)
+
+        with self._client() as client:
+            self._delete_existing_container(client, container_name)
+
+            payload = {
+                'Image': image,
+                'Labels': {
+                    'longlink.app_id': app_id,
+                    'longlink.managed': 'true',
+                },
+            }
+            if self.network:
+                payload['HostConfig'] = {'NetworkMode': self.network}
+
+            response = client.post(
+                f'/containers/create?name={container_name}',
+                json=payload,
+            )
+            response.raise_for_status()
+            container_id = response.json()['Id']
+
+            start_response = client.post(f'/containers/{container_id}/start')
+            start_response.raise_for_status()
+
+        return container_id
+
+    def delete(self, app_id: str) -> None:
+        container_name = self._container_name(app_id)
+
+        with self._client() as client:
+            self._delete_existing_container(client, container_name)
+
+    def credentials(self, app_id: str) -> dict[str, str | int]:
+        return {
+            'type': 'docker',
+            'host': self.host,
+            'port': self.port,
+            'control_plane_url': self.control_plane_url,
+            'container_name': self._container_name(app_id),
+        }
+
+    def _container_name(self, app_id: str) -> str:
+        safe = re.sub(r'[^a-zA-Z0-9_.-]+', '-', app_id).strip('-').lower()
+        if not safe:
+            safe = 'app'
+
+        digest = hashlib.sha1(app_id.encode()).hexdigest()[:8]
+        prefix = f'll-{safe}'
+
+        if len(prefix) > 54:
+            prefix = prefix[:54].rstrip('-')
+
+        return f'{prefix}-{digest}'
+
+    def _client(self) -> httpx.Client:
+        if self.unix_socket:
+            transport = httpx.HTTPTransport(uds=self.unix_socket)
+            return httpx.Client(base_url='http://localhost/v1.41', transport=transport, timeout=30)
+
+        return httpx.Client(base_url=f'{self.control_plane_url}/v1.41', timeout=30)
+
+    def _delete_existing_container(self, client: httpx.Client, container_name: str) -> None:
+        response = client.get(f'/containers/{container_name}/json')
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+
+        delete_response = client.delete(f'/containers/{container_name}?force=true')
+        delete_response.raise_for_status()

--- a/api/src/compute/podman.py
+++ b/api/src/compute/podman.py
@@ -1,0 +1,102 @@
+import re
+import httpx
+import hashlib
+from src.compute.__root__ import Compute
+
+
+class Podman(Compute):
+    def __init__(
+        self,
+        *,
+        host: str = 'localhost',
+        port: int = 8080,
+        use_tls: bool = False,
+        unix_socket: str | None = '/run/podman/podman.sock',
+        network: str | None = None,
+    ):
+        self.host = host
+        self.port = port
+        self.use_tls = use_tls
+        self.unix_socket = unix_socket
+        self.network = network
+
+    @property
+    def control_plane_url(self) -> str:
+        if self.unix_socket:
+            return f'unix://{self.unix_socket}'
+
+        scheme = 'https' if self.use_tls else 'http'
+        return f'{scheme}://{self.host}:{self.port}'
+
+    def create(self, app_id: str) -> str:
+        return self._container_name(app_id)
+
+    def deploy(self, app_id: str, image: str) -> str:
+        container_name = self._container_name(app_id)
+
+        with self._client() as client:
+            self._delete_existing_container(client, container_name)
+
+            payload = {
+                'image': image,
+                'name': container_name,
+                'labels': {
+                    'longlink.app_id': app_id,
+                    'longlink.managed': 'true',
+                },
+            }
+            if self.network:
+                payload['networks'] = [self.network]
+
+            response = client.post('/libpod/containers/create', json=payload)
+            response.raise_for_status()
+            container_id = response.json()['Id']
+
+            start_response = client.post(f'/libpod/containers/{container_id}/start')
+            start_response.raise_for_status()
+
+        return container_id
+
+    def delete(self, app_id: str) -> None:
+        container_name = self._container_name(app_id)
+
+        with self._client() as client:
+            self._delete_existing_container(client, container_name)
+
+    def credentials(self, app_id: str) -> dict[str, str | int]:
+        return {
+            'type': 'podman',
+            'host': self.host,
+            'port': self.port,
+            'control_plane_url': self.control_plane_url,
+            'container_name': self._container_name(app_id),
+        }
+
+    def _container_name(self, app_id: str) -> str:
+        safe = re.sub(r'[^a-zA-Z0-9_.-]+', '-', app_id).strip('-').lower()
+        if not safe:
+            safe = 'app'
+
+        digest = hashlib.sha1(app_id.encode()).hexdigest()[:8]
+        prefix = f'll-{safe}'
+
+        if len(prefix) > 54:
+            prefix = prefix[:54].rstrip('-')
+
+        return f'{prefix}-{digest}'
+
+    def _client(self) -> httpx.Client:
+        if self.unix_socket:
+            transport = httpx.HTTPTransport(uds=self.unix_socket)
+            return httpx.Client(base_url='http://localhost/v5.0.0', transport=transport, timeout=30)
+
+        return httpx.Client(base_url=f'{self.control_plane_url}/v5.0.0', timeout=30)
+
+    def _delete_existing_container(self, client: httpx.Client, container_name: str) -> None:
+        response = client.get(f'/libpod/containers/{container_name}/json')
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+
+        delete_response = client.delete(f'/libpod/containers/{container_name}?force=true')
+        delete_response.raise_for_status()


### PR DESCRIPTION
### Motivation
- Provide a compute provider layer analogous to the existing database adapters so the control plane can manage container deployments for apps. 
- Support both Docker and Podman control planes over TCP or Unix socket and allow the platform to create, deploy, and delete managed containers. 

### Description
- Add a base adapter interface in `api/src/compute/__root__.py` with `create`, `deploy`, `delete`, and `credentials` method signatures. 
- Implement a `Docker` adapter in `api/src/compute/docker.py` that connects to Docker over TCP/Unix socket using `httpx`, exposes `control_plane_url`, creates deterministic per-app container names, deploys and starts containers via the Docker HTTP API (`/v1.41`), removes existing containers, and returns connection metadata via `credentials()`. 
- Implement a `Podman` adapter in `api/src/compute/podman.py` that connects to Podman over TCP/Unix socket using `httpx`, creates deterministic per-app container names, deploys and starts containers via the libpod API (`/v5.0.0`), removes existing containers, and returns connection metadata via `credentials()`. 
- Export `Compute`, `Docker`, and `Podman` from `api/src/compute/__init__.py` for easy imports. 

### Testing
- Ran `isort src/compute` to normalize imports and it completed successfully. 
- Ran `python -m compileall src/compute` to verify the new modules compile and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc16b975c8323b0de9fddfda4cb32)