### PR TITLE
Simplify SDK app route registration

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -13,15 +13,17 @@ def create_app() -> Starlette:
     async def endpoint(request: Request) -> Response:
         return await dispatch_request(request)
 
-    return Starlette(
-        routes=[
-            Route(
-                "/{full_path:path}",
-                endpoint,
-                methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
-            )
-        ]
-    )
+    methods_by_path: dict[str, set[str]] = {}
+    for registered_route in router._routes:
+        path = registered_route.template.split("?", 1)[0]
+        methods_by_path.setdefault(path, set()).add(registered_route.method)
+
+    routes = [
+        Route(path, endpoint, methods=sorted(methods))
+        for path, methods in methods_by_path.items()
+    ]
+
+    return Starlette(routes=routes)
 
 
 async def dispatch_request(request: Request) -> Response:


### PR DESCRIPTION
### Motivation
- Replace the single catch-all endpoint with explicit routes derived from the SDK router so only declared endpoints are registered and the wiring is simpler.

### Description
- Updated `create_app()` in `sdk/longlink/app.py` to iterate `router._routes`, group entries by the path template (stripping query portion), collect methods per path, and build `starlette.routing.Route` instances via `Route(path, endpoint, methods=sorted(methods))` instead of a single `"/{full_path:path}"` catch-all.

### Testing
- Ran `python -m compileall sdk/longlink/app.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd0ef3ecc832395b689db87bd6290)