### PR TITLE
Support custom app IDs when connecting apps and stack connect fields vertically

### DIFF
--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -51,7 +51,14 @@ class AppsService:
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
-    async def create(self, name: str, url: str, key: str, app_type: str) -> App:
+    async def create(
+        self,
+        name: str,
+        url: str,
+        key: str,
+        app_type: str,
+        app_id: str | None = None,
+    ) -> App:
         '''Add a new app to the database.'''
 
         Session = await get_session()
@@ -69,7 +76,23 @@ class AppsService:
             if existing_key is not None:
                 raise ValueError('App key already exists')
 
-            app = App(name=name, url=url, key=key, type=app_type)
+            if app_id is not None:
+                id_statement = select(App).where(App.id == app_id)
+                id_result = await session.execute(id_statement)
+                existing_id = id_result.scalar_one_or_none()
+                if existing_id is not None:
+                    raise ValueError('App id already exists')
+
+            app_kwargs: dict[str, str] = {
+                'name': name,
+                'url': url,
+                'key': key,
+                'type': app_type,
+            }
+            if app_id is not None:
+                app_kwargs['id'] = app_id
+
+            app = App(**app_kwargs)
             session.add(app)
             await session.commit()
             await session.refresh(app)

--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 
 class AppCreate(BaseModel):
+    id: str | None = None
     url: str
     key: str
 

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -77,11 +77,16 @@ async def create_app(payload: AppCreate) -> AppResponse:
         )
 
     try:
+        app_id = payload.id.strip() if payload.id is not None else None
+        if app_id == '':
+            app_id = None
+
         app = await db.apps.create(
             app_name,
             url=app_url,
             key=payload.key,
             app_type=app_type,
+            app_id=app_id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/web/src/components/dialogs/ConnectApplicationDialog.tsx
+++ b/web/src/components/dialogs/ConnectApplicationDialog.tsx
@@ -9,22 +9,26 @@ import {
 import { Input } from '@/ui/input';
 
 type ConnectApplicationDialogProps = {
+    id: string;
     url: string;
     token: string;
     canConnect: boolean;
     isPending: boolean;
     error: string | null;
+    onIdChange: (value: string) => void;
     onUrlChange: (value: string) => void;
     onTokenChange: (value: string) => void;
     onConnect: () => void;
 };
 
 export default function ConnectApplicationDialog({
+    id,
     url,
     token,
     canConnect,
     isPending,
     error,
+    onIdChange,
     onUrlChange,
     onTokenChange,
     onConnect,
@@ -39,18 +43,32 @@ export default function ConnectApplicationDialog({
                 </DialogDescription>
             </DialogHeader>
 
-            <div className="grid gap-3 md:grid-cols-2">
-                <Input
-                    placeholder="localhost:1707"
-                    value={url}
-                    onChange={(event) => onUrlChange(event.target.value)}
-                />
-                <Input
-                    type="password"
-                    placeholder="App key"
-                    value={token}
-                    onChange={(event) => onTokenChange(event.target.value)}
-                />
+            <div className="grid gap-3">
+                <div className="grid gap-2">
+                    <p className="text-sm text-muted-foreground">Id</p>
+                    <Input
+                        placeholder="Optional app id"
+                        value={id}
+                        onChange={(event) => onIdChange(event.target.value)}
+                    />
+                </div>
+                <div className="grid gap-2">
+                    <p className="text-sm text-muted-foreground">Host</p>
+                    <Input
+                        placeholder="localhost:1707"
+                        value={url}
+                        onChange={(event) => onUrlChange(event.target.value)}
+                    />
+                </div>
+                <div className="grid gap-2">
+                    <p className="text-sm text-muted-foreground">Key</p>
+                    <Input
+                        type="password"
+                        placeholder="App key"
+                        value={token}
+                        onChange={(event) => onTokenChange(event.target.value)}
+                    />
+                </div>
             </div>
 
             <div className="flex justify-end">

--- a/web/src/components/settings/Applications.tsx
+++ b/web/src/components/settings/Applications.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/ui/table';
 
 type Application = {
-    id: number;
+    id: string;
     name: string;
     url: string;
 };
@@ -31,6 +31,7 @@ export default function Applications() {
 
     const [connectUrl, setConnectUrl] = useState('');
     const [connectToken, setConnectToken] = useState('');
+    const [connectId, setConnectId] = useState('');
     const [connectError, setConnectError] = useState<string | null>(null);
     const [isConnectPending, setIsConnectPending] = useState(false);
     const [connectCloseSignal, setConnectCloseSignal] = useState(0);
@@ -88,6 +89,7 @@ export default function Applications() {
 
         const normalizedUrl = connectUrl.trim();
         const normalizedToken = connectToken.trim();
+        const normalizedId = connectId.trim();
 
         setConnectError(null);
         setIsConnectPending(true);
@@ -96,11 +98,13 @@ export default function Applications() {
             await apiFetch<Application>('/apps', {
                 method: 'POST',
                 body: {
+                    id: normalizedId.length > 0 ? normalizedId : undefined,
                     url: normalizedUrl,
                     key: normalizedToken,
                 },
             });
 
+            setConnectId('');
             setConnectUrl('');
             setConnectToken('');
             setConnectCloseSignal((currentSignal) => currentSignal + 1);
@@ -130,9 +134,11 @@ export default function Applications() {
                         <ConnectApplicationDialog
                             url={connectUrl}
                             token={connectToken}
+                            id={connectId}
                             canConnect={canConnect}
                             isPending={isConnectPending}
                             error={connectError}
+                            onIdChange={setConnectId}
                             onUrlChange={setConnectUrl}
                             onTokenChange={setConnectToken}
                             onConnect={() => {


### PR DESCRIPTION
### Motivation
- Allow administrators to supply a custom unique app identifier when registering/connecting an app instead of always using a generated UUID. 
- Surface the optional ID in the UI and place connect form fields vertically in the requested order: `Id`, `Host`, `Key`.

### Description
- Added an optional `id: str | None` to the request model `AppCreate` so clients may include a custom app id (`api/src/models/apps.py`).
- Normalized the optional `id` in the `/apps` route and forwarded it as `app_id` to the DB layer (`api/src/routes/apps.py`).
- Extended `AppsService.create` to accept `app_id`, check uniqueness for the provided id, and persist it when present while preserving automatic UUID generation when omitted (`api/src/db/services/apps.py`).
- Updated the web settings UI to capture and submit an optional connect id (`connectId`) and changed `Application.id` to `string` (`web/src/components/settings/Applications.tsx`).
- Reworked the Connect App dialog to a vertical form and added `Id` + `onIdChange` props so the UI shows fields in the order `Id`, `Host`, `Key` (`web/src/components/dialogs/ConnectApplicationDialog.tsx`).

### Testing
- Ran `bun run format` in `web` which completed successfully.
- Attempted `bun run build` in `web`, which failed due to pre-existing unrelated TypeScript issues in `src/ui/resizable.tsx`, `src/ui/scroll-area.tsx` and a missing import referenced from `src/ui/sidebar.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd0cbaa24832398e446c79c5c5dbf)