### PR TITLE
Normalize app URL in AppCreate schema

### DIFF
--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel, field_validator
+from src.utils import url
 
 
 class AppType(str, Enum):
@@ -12,6 +13,11 @@ class AppCreate(BaseModel):
     id: str | None = None
     url: str
     key: str
+
+    @field_validator('url', mode='before')
+    @classmethod
+    def normalize_url_field(cls, value: str) -> str:
+        return url.normalize(value)
 
     @field_validator('id', mode='before')
     @classmethod

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -1,6 +1,6 @@
 import src.db as db
 from fastapi import HTTPException
-from src.utils import url, apps
+from src.utils import apps
 from src.router import router
 from src.models.apps import AppType, AppCreate, AppMetadata, AppResponse
 from src.apps.organization import (organization_settings_payload,
@@ -21,12 +21,7 @@ async def list_apps(type: AppType | None = None) -> list[AppResponse]:
 @router.post('/apps')
 async def create_app(payload: AppCreate) -> AppResponse:
     """Create a new app."""
-    try:
-        app_url = url.normalize(payload.url)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    metadata_response = await apps.raw(f'{app_url.rstrip("/")}/metadata.json', "GET")
+    metadata_response = await apps.raw(f'{payload.url.rstrip("/")}/metadata.json', "GET")
     if not metadata_response.is_success:
         raise HTTPException( status_code=400, detail=f'Unable to fetch metadata.json ({metadata_response.status_code})')
 
@@ -38,7 +33,7 @@ async def create_app(payload: AppCreate) -> AppResponse:
     try:
         app = await db.apps.create(
             metadata.name,
-            url=app_url,
+            url=payload.url,
             key=payload.key,
             app_type=metadata.type,
             app_id=payload.id,


### PR DESCRIPTION
### Motivation

- Ensure incoming app URLs are normalized at the schema boundary so all downstream code receives a validated, canonical URL.

### Description

- Added a `field_validator('url', mode='before')` on `AppCreate` to call `src.utils.url.normalize` and normalize the URL when the Pydantic model is created (`api/src/models/apps.py`).
- Removed the route-level normalization in `create_app` and updated the route to use the schema-normalized `payload.url` for fetching `metadata.json` and for persistence (`api/src/routes/apps.py`).

### Testing

- Ran `isort .` in the `api` package to fix imports, which completed successfully.
- Ran `python -m compileall src/models/apps.py src/routes/apps.py` in `api` to validate the modified modules compiled, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbddf0f320832398c8ea049fb7aea2)