### PR TITLE
docs: remove uv usage from README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,24 @@ Instead of fragmented SaaS tools or custom-built systems, LongLink offers a stru
 
 ## Development
 
-Install [uv](https://astral.sh/uv/) and create a virtual environment `uv venv`:
+Create and activate a virtual environment with standard Python tooling:
 
 ```bash
-uv pip install -e './api[dev]' -e './sdk'
+python -m venv .venv
+source .venv/bin/activate
+pip install -e './api[dev]' -e './sdk'
 ```
 
 Run control plane:
 
 ```bash
-uv run --project api python main.py
+python api/main.py
 ```
 
 Run sample app:
 
 ```bash
-uv run --project sdk python sample/main.py
+python sdk/sample/main.py
 ```
 
 ### Frontend

--- a/api/README.md
+++ b/api/README.md
@@ -6,5 +6,5 @@
 ## Development setup
 
 ```bash
-uv pip install -e '.[dev]'
+pip install -e '.[dev]'
 ```

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -21,11 +21,11 @@ longlink publish <module>
 ## Stanalone
 
 ```
-uv pip install longlink
+pip install longlink
 ```
 
 ```
-uv pip install 'longlink[standalone]'
+pip install 'longlink[standalone]'
 ```
 
 before update


### PR DESCRIPTION
### Motivation

- Remove references to the `uv` tool so the project can be run with standard Python tooling and `pip` only. 

### Description

- Replace root `README.md` development workflow to create a venv with `python -m venv .venv`, activate it, and install with `pip install -e './api[dev]' -e './sdk'`.
- Replace `uv` run commands with direct `python` invocations (`python api/main.py` and `python sdk/sample/main.py`).
- Update `api/README.md` to use `pip install -e '.[dev]'` instead of `uv pip install`.
- Update `sdk/README.md` standalone install instructions to use `pip install longlink` and `pip install 'longlink[standalone]'` instead of `uv pip install`.

### Testing

- Ran an automated search for remaining `uv` usage with `rg -n "\buv\b|uvx|uv pip|uv run" README.md api/README.md sdk/README.md` and confirmed there are no matches (check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf58e69c483238e128140ec60fb82)