### PR TITLE
web: remove SDK auth gate and add explicit `sdk`/`api` run scripts

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,14 +4,14 @@
     "version": "0.0.0",
     "type": "module",
     "scripts": {
-        "dev": "vite --open /api/",
         "build": "tsc -b && vite build",
         "lint": "eslint . --fix",
         "preview": "vite preview",
         "format": "bunx prettier . --write",
         "build:api": "tsc -b && vite build --mode api",
         "build:sdk": "tsc -b && vite build --mode sdk",
-        "dev:sdk": "vite --open /sdk/"
+        "api": "vite --open /api/",
+        "sdk": "vite --open /sdk/"
     },
     "dependencies": {
         "@base-ui/react": "^1.1.0",

--- a/web/sdk/App.tsx
+++ b/web/sdk/App.tsx
@@ -1,35 +1,22 @@
 import { Toaster } from '@/ui/sonner';
 import { ThemeProvider } from '@/components/theme';
-import { RouterProvider, createBrowserRouter } from 'react-router';
+import { Navigate, RouterProvider, createBrowserRouter } from 'react-router';
 import { useIsFetching, useIsMutating } from '@tanstack/react-query';
 import Layout from './Layout';
-import { RequireAuth } from '@/components/Auth';
-import Login from '@/pages/user/Login';
 import NotFound from '@/pages/NotFound';
 import Longlink from './Longlink';
 
 const router = createBrowserRouter([
     {
         path: '/',
-        element: (
-            <RequireAuth>
-                <Layout />
-            </RequireAuth>
-        ),
+        element: <Layout />,
         children: [
             { index: true, element: <Longlink /> },
             { path: '*', element: <Longlink /> },
         ],
     },
-    { path: '/login', element: <Login /> },
-    {
-        path: '*',
-        element: (
-            <RequireAuth>
-                <NotFound />
-            </RequireAuth>
-        ),
-    },
+    { path: '/login', element: <Navigate to="/" replace /> },
+    { path: '*', element: <NotFound /> },
 ]);
 
 function GlobalLoader() {


### PR DESCRIPTION
### Motivation

- Align developer commands so SDK and API dev servers are started via `bun run sdk` and `bun run api` instead of the previous `dev:sdk` pattern.
- Allow the SDK build and local SDK preview to run without an authentication gate so SDK pages render without requiring login.
- Simplify SDK-mode routing so `/login` does not present an auth flow when running the SDK bundle.

### Description

- Updated `web/package.json` scripts by removing the previous `dev`/`dev:sdk` usage and adding `api` and `sdk` entries (`"api": "vite --open /api/", "sdk": "vite --open /sdk/"`).
- Modified `web/sdk/App.tsx` to remove the `RequireAuth` wrapper around the SDK `Layout`, removed the `Login` route, and changed the `/login` route to `Navigate` back to `/` so SDK mode no longer shows the login UI.
- Cleaned up imports in `web/sdk/App.tsx` (use `Navigate`) and kept the global loading/toaster provider intact.
- Ran code formatting via `bun run format` to normalize whitespace and styling.

### Testing

- Ran `bun run format` in `web` which completed successfully.
- Attempted `bun run build:sdk` which failed due to pre-existing TypeScript errors unrelated to these changes (errors reported in `src/ui/resizable.tsx`, `src/ui/scroll-area.tsx`, and `src/ui/sidebar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf6a2bc98832391c77281e084c3d3)