### PR TITLE
Fix SDK `build:sdk` TypeScript errors in web UI components

### DIFF
--- a/web/src/hooks/use-mobile.ts
+++ b/web/src/hooks/use-mobile.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+    const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+        undefined
+    );
+
+    React.useEffect(() => {
+        const mediaQuery = window.matchMedia(
+            `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+        );
+
+        const updateIsMobile = () => {
+            setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+        };
+
+        mediaQuery.addEventListener('change', updateIsMobile);
+        updateIsMobile();
+
+        return () => mediaQuery.removeEventListener('change', updateIsMobile);
+    }, []);
+
+    return Boolean(isMobile);
+}

--- a/web/src/ui/resizable.tsx
+++ b/web/src/ui/resizable.tsx
@@ -6,9 +6,9 @@ import { cn } from '@/lib/utils';
 function ResizablePanelGroup({
     className,
     ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) {
     return (
-        <ResizablePrimitive.PanelGroup
+        <ResizablePrimitive.Group
             data-slot="resizable-panel-group"
             className={cn(
                 'flex h-full w-full data-[panel-group-direction=vertical]:flex-col',
@@ -29,11 +29,11 @@ function ResizableHandle({
     withHandle,
     className,
     ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
     withHandle?: boolean;
 }) {
     return (
-        <ResizablePrimitive.PanelResizeHandle
+        <ResizablePrimitive.Separator
             data-slot="resizable-handle"
             className={cn(
                 'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
@@ -44,7 +44,7 @@ function ResizableHandle({
             {withHandle && (
                 <div className="bg-border h-6 w-1 rounded-lg z-10 flex shrink-0" />
             )}
-        </ResizablePrimitive.PanelResizeHandle>
+        </ResizablePrimitive.Separator>
     );
 }
 

--- a/web/src/ui/scroll-area.tsx
+++ b/web/src/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as React from 'react';
 import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
 
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
### Motivation
- The SDK-mode web build was failing due to TypeScript errors from mismatched `react-resizable-panels` exports, a missing mobile hook used by the sidebar, and an unused import flagged by the type checker. These prevented `bun run build:sdk` from completing.

### Description
- Update `web/src/ui/resizable.tsx` to use the library's current exports and types by switching `PanelGroup`/`PanelResizeHandle` references to `Group`/`Separator` and adjusting prop typings accordingly. 
- Add `web/src/hooks/use-mobile.ts` implementing `useIsMobile` so the sidebar's `useIsMobile` import resolves and types correctly. 
- Remove the unused `React` import from `web/src/ui/scroll-area.tsx` to satisfy the linter/type-checker. 
- Exported components remain `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle` with updated internal implementations.

### Testing
- Ran `bun run build:sdk` in `web/` and the TypeScript + Vite build completed successfully. 
- Ran formatting with `bun run format` in `web/` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1c1f9e4c8323b4a6ad7108c3330f)