### PR TITLE
Fix `build:sdk` TypeScript compilation errors

### DIFF
--- a/web/src/ui/chart.tsx
+++ b/web/src/ui/chart.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
-import type { TooltipValueType } from 'recharts';
+import type { ValueType as TooltipValueType } from 'recharts/types/component/DefaultTooltipContent';
 
 import { cn } from '@/lib/utils';
 

--- a/web/src/ui/scroll-area.tsx
+++ b/web/src/ui/scroll-area.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
 
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
### Motivation
- `bun run build:sdk` was failing due to TypeScript errors in the web UI caused by an incorrect Recharts type import and an unused `React` import.

### Description
- Import `ValueType` from `recharts/types/component/DefaultTooltipContent` and alias it as `TooltipValueType` in `web/src/ui/chart.tsx` to match Recharts v3 typings.
- Remove the unused `React` import from `web/src/ui/scroll-area.tsx` to resolve the TS6133 unused-value error.

### Testing
- Ran `bun run build:sdk` in `web/` and the build completed successfully.
- Ran `bun run format` in `web/` and formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd203ee0e48323a71ec33d9e6d5ad5)