### PR TITLE
Add Lefthook pre-commit hooks and document Git hook setup; standardize isort invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ bun install
 bun run sdk
 bun run api
 ```
+
+## Git Hooks (Lefthook)
+
+Install Lefthook and enable repository hooks:
+
+```bash
+pip install lefthook
+lefthook install
+```
+
+Once installed, every commit runs:
+
+- Python import formatting in `api/` and `sdk/` with `python -m isort .`
+- Frontend formatting in `web/` with `bun run format`

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -19,5 +19,5 @@ Is a FastAPI application that handles authentication, permissions, and routing t
 Fix imports with `isort`:
 
 ```
-isort .
+python -m isort .
 ```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  commands:
+    python-format-api:
+      root: "api"
+      run: "python -m isort ."
+    python-format-sdk:
+      root: "sdk"
+      run: "python -m isort ."
+    bun-format-web:
+      root: "web"
+      run: "bun run format"

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -9,7 +9,7 @@ This folder contains the LongLink Python SDK, the folder contains:
 You can install the SDK locally in development mode with the following command:
 
 ```bash
-uv pip install -e './sdk'
+pip install -e './sdk'
 ```
 
 ## Tests
@@ -29,5 +29,5 @@ The sdk folder contains the code to create a LongLink application. Each reposito
 Fix imports with `isort`:
 
 ```
-isort .
+python -m isort .
 ```


### PR DESCRIPTION
### Motivation
- Enforce consistent code formatting across `api`, `sdk`, and `web` and document how to enable repository hooks.
- Standardize the way `isort` is invoked to avoid ambiguity across environments and fix a small typo in the SDK docs.

### Description
- Add `lefthook.yml` to configure pre-commit hooks that run `python -m isort .` in `api` and `sdk` and `bun run format` in `web` on every commit. 
- Update `README.md` with a "Git Hooks (Lefthook)" section including installation instructions (`pip install lefthook` and `lefthook install`) and a summary of what each hook runs. 
- Normalize `isort` guidance in `api/AGENTS.md` and `sdk/AGENTS.md` to use `python -m isort .` instead of `isort .`. 
- Fix a typo in `sdk/AGENTS.md` by replacing `uv pip install -e './sdk'` with `pip install -e './sdk'`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2024bb788323a2a150afdb3a1e2a)