### PR TITLE
Add /demo sample page to SDK sample app

### DIFF
--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -3,4 +3,5 @@ import src.pages.input
 import src.pages.table
 import src.routes.sample
 # Register pages
+import src.pages.demo
 import src.pages.settings

--- a/sdk/sample/src/pages/demo.py
+++ b/sdk/sample/src/pages/demo.py
@@ -1,0 +1,51 @@
+from longlink import Page, page
+
+
+@page("/demo", name="Demo", icon="layout")
+async def demo_page() -> Page:
+    page = Page(title="Demo")
+
+    # Navigation (sidebar)
+    menu = page.menu()
+
+    table_section = menu.section("Table", icon="table", default=True)
+    form_section = menu.section("Form", icon="file-text")
+    chart_section = menu.section("Chart", icon="bar-chart-3")
+
+    # ---- TABLE SECTION ----
+    with page.section(table_section):
+        page.heading("Users")
+
+        page.table(
+            endpoint="/sample",
+            columns=[
+                {"key": "id", "label": "ID"},
+                {"key": "name", "label": "Name"},
+                {"key": "active", "label": "Active"},
+            ],
+            pagination=True,
+            searchable=True,
+            filters=[{"key": "active", "type": "boolean"}],
+        )
+
+    # ---- FORM SECTION ----
+    with page.section(form_section):
+        page.heading("Create User")
+
+        with page.form():
+            page.input("name", label="Name")
+            page.input("email", label="Email")
+            page.checkbox("active", label="Active")
+
+            page.submit("Save")
+
+    # ---- CHART SECTION ----
+    with page.section(chart_section):
+        page.heading("User Distribution")
+
+        page.chart(
+            endpoint="/sample/chart",
+            type="pie",
+        )
+
+    return page


### PR DESCRIPTION
### Motivation
- Provide a sample `/demo` page in the SDK sample app to demonstrate navigation, table, form, and chart usage while preserving the requested `with` statement structure.

### Description
- Added `sdk/sample/src/pages/demo.py` implementing the `/demo` page using `Page`, `menu`, `section`, `form`, `table`, and `chart` constructs exactly as provided.
- Registered the new page import in `sdk/sample/main.py` so the demo page is loaded with the other sample pages.
- The page uses the `/sample` and `/sample/chart` endpoints and keeps the `with` block composition for sections and forms.

### Testing
- Ran `python -m compileall sdk/sample/src/pages/demo.py sdk/sample/main.py` and compilation succeeded.
- No unit tests were added per the SDK guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2175a90c8323bc916fd8f9a4550c)