### PR TITLE
web sdk: remove VITE_SDK_APP_ID dependency and target localhost:1707 in sdk mode

### DIFF
--- a/web/sdk/Layout.tsx
+++ b/web/sdk/Layout.tsx
@@ -12,12 +12,8 @@ type AppMetadata = {
     pages?: AppNavigationPage[];
 };
 
-const sdkAppId = import.meta.env.VITE_SDK_APP_ID;
-
 export default function Layout() {
-    const { data: appMetadata, isLoading } = useApiData<AppMetadata>(
-        sdkAppId ? `/apps/${sdkAppId}` : null
-    );
+    const { data: appMetadata, isLoading } = useApiData<AppMetadata>('/pages');
 
     const tabs = isLoading
         ? [

--- a/web/sdk/Longlink.tsx
+++ b/web/sdk/Longlink.tsx
@@ -8,7 +8,6 @@ type AppMetadata = {
     pages?: AppNavigationPage[];
 };
 
-const sdkAppId = import.meta.env.VITE_SDK_APP_ID;
 const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
 
 export default function Longlink() {
@@ -17,9 +16,7 @@ export default function Longlink() {
 
     const { data: appMetadata, isLoading: isAppMetadataLoading } =
         useApiData<AppMetadata>(
-            sdkAppId && normalizedRoutePath.length === 0
-                ? `/apps/${sdkAppId}`
-                : null
+            normalizedRoutePath.length === 0 ? '/pages' : null
         );
 
     const fallbackPagePath = useMemo(() => {
@@ -31,20 +28,13 @@ export default function Longlink() {
     }, [appMetadata?.pages]);
 
     const activePagePath = normalizedRoutePath || fallbackPagePath;
-    const pageEndpoint = sdkAppId
-        ? activePagePath.length > 0
-            ? `/apps/${sdkAppId}/${activePagePath}`
-            : null
-        : null;
+    const pageEndpoint =
+        activePagePath.length > 0 ? `/${activePagePath}` : null;
 
     const { data, isLoading, error } = useApiData<unknown>(pageEndpoint);
     const samplePageData = Array.isArray(data)
         ? (data as RenderNodeSchema[])
         : [];
-
-    if (!sdkAppId) {
-        return <div>Missing VITE_SDK_APP_ID configuration.</div>;
-    }
 
     if (error) {
         return <div>{error.message}</div>;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,7 @@
-const defaultApiBaseUrl = 'http://localhost:8000';
+const defaultApiBaseUrl =
+    import.meta.env.MODE === 'sdk'
+        ? 'http://localhost:1707'
+        : 'http://localhost:8000';
 
 const apiBaseUrl =
     import.meta.env.VITE_API_BASE_URL?.toString() ?? defaultApiBaseUrl;


### PR DESCRIPTION
### Motivation

- The web SDK should work with the single local vite app used for SDK development without requiring a configured `VITE_SDK_APP_ID` environment variable. 
- In SDK mode the client should target the locally-run SDK app on `localhost:1707` instead of the default API host. 
- Simplify the SDK shell so it loads pages and page content directly from the local SDK app routes.

### Description

- Updated API base URL logic in `web/src/lib/api.ts` so `import.meta.env.MODE === 'sdk'` defaults the base URL to `http://localhost:1707` while non-SDK mode continues to default to `http://localhost:8000`.
- Removed the `VITE_SDK_APP_ID` dependency in `web/sdk/Layout.tsx` and now load metadata via `useApiData<AppMetadata>('/pages')`.
- Updated `web/sdk/Longlink.tsx` to fetch metadata when the route is root (`/pages`) and to request page content directly from `/<page>` (removed `/apps/{id}/...` paths and the missing-`VITE_SDK_APP_ID` guard).

### Testing

- Ran `cd web && bun run format` and the codebase formatted successfully. 
- Ran `cd web && bun run build --mode sdk` and the SDK build completed successfully (build produced normal output with a chunk-size warning). 
- The project built and the modified SDK static output was produced, indicating the changes work for local SDK dev mode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3133e4808323a2c66900167481f2)