### PR TITLE
Fix missing `/pages` route registration in SDK apps

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,3 +1,5 @@
+# Import internal routes for side-effect registration on the global router.
+import longlink.routes  # noqa: E402,F401
 from longlink.ui import Page
 from longlink.app import create_app
 from longlink.router import get, put, page, post, pages, patch, route, delete
@@ -5,6 +7,3 @@ from longlink.organization import org
 
 # Official Starlette application instance.
 app = create_app()
-
-# Import internal routes for side-effect registration on the global router.
-import longlink.routes  # noqa: E402,F401

--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,6 +1,6 @@
 """Metadata route."""
 
-from longlink import get
+from longlink.router import get
 from longlink.metadata import metadata
 
 

--- a/sdk/longlink/routes/organization.py
+++ b/sdk/longlink/routes/organization.py
@@ -1,4 +1,4 @@
-from longlink import put, post
+from longlink.router import put, post
 from longlink.organization import OrganizationSettings, org
 
 

--- a/sdk/longlink/routes/pages.py
+++ b/sdk/longlink/routes/pages.py
@@ -1,4 +1,5 @@
-from longlink import get, pages
+from longlink.router import get, pages
+
 
 @get('/pages')
 async def get_available_pages() -> list[dict[str, str]]:


### PR DESCRIPTION
### Motivation
- The SDK exported the FastAPI `app` instance before internal SDK routes were imported, which caused `/pages` to be absent and proxied requests to return `404 Not Found`. 
- Some route modules imported decorators from the package entrypoint, creating a circular-import risk when routes are loaded early.

### Description
- Register internal routes earlier by importing `longlink.routes` before creating the exported app in `sdk/longlink/__init__.py` so routes are present on the exported `app` instance. 
- Update route modules to import decorators directly from `longlink.router` (changed `sdk/longlink/routes/pages.py`, `sdk/longlink/routes/metadata.py`, and `sdk/longlink/routes/organization.py`) to avoid circular imports. 
- Run `python -m isort` on the modified files to normalize import ordering.

### Testing
- Ran a small runtime check with `python - <<'PY' ... from longlink import app` and verified `/pages` is present (printed `True`) and that `['/metadata.json','/organization','/pages']` were found in `app.routes`, which succeeded. 
- Ran `python -m isort` on the touched SDK files to fix import ordering, which completed successfully. 
- Verified the modified files load without circular-import errors when importing the SDK package, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd327745a48323a89b912b6ff2eea2)