### PR TITLE
Handle `/pages` array response in SDK Longlink

### DIFF
--- a/web/sdk/Longlink.tsx
+++ b/web/sdk/Longlink.tsx
@@ -14,18 +14,25 @@ export default function Longlink() {
     const { '*': wildcardPath } = useParams();
     const normalizedRoutePath = normalizePath(wildcardPath ?? '');
 
-    const { data: appMetadata, isLoading: isAppMetadataLoading } =
-        useApiData<AppMetadata>(
-            normalizedRoutePath.length === 0 ? '/pages' : null
-        );
+    const { data: pagesResponse, isLoading: isAppMetadataLoading } = useApiData<
+        AppMetadata | AppNavigationPage[]
+    >(normalizedRoutePath.length === 0 ? '/pages' : null);
+
+    const availablePages = useMemo(() => {
+        if (Array.isArray(pagesResponse)) {
+            return pagesResponse;
+        }
+
+        return pagesResponse?.pages ?? [];
+    }, [pagesResponse]);
 
     const fallbackPagePath = useMemo(() => {
-        if (!appMetadata?.pages || appMetadata.pages.length === 0) {
+        if (availablePages.length === 0) {
             return '';
         }
 
-        return normalizePath(appMetadata.pages[0]?.path ?? '');
-    }, [appMetadata?.pages]);
+        return normalizePath(availablePages[0]?.path ?? '');
+    }, [availablePages]);
 
     const activePagePath = normalizedRoutePath || fallbackPagePath;
     const pageEndpoint =


### PR DESCRIPTION
### Motivation
- The SDK app view showed `No pages configured for this app.` when the API returned the pages as a direct array instead of an object with a `pages` field, so the page discovery needed to accept both shapes.

### Description
- Updated `web/sdk/Longlink.tsx` to accept `AppMetadata | AppNavigationPage[]` from the `useApiData` call to `/pages`.
- Added an `availablePages` normalization with `useMemo` that returns the array when the response is a direct list or `pagesResponse.pages` when it is an object.
- Switched the fallback selection to use `availablePages` so the first page path is selected correctly when pages are returned directly as an array.
- Kept the rest of the rendering flow unchanged and preserved existing error/loading handling.

### Testing
- Ran `bun run format` in `web` (format completed successfully). 
- Built the SDK bundle with `bun run build:sdk` in `web` (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd346eb87c8323a8e22e6c0667adcc)