### PR TITLE
web: split organization and application layouts

### DIFF
--- a/web/api/Layout.tsx
+++ b/web/api/Layout.tsx
@@ -1,156 +1,39 @@
-import { Loader2, PanelTop } from 'lucide-react';
-import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
-import { Breadcrumb } from '@/components/breadcrumb';
-import { UserProfile } from '@/components/Profile';
-import { Card } from '@/ui/card';
-import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/ui/empty';
-import { Tabs, TabsList, TabsTrigger } from '@/ui/tabs';
+import { Outlet, useParams } from 'react-router';
 import { useApiData } from '@/hooks/use-data';
-import { getActiveTabConfig, getAppTabsFromPages, getTabsConfig, type AppNavigationPage } from '@/lib/navigation';
+import { getAppTabsFromPages, type AppNavigationPage } from '@/lib/navigation';
+import ApplicationLayout, { getLoadingApplicationTabs } from '@/layouts/Application';
+import OrganizationLayout from '@/layouts/Organization';
 
 type AppMetadata = {
     pages?: AppNavigationPage[];
 };
 
-type NavigationProps = {
-    tabs: ReturnType<typeof getTabsConfig>['tabs'];
-    basePathSuffix?: string;
-    isTabsLoading?: boolean;
-    showEmptyAppSection?: boolean;
-};
-
 export default function Layout() {
     const { appId } = useParams();
-    const appMetadataEndpoint = appId ? `/apps/${appId}` : null;
 
+    if (!appId) {
+        return (
+            <OrganizationLayout>
+                <Outlet />
+            </OrganizationLayout>
+        );
+    }
+
+    const appMetadataEndpoint = `/apps/${appId}`;
     const { data: appMetadata, isLoading: isAppMetadataLoading } = useApiData<AppMetadata>(appMetadataEndpoint);
-    const appTabs = appId
-        ? isAppMetadataLoading
-            ? [
-                  {
-                      value: 'loading',
-                      label: 'Loading',
-                      path: '',
-                      icon: Loader2,
-                  },
-              ]
-            : getAppTabsFromPages(appMetadata?.pages ?? [])
-        : undefined;
 
-    const { tabs, basePathSuffix } = getTabsConfig({
-        section: 'organization',
-        appId,
-        appTabs,
-    });
+    const tabs = isAppMetadataLoading ? getLoadingApplicationTabs() : getAppTabsFromPages(appMetadata?.pages ?? []);
 
-    const showEmptyAppSection = Boolean(appId && !isAppMetadataLoading && tabs.length === 0);
+    const showEmptyAppSection = !isAppMetadataLoading && tabs.length === 0;
 
     return (
-        <Navigation
+        <ApplicationLayout
             tabs={tabs}
-            basePathSuffix={basePathSuffix}
-            isTabsLoading={Boolean(appId && isAppMetadataLoading)}
+            basePathSuffix={appId}
+            isTabsLoading={isAppMetadataLoading}
             showEmptyAppSection={showEmptyAppSection}
-        />
-    );
-}
-
-export function Navigation({ tabs, basePathSuffix, isTabsLoading, showEmptyAppSection }: NavigationProps) {
-    const { appId } = useParams();
-    const location = useLocation();
-    const navigate = useNavigate();
-
-    const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
-    const basePath = appId ? (normalizedSuffix ? `/${normalizedSuffix}` : '/') : '';
-
-    const activeTabConfig = getActiveTabConfig({
-        tabs,
-        locationPath: location.pathname,
-        basePath,
-    });
-    const activeTab = isTabsLoading
-        ? 'loading'
-        : location.pathname.startsWith('/profile')
-          ? (tabs[0]?.value ?? '')
-          : (activeTabConfig?.value ?? tabs[0]?.value ?? '');
-
-    return (
-        <div className="min-h-screen text-white">
-            <header className="border-b border-white/10">
-                <div className="mx-auto w-full px-6 pb-2 pt-4">
-                    <div className="flex items-center justify-between gap-4 text-white/80">
-                        <div className="flex items-center gap-4">
-                            <Breadcrumb />
-                        </div>
-                        <UserProfile />
-                    </div>
-                </div>
-
-                {/* Tabs navigation */}
-                {tabs.length > 0 ? (
-                    <div className="mx-auto w-full px-6 pb-2">
-                        <Tabs
-                            value={activeTab}
-                            onValueChange={(value) => {
-                                if (isTabsLoading) {
-                                    return;
-                                }
-                                const nextTab = tabs.find((tab) => tab.value === value);
-                                if (!nextTab) {
-                                    return;
-                                }
-                                const nextPath = nextTab.path ?? '';
-                                const targetPath =
-                                    nextPath === ''
-                                        ? basePath || '/'
-                                        : basePath
-                                          ? `${basePath}/${nextPath}`
-                                          : `/${nextPath}`;
-                                navigate(targetPath);
-                            }}
-                        >
-                            <TabsList variant="line" className="gap-4">
-                                {tabs.map((tab) => {
-                                    const Icon = tab.icon;
-                                    return (
-                                        <TabsTrigger
-                                            key={tab.value}
-                                            value={tab.value}
-                                            disabled={isTabsLoading}
-                                            className="cursor-pointer"
-                                        >
-                                            <Icon
-                                                className={`h-4 w-4 ${tab.value === 'loading' ? 'animate-spin' : ''}`}
-                                            />
-                                            {tab.label}
-                                        </TabsTrigger>
-                                    );
-                                })}
-                            </TabsList>
-                        </Tabs>
-                    </div>
-                ) : null}
-            </header>
-
-            <main className="mx-auto w-full max-w-6xl gap-8 px-6 pb-16 pt-10">
-                {showEmptyAppSection ? (
-                    <Card className="p-10 text-center">
-                        <Empty>
-                            <EmptyHeader>
-                                <EmptyMedia variant="icon">
-                                    <PanelTop />
-                                </EmptyMedia>
-                                <EmptyTitle>No Tabs Yet</EmptyTitle>
-                                <EmptyDescription>This app has no configured tabs yet.</EmptyDescription>
-                            </EmptyHeader>
-                        </Empty>
-                    </Card>
-                ) : (
-                    <section className="space-y-6">
-                        <Outlet />
-                    </section>
-                )}
-            </main>
-        </div>
+        >
+            <Outlet />
+        </ApplicationLayout>
     );
 }

--- a/web/src/layouts/Application.tsx
+++ b/web/src/layouts/Application.tsx
@@ -1,0 +1,123 @@
+import { Loader2, PanelTop } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router';
+import type { ReactNode } from 'react';
+import { Breadcrumb } from '@/components/breadcrumb';
+import { UserProfile } from '@/components/Profile';
+import { Card } from '@/ui/card';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/ui/empty';
+import { Tabs, TabsList, TabsTrigger } from '@/ui/tabs';
+import { getActiveTabConfig, type NavigationTab } from '@/lib/navigation';
+
+type ApplicationLayoutProps = {
+    tabs: NavigationTab[];
+    basePathSuffix?: string;
+    isTabsLoading?: boolean;
+    showEmptyAppSection?: boolean;
+    children: ReactNode;
+};
+
+export default function ApplicationLayout({
+    tabs,
+    basePathSuffix,
+    isTabsLoading,
+    showEmptyAppSection,
+    children,
+}: ApplicationLayoutProps) {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const normalizedSuffix = basePathSuffix?.replace(/^\/+|\/+$/g, '') ?? '';
+    const basePath = normalizedSuffix ? `/${normalizedSuffix}` : '/';
+
+    const activeTabConfig = getActiveTabConfig({
+        tabs,
+        locationPath: location.pathname,
+        basePath,
+    });
+
+    const activeTab = isTabsLoading ? 'loading' : (activeTabConfig?.value ?? tabs[0]?.value ?? '');
+
+    return (
+        <div className="min-h-screen text-white">
+            <header className="border-b border-white/10">
+                <div className="mx-auto w-full px-6 pb-2 pt-4">
+                    <div className="flex items-center justify-between gap-4 text-white/80">
+                        <div className="flex items-center gap-4">
+                            <Breadcrumb />
+                        </div>
+                        <UserProfile />
+                    </div>
+                </div>
+
+                {tabs.length > 0 ? (
+                    <div className="mx-auto w-full px-6 pb-2">
+                        <Tabs
+                            value={activeTab}
+                            onValueChange={(value) => {
+                                if (isTabsLoading) {
+                                    return;
+                                }
+                                const nextTab = tabs.find((tab) => tab.value === value);
+                                if (!nextTab) {
+                                    return;
+                                }
+
+                                const nextPath = nextTab.path ?? '';
+                                navigate(nextPath === '' ? basePath : `${basePath}/${nextPath}`);
+                            }}
+                        >
+                            <TabsList variant="line" className="gap-4">
+                                {tabs.map((tab) => {
+                                    const Icon = tab.icon;
+
+                                    return (
+                                        <TabsTrigger
+                                            key={tab.value}
+                                            value={tab.value}
+                                            disabled={isTabsLoading}
+                                            className="cursor-pointer"
+                                        >
+                                            <Icon
+                                                className={`h-4 w-4 ${tab.value === 'loading' ? 'animate-spin' : ''}`}
+                                            />
+                                            {tab.label}
+                                        </TabsTrigger>
+                                    );
+                                })}
+                            </TabsList>
+                        </Tabs>
+                    </div>
+                ) : null}
+            </header>
+
+            <main className="mx-auto w-full max-w-6xl gap-8 px-6 pb-16 pt-10">
+                {showEmptyAppSection ? (
+                    <Card className="p-10 text-center">
+                        <Empty>
+                            <EmptyHeader>
+                                <EmptyMedia variant="icon">
+                                    <PanelTop />
+                                </EmptyMedia>
+                                <EmptyTitle>No Tabs Yet</EmptyTitle>
+                                <EmptyDescription>This app has no configured tabs yet.</EmptyDescription>
+                            </EmptyHeader>
+                        </Empty>
+                    </Card>
+                ) : (
+                    <section className="space-y-6">{children}</section>
+                )}
+            </main>
+        </div>
+    );
+}
+
+export function getLoadingApplicationTabs(): NavigationTab[] {
+    return [
+        {
+            value: 'loading',
+            label: 'Loading',
+            path: '',
+            icon: Loader2,
+        },
+    ];
+}

--- a/web/src/layouts/Organization.tsx
+++ b/web/src/layouts/Organization.tsx
@@ -1,0 +1,84 @@
+import { useLocation, useNavigate } from 'react-router';
+import type { ReactNode } from 'react';
+import { Breadcrumb } from '@/components/breadcrumb';
+import { UserProfile } from '@/components/Profile';
+import { Tabs, TabsList, TabsTrigger } from '@/ui/tabs';
+import { getActiveTabConfig, getTabsConfig } from '@/lib/navigation';
+
+type OrganizationLayoutProps = {
+    children: ReactNode;
+};
+
+export default function OrganizationLayout({ children }: OrganizationLayoutProps) {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const { tabs } = getTabsConfig({
+        section: 'organization',
+    });
+
+    const activeTabConfig = getActiveTabConfig({
+        tabs,
+        locationPath: location.pathname,
+        basePath: '',
+    });
+
+    const activeTab = location.pathname.startsWith('/profile')
+        ? (tabs[0]?.value ?? '')
+        : (activeTabConfig?.value ?? tabs[0]?.value ?? '');
+
+    return (
+        <div className="min-h-screen text-white">
+            <header className="border-b border-white/10">
+                <div className="mx-auto w-full px-6 pb-2 pt-4">
+                    <div className="flex items-center justify-between gap-4 text-white/80">
+                        <div className="flex items-center gap-4">
+                            <Breadcrumb />
+                        </div>
+                        <UserProfile />
+                    </div>
+                </div>
+
+                <div className="mx-auto w-full px-6 pb-2">
+                    <Tabs
+                        value={activeTab}
+                        onValueChange={(value) => {
+                            const nextTab = tabs.find((tab) => tab.value === value);
+                            if (!nextTab) {
+                                return;
+                            }
+
+                            const nextPath = nextTab.path ?? '';
+                            navigate(nextPath === '' ? '/' : `/${nextPath}`);
+                        }}
+                    >
+                        <TabsList variant="line" className="gap-4">
+                            <TabsTrigger value="overview" className="cursor-pointer">
+                                Overview
+                            </TabsTrigger>
+                            <TabsTrigger value="tools" className="cursor-pointer">
+                                Tools
+                            </TabsTrigger>
+                            <TabsTrigger value="spaces" className="cursor-pointer">
+                                Spaces
+                            </TabsTrigger>
+                            <TabsTrigger value="processes" className="cursor-pointer">
+                                Processes
+                            </TabsTrigger>
+                            <TabsTrigger value="people" className="cursor-pointer">
+                                People
+                            </TabsTrigger>
+                            <TabsTrigger value="settings" className="cursor-pointer">
+                                Settings
+                            </TabsTrigger>
+                        </TabsList>
+                    </Tabs>
+                </div>
+            </header>
+
+            <main className="mx-auto w-full max-w-6xl gap-8 px-6 pb-16 pt-10">
+                <section className="space-y-6">{children}</section>
+            </main>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation
- Separate the organization-level shell (fixed tabs) from the application-level shell so app pages can receive dynamic tabs and loading/empty handling.  
- Make the application layout reusable by passing tabs and related state as props to keep routing/layout concerns clearer.

### Description
- Add `src/layouts/Organization.tsx` which provides the fixed organization header and explicit organization tab triggers (Overview, Tools, Spaces, Processes, People, Settings).  
- Add `src/layouts/Application.tsx` which accepts dynamic `tabs`, `basePathSuffix`, `isTabsLoading`, and `showEmptyAppSection` props and renders loading/empty states and navigation.  
- Update `web/api/Layout.tsx` to render `OrganizationLayout` when `appId` is not present and `ApplicationLayout` (with tabs derived from `getAppTabsFromPages` or `getLoadingApplicationTabs`) when `appId` is present.  
- Add helper `getLoadingApplicationTabs()` in `Application.tsx` and standardize child prop types to `ReactNode` for both layouts.

### Testing
- Ran formatting with `bun run format`, which completed successfully.  
- Attempted a type-check/build with `bun run build:api`, which failed in this environment due to a missing dependency error: `src/lib/api.ts(1,60): Cannot find module 'axios' or its corresponding type declarations.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd43c427b483238fcbd9db9f4dbe39)