### PR TITLE
Fix SDK list responses to be returned as JSON

### DIFF
--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -57,7 +57,7 @@ def _format_response(handler: Handler, body: Any) -> Response | JSONResponse | P
 
         return Response(content=response_body, media_type="application/json")
 
-    if isinstance(body, dict):
+    if isinstance(body, (dict, list)):
         return JSONResponse(body)
 
     if isinstance(body, bytes):


### PR DESCRIPTION
### Motivation
- The SDK `/pages` endpoint was returning Python repr/plain text for list responses which prevented the web SDK from receiving a proper JSON array.

### Description
- Update `_format_response` in `sdk/longlink/router/__init__.py` to treat `list` values the same as `dict` and return a `JSONResponse` for both.

### Testing
- Ran a Python smoke test from `sdk/` that calls `_format_response` with a list payload and asserts the result is a `JSONResponse` with `media_type` `application/json` and body `[{"path":"/demo"}]`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd49316dfc8323b194319249bb1e29)