### PR TITLE
Fix SDK page discovery when /pages response is not wrapped in pages

### DIFF
--- a/web/sdk/App.tsx
+++ b/web/sdk/App.tsx
@@ -17,7 +17,6 @@ const router = createBrowserRouter([
     { path: '*', element: <NotFound /> },
 ]);
 
-
 export default function App() {
     return (
         <ThemeProvider>

--- a/web/sdk/Layout.tsx
+++ b/web/sdk/Layout.tsx
@@ -3,13 +3,15 @@ import { Outlet, useLocation, useNavigate } from 'react-router';
 import { Tabs, TabsList, TabsTrigger } from '@/ui/tabs';
 import { useApiData } from '@/hooks/use-data';
 import { getActiveTabConfig, getAppTabsFromPages, type AppNavigationPage } from '@/lib/navigation';
+import { getPagesFromResponse } from './pages';
 
 type AppMetadata = {
     pages?: AppNavigationPage[];
 };
 
 export default function Layout() {
-    const { data: appMetadata, isLoading } = useApiData<AppMetadata>('/pages');
+    const { data: pagesResponse, isLoading } = useApiData<AppMetadata | AppNavigationPage[] | string>('/pages');
+    const pages = getPagesFromResponse(pagesResponse);
 
     const tabs = isLoading
         ? [
@@ -20,7 +22,7 @@ export default function Layout() {
                   icon: Loader2,
               },
           ]
-        : getAppTabsFromPages(appMetadata?.pages ?? []);
+        : getAppTabsFromPages(pages);
 
     return <Navigation tabs={tabs} isTabsLoading={isLoading} />;
 }

--- a/web/sdk/Longlink.tsx
+++ b/web/sdk/Longlink.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import Render, { type RenderNodeSchema } from '@/components/Render';
 import { useApiData } from '@/hooks/use-data';
 import { type AppNavigationPage } from '@/lib/navigation';
+import { getPagesFromResponse } from './pages';
 
 type AppMetadata = {
     pages?: AppNavigationPage[];
@@ -18,13 +19,7 @@ export default function Longlink() {
         normalizedRoutePath.length === 0 ? '/pages' : null
     );
 
-    const availablePages = useMemo(() => {
-        if (Array.isArray(pagesResponse)) {
-            return pagesResponse;
-        }
-
-        return pagesResponse?.pages ?? [];
-    }, [pagesResponse]);
+    const availablePages = useMemo(() => getPagesFromResponse(pagesResponse), [pagesResponse]);
 
     const fallbackPagePath = useMemo(() => {
         if (availablePages.length === 0) {

--- a/web/sdk/pages.ts
+++ b/web/sdk/pages.ts
@@ -1,0 +1,29 @@
+import { type AppNavigationPage } from '@/lib/navigation';
+
+type AppMetadata = {
+    pages?: AppNavigationPage[];
+};
+
+const toPageList = (value: unknown): AppNavigationPage[] => {
+    if (Array.isArray(value)) {
+        return value as AppNavigationPage[];
+    }
+
+    if (value && typeof value === 'object' && Array.isArray((value as AppMetadata).pages)) {
+        return (value as AppMetadata).pages ?? [];
+    }
+
+    return [];
+};
+
+export const getPagesFromResponse = (response: unknown): AppNavigationPage[] => {
+    if (typeof response === 'string') {
+        try {
+            return toPageList(JSON.parse(response));
+        } catch {
+            return [];
+        }
+    }
+
+    return toPageList(response);
+};


### PR DESCRIPTION
### Motivation
- The SDK UI assumed `/pages` always returned an object with a `pages` property, while the local SDK backend can return a raw array (or even a string payload), causing the app to show "No pages configured for this app." at the root route.

### Description
- Added a normalization helper `getPagesFromResponse` in `web/sdk/pages.ts` that accepts a raw array, an object with `pages`, or a JSON string and returns a normalized `AppNavigationPage[]`.
- Updated `web/sdk/Layout.tsx` to call the helper and build tabs from the normalized pages list instead of assuming `appMetadata.pages`.
- Updated `web/sdk/Longlink.tsx` to reuse the same normalization helper for selecting the fallback page route.
- Minor formatting cleanup applied to `web/sdk/App.tsx` via the project's formatter hooks.

### Testing
- Ran `bun run format` (Prettier) in `web`, which completed successfully. 
- Attempted `bun run build:sdk` in `web`, which failed due to pre-existing unrelated TypeScript errors in `src/hooks/use-user.tsx` and `src/hooks/use-users.ts` (errors about `credentials` not existing in `ApiRequestOptions`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd501fb1d0832390114c86f1b1a136)