### PR TITLE
sdk: enable CORS for local web dev origin

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -2,10 +2,22 @@ from fastapi import FastAPI
 from pathlib import Path
 from longlink.router import api_router
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 
 
 def create_app() -> FastAPI:
     app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://localhost:8000",
+        ],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     app.include_router(api_router)
 
     static_dir = Path(__file__).resolve().parent / "static"


### PR DESCRIPTION
### Motivation
- Requests from the Vite dev server (`http://localhost:5173`) to the SDK dev API (`http://localhost:1707`) were blocked by the browser CORS policy because responses lacked an `Access-Control-Allow-Origin` header.

### Description
- Add FastAPI `CORSMiddleware` configuration in `sdk/longlink/app.py` to permit local development origins (`http://localhost:3000`, `http://localhost:5173`, `http://localhost:8000`).
- Allow credentials and broadly enable methods and headers to simplify local SDK <-> web interactions during development.
- Leave existing router registration and static file mounting intact in `sdk/longlink/app.py`.

### Testing
- Ran `python -m isort sdk/longlink/app.py` which completed successfully.
- Ran `python -m compileall sdk/longlink/app.py` which compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce27b7be648323ba48ad7725254780)