### PR TITLE
Remove path normalization and simplify route path handling

### DIFF
--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -11,9 +11,6 @@ api_router = APIRouter()
 _pages: list[dict[str, str]] = []
 
 
-def _normalize_path(path: str) -> str:
-    return path.split("?", 1)[0]
-
 
 def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
     @wraps(handler)
@@ -71,7 +68,7 @@ def route(path: str, methods: list[str] | None = None):
 
     def decorator(func: Handler) -> Handler:
         api_router.add_api_route(
-            _normalize_path(path),
+            path,
             _build_endpoint(func),
             methods=normalized_methods,
             response_model=None,
@@ -83,9 +80,9 @@ def route(path: str, methods: list[str] | None = None):
 
 def page(path: str, name: str, icon: str):
     def decorator(func: Handler) -> Handler:
-        _pages.append({"path": _normalize_path(path), "name": name, "icon": icon})
+        _pages.append({"path": path, "name": name, "icon": icon})
         api_router.add_api_route(
-            _normalize_path(path),
+            path,
             _build_endpoint(func, is_page=True),
             methods=["GET"],
             response_model=None,

--- a/sdk/sample/src/routes/sample.py
+++ b/sdk/sample/src/routes/sample.py
@@ -36,7 +36,7 @@ async def sample_post_endpoint_with_object(object: int):
 
 # Example with params
 # Params must have a default value
-@post("/params/{object}?{start}&{end}")
+@post("/params/{object}")
 async def sample_post_endpoint_with_params(object: int, start: int = 0, end: int = 10):
     return "Sample POST endpoint response"
 
@@ -55,6 +55,6 @@ async def sample_post_user_endpoint() -> UserModel:
 
 # Example with params
 # Params must have a default value
-@get("/params/{object}?{start}&{end}")
+@get("/params/{object}")
 async def sample_get_endpoint_with_params(object: int, start: int = 0, end: int = 10):
     return "Sample GET endpoint response"


### PR DESCRIPTION
### Motivation
- Remove custom path normalization that stripped query strings to simplify and avoid incorrect manipulation of route paths.
- Ensure registered routes and page metadata store the original path strings so FastAPI can handle query parameters via handler signatures.

### Description
- Deleted the `_normalize_path` helper and replaced its uses with the raw `path` value in `sdk/longlink/router/__init__.py` when calling `api_router.add_api_route` and when appending to `_pages`.
- Kept response formatting logic in `_build_endpoint` unchanged while making the router use the provided path verbatim.
- Updated example routes in `sdk/sample/src/routes/sample.py` to remove querystring specifiers from decorator paths (e.g. changed `"/params/{object}?{start}&{end}"` to `"/params/{object}"`) so query parameters are handled by function arguments.

### Testing
- Ran the automated unit test suite with `pytest` against the changed modules and the tests passed.
- Executed a sample app integration smoke test to verify route registration and example endpoints, and the smoke test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2753edf88323b9859c804ca66dce)