### PR TITLE
Fix SDK tab routing and horizontal tab layout

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "vite-app",
@@ -11,7 +10,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.96.1",
         "@tanstack/react-table": "^8.21.3",
-        "axios": "^1.11.0",
+        "axios": "^1.14.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,7 +25,7 @@ export type ApiRequestOptions<TBody = unknown> = Omit<
 const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, '');
 
 const normalizeAppPathForSdk = (path: string) => {
-    const sdkPathMatch = path.match(/^\/apps\/[^/]+\/?(.*)$/);
+    const sdkPathMatch = path.match(/^\/apps\/[^/]+\/(.+)$/);
 
     if (!sdkPathMatch) {
         return path;

--- a/web/src/ui/tabs.tsx
+++ b/web/src/ui/tabs.tsx
@@ -10,7 +10,7 @@ function Tabs({ className, orientation = 'horizontal', ...props }: TabsPrimitive
         <TabsPrimitive.Root
             data-slot="tabs"
             data-orientation={orientation}
-            className={cn('group/tabs flex gap-2 data-horizontal:flex-col', className)}
+            className={cn('group/tabs flex gap-2 data-[orientation=vertical]:flex-col', className)}
             {...props}
         />
     );


### PR DESCRIPTION
### Motivation
- Tabs were rendering incorrectly in SDK mode because path normalization could rewrite `/apps/<app>/settings` into `/`, causing the pages endpoint to return `Not Found` and breaking tab switching. 
- The tabs root CSS utility used a generic `data-horizontal` selector which caused horizontal tabs to behave like vertical (stacked) tabs in some contexts, so the orientation handling needed to be corrected.

### Description
- Relaxed the SDK path normalization regex in `web/src/lib/api.ts` so `normalizeAppPathForSdk` only strips the `/apps/<app>/` prefix when there is an actual nested segment (`/^\/apps\/[^/]+\/(.+)$/`).
- Fixed the Tabs root classname in `web/src/ui/tabs.tsx` to use `data-[orientation=vertical]:flex-col` so horizontal tabs remain horizontal and only vertical orientation switches to column layout.
- Updated the web lockfile metadata via the project formatter run, which changed the `web/bun.lock` snapshot.

### Testing
- Ran `bun run format` which completed successfully and reformatted/updated the lockfile.
- Ran `bun run build:sdk` which reported TypeScript errors unrelated to these changes (`TS2353` about an unexpected `credentials` property in `ApiRequestOptions` in `src/hooks/use-user.tsx` and `src/hooks/use-users.ts`), so the SDK build currently fails for pre-existing type issues.
- No new unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce28beff5c8323ad586c20e0a59700)