### PR TITLE
fix(web): restore Tailwind styling for tabs and shared UI components

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,6 +3,10 @@
 @import 'shadcn/tailwind.css';
 @import '@fontsource-variable/inter';
 
+@source "./**/*.{ts,tsx}";
+@source "../api/**/*.{ts,tsx}";
+@source "../sdk/**/*.{ts,tsx}";
+
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
### Motivation
- Tabs and other UI controls were rendering unstyled because Tailwind v4 utility scanning did not include the shared UI/component sources across the different Vite roots, so required classes were not being generated.

### Description
- Added explicit Tailwind v4 `@source` directives to `web/src/index.css` to include `./**/*.{ts,tsx}`, `../api/**/*.{ts,tsx}`, and `../sdk/**/*.{ts,tsx}` so the scanner picks up all UI/component files used by both `api` and `sdk` Vite modes.
- Change is limited to CSS discovery only and does not modify any component logic or behavior.

### Testing
- Ran formatter: `cd web && bun run format` and it succeeded.
- Verified CSS extraction by building the web app: `cd web && bunx vite build --mode api` and observed the CSS bundle grow (indicating utilities are now generated), which confirms the visual styles are being produced.
- Attempted full build with TypeScript step: `cd web && bun run build:api` fails due to existing unrelated TypeScript errors in `use-user` / `use-users`, which are outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2c55489483238c7f98f62d881da8)