### PR TITLE
Fix SDK dev server to register page routes before app creation

### DIFF
--- a/sdk/longlink/cli/dev.py
+++ b/sdk/longlink/cli/dev.py
@@ -7,9 +7,9 @@ import importlib
 
 def load_app():
     importlib.import_module("main")
-    from longlink import app
+    from longlink.app import create_app
 
-    return app
+    return create_app()
 
 
 @click.command(name="dev")


### PR DESCRIPTION
### Motivation
- The dev server was returning the pre-created `longlink.app` singleton which caused the FastAPI app to be instantiated before page decorators executed, making page endpoints (for example `/settings`) unavailable in dev mode.

### Description
- Change `load_app()` in `sdk/longlink/cli/dev.py` to `import main` and then call `create_app()` from `longlink.app` instead of returning the already-created `longlink.app`, ensuring pages registered by decorators are present when the app is built.

### Testing
- Verified with a small loader script that `load_app()` exposes `/settings`, `/demo`, `/input`, `/table`, and `/pages` when run against the sample app, and ran `python -m compileall longlink/cli/dev.py`; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2d23ac088323b0c000da569fcbff)