### PR TITLE
web: stop propagating `return_to` in login redirects

### DIFF
--- a/web/src/components/Auth.tsx
+++ b/web/src/components/Auth.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from 'react';
-import { Navigate, useLocation } from 'react-router';
+import { Navigate } from 'react-router';
 import { useUser } from '@/hooks/use-user';
 
 export function RequireAuth({ children }: { children: ReactElement }) {
-    const location = useLocation();
     const { data: user, isLoading } = useUser();
 
     if (isLoading) {
@@ -11,8 +10,7 @@ export function RequireAuth({ children }: { children: ReactElement }) {
     }
 
     if (!user) {
-        const returnTo = `${location.pathname}${location.search}${location.hash}`;
-        return <Navigate to={`/login?return_to=${encodeURIComponent(returnTo)}`} replace />;
+        return <Navigate to="/login" replace />;
     }
 
     return children;

--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -2,14 +2,13 @@ import { Chrome, Github, Layers } from 'lucide-react';
 import { Button } from '@/ui/button';
 import { Card, CardContent } from '@/ui/card';
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { apiFetch, getApiBaseUrl } from '@/lib/api';
 import { useUser } from '@/hooks/use-user';
 
 type LoginMethodsResponse = string[] | { methods?: string[] };
 
 export default function Login() {
-    const location = useLocation();
     const navigate = useNavigate();
     const { data: user, isLoading } = useUser();
     const apiBaseUrl = getApiBaseUrl();
@@ -33,14 +32,7 @@ export default function Login() {
         }
     };
 
-    const searchParams = new URLSearchParams(location.search);
-    const queryReturnTo = searchParams.get('return_to');
-    const returnTo = (() => {
-        if (!queryReturnTo || !queryReturnTo.startsWith('/')) {
-            return getDefaultReturnTo();
-        }
-        return queryReturnTo.startsWith('/login') ? getDefaultReturnTo() : queryReturnTo;
-    })();
+    const returnTo = getDefaultReturnTo();
 
     useEffect(() => {
         if (!isLoading && user) {


### PR DESCRIPTION
### Motivation
- The `?return_to=` query parameter was causing redirect loops and preventing successful login completion, so redirects from the auth guard should stop including it and the login page should not rely on that query param.

### Description
- Removed `useLocation` and the `?return_to=` query propagation from the auth guard so unauthenticated users are redirected to `/login` without a query string (`web/src/components/Auth.tsx`).
- Simplified the login page by removing parsing of `location.search`/`return_to` and always using the safe same-origin referrer fallback via `getDefaultReturnTo()` (`web/src/pages/user/Login.tsx`).
- Adjusted imports accordingly to remove unused `useLocation` references.

### Testing
- Ran web formatting with `bun run format` which completed successfully. 
- Pre-commit formatting hook executed and passed during the change process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6d679eb88323a405163de4a73d40)