### PR TITLE
feat(api): migrate auth to pure OIDC bridge with Keycloak integration test

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -8,3 +8,13 @@
 ```bash
 pip install -e '.[dev]'
 ```
+
+## OIDC bridge environment variables
+
+The API uses a pure OIDC bridge based on Authlib and expects these variables:
+
+- `ENV_OIDC_ISSUER` (example: `http://localhost:8080/realms/longlink-control-plane`)
+- `ENV_OIDC_CLIENT_ID`
+- `ENV_OIDC_CLIENT_SECRET`
+- `ENV_OIDC_REDIRECT_URI` (default: `http://localhost:8000/auth/oidc`)
+- `ENV_OIDC_SCOPES` (default: `openid profile email`)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -47,3 +47,8 @@ from_first = false
 no_sections = true
 lines_between_types = 0
 length_sort = true
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks integration tests requiring docker/keycloak",
+]

--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -3,45 +3,25 @@ from fastapi import Request, HTTPException
 from src.env import env
 from authlib.integrations.starlette_client import OAuth
 
-"""
-TODO: We do not create a new authentication system, instead we integrate with existing Identity Providers (IdP)
-- SAML 2.0
-- OpenID Connect (OIDC)
-- OAuth 2.0
-
-IdP
-- Microsoft Entra ID (formerly Azure AD)
-- Okta
-- Ping Identity
-- Auth0
-- Google Workspace
-
-TODO: MFA (Multi-Factor Authentication)
-TODO: Enterprise SCIM 2.0 Support
-"""
-
 oauth = OAuth()
 AVAILABLE_AUTH_METHODS: list[str] = []
 
 
-if env.ENV_GITHUB_CLIENT_ID and env.ENV_GITHUB_CLIENT_SECRET:
-    oauth.register(
-        name='github',
-        client_id=env.ENV_GITHUB_CLIENT_ID,
-        client_secret=env.ENV_GITHUB_CLIENT_SECRET,
-        access_token_url='https://github.com/login/oauth/access_token',
-        authorize_url='https://github.com/login/oauth/authorize',
-        api_base_url='https://api.github.com/',
-        userinfo_endpoint='https://api.github.com/user',
-        client_kwargs={'scope': 'read:user user:email'},
-        redirect_uri='https://api.swissgpu.ch/auth/github',
-    )
-    AVAILABLE_AUTH_METHODS.append('github')
-else:
-    print('GitHub authentication not configured')
+def _oidc_enabled() -> bool:
+    return bool(env.ENV_OIDC_ISSUER and env.ENV_OIDC_CLIENT_ID and env.ENV_OIDC_CLIENT_SECRET)
 
-if env.DEV:
-    AVAILABLE_AUTH_METHODS.append('localhost')
+
+if _oidc_enabled():
+    oauth.register(
+        name='oidc',
+        client_id=env.ENV_OIDC_CLIENT_ID,
+        client_secret=env.ENV_OIDC_CLIENT_SECRET,
+        server_metadata_url=f"{env.ENV_OIDC_ISSUER.rstrip('/')}/.well-known/openid-configuration",
+        client_kwargs={'scope': env.ENV_OIDC_SCOPES},
+    )
+    AVAILABLE_AUTH_METHODS.append('oidc')
+else:
+    print('OIDC bridge authentication not configured')
 
 
 async def authuser(request: Request) -> db.User:

--- a/api/src/db/models/users.py
+++ b/api/src/db/models/users.py
@@ -1,24 +1,19 @@
 from datetime import datetime
-from sqlalchemy import String, Integer, DateTime, BigInteger, func
+from sqlalchemy import String, Integer, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column
 from src.db.models.__base__ import Base
 
 
 class User(Base):
-    """
-    Represent a user account in the platform.
+    '''Represent a user account authenticated via OIDC.'''
 
-    We don't support credential-based authentication directly; instead, users authenticate via OAuth providers.
-    """
     __tablename__ = 'users'
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(128), nullable=False)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     avatar: Mapped[str | None] = mapped_column(String(2048), nullable=True)
-
-    # Multiple providers can be linked to the same user account, so we store provider-specific IDs in separate columns.
-    oauth_github_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    oidc_subject: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
 
     # Timestamp informations
     date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())

--- a/api/src/db/services/users.py
+++ b/api/src/db/services/users.py
@@ -13,22 +13,34 @@ class UsersService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
-    async def create(
+    async def create_or_update_oidc_user(
         self,
-        name: str,
-        email: str,
-        avatar: str | None,
         *,
-        oauth_github_id: int | None,
+        oidc_subject: str,
+        email: str,
+        name: str,
+        avatar: str | None,
     ) -> User:
-        """Add a new user to the database and return the user."""
+        '''Create a new OIDC user or update an existing one.'''
 
-        if oauth_github_id is not None:
-            existing_user = await self.get(oauth_github_id, by='github')
-            if existing_user is not None:
-                return existing_user
-        else:
-            raise ValueError('An OAuth ID must be provided to create a user.')
+        existing_user = await self.get(oidc_subject, by='oidc_subject')
+        if existing_user is not None:
+            return await self.update(
+                existing_user.id,
+                email=email,
+                name=name,
+                avatar=avatar,
+                oidc_subject=oidc_subject,
+            ) or existing_user
+
+        user_by_email = await self.get(email, by='email')
+        if user_by_email is not None:
+            return await self.update(
+                user_by_email.id,
+                name=name,
+                avatar=avatar,
+                oidc_subject=oidc_subject,
+            ) or user_by_email
 
         Session = await get_session()
         async with Session() as session:
@@ -36,7 +48,7 @@ class UsersService:
                 name=name,
                 email=email,
                 avatar=avatar,
-                oauth_github_id=oauth_github_id,
+                oidc_subject=oidc_subject,
             )
 
             session.add(user)
@@ -45,14 +57,14 @@ class UsersService:
             return user
 
     async def get(self, param: int | str, *, by: str = 'id') -> User | None:
-        """Retrieve a user by id, email, or GitHub OAuth ID."""
+        '''Retrieve a user by id, email, or OIDC subject.'''
 
         Session = await get_session()
         async with Session() as session:
             if by == 'email':
                 result = await session.execute(select(User).where(User.email == param))
-            elif by == 'github':
-                result = await session.execute(select(User).where(User.oauth_github_id == param))
+            elif by == 'oidc_subject':
+                result = await session.execute(select(User).where(User.oidc_subject == param))
             elif by == 'id':
                 result = await session.execute(select(User).where(User.id == param))
             else:
@@ -61,7 +73,7 @@ class UsersService:
             return result.scalars().first()
 
     async def update(self, user_id: int, **params: str | int | None) -> User | None:
-        """Update a user and return the updated record."""
+        '''Update a user and return the updated record.'''
 
         Session = await get_session()
         async with Session() as session:

--- a/api/src/env.py
+++ b/api/src/env.py
@@ -10,9 +10,12 @@ class Env(BaseSettings):
     # Control plane database URL
     ENV_DATABASE_URL: str = 'sqlite+aiosqlite:///./dev.db'
 
-    # OAuth credentials
-    ENV_GITHUB_CLIENT_ID: str | None = None
-    ENV_GITHUB_CLIENT_SECRET: str | None = None
+    # OIDC bridge credentials
+    ENV_OIDC_CLIENT_ID: str | None = None
+    ENV_OIDC_CLIENT_SECRET: str | None = None
+    ENV_OIDC_ISSUER: str | None = None
+    ENV_OIDC_REDIRECT_URI: str = 'http://localhost:8000/auth/oidc'
+    ENV_OIDC_SCOPES: str = 'openid profile email'
 
     # Web URL used for auth redirects
     URL: str = 'http://localhost:5173'
@@ -27,9 +30,12 @@ class DevEnv(Env):
     # Control plane database URL
     ENV_DATABASE_URL: str = 'sqlite+aiosqlite:///./dev.db'
 
-    # OAuth credentials
-    ENV_GITHUB_CLIENT_ID: str | None = None
-    ENV_GITHUB_CLIENT_SECRET: str | None = None
+    # OIDC bridge credentials
+    ENV_OIDC_CLIENT_ID: str | None = None
+    ENV_OIDC_CLIENT_SECRET: str | None = None
+    ENV_OIDC_ISSUER: str | None = None
+    ENV_OIDC_REDIRECT_URI: str = 'http://localhost:8000/auth/oidc'
+    ENV_OIDC_SCOPES: str = 'openid profile email'
 
     # Web URL used for auth redirects
     URL: str = 'http://localhost:5173'

--- a/api/src/models/users.py
+++ b/api/src/models/users.py
@@ -12,4 +12,4 @@ class UserResponse(BaseModel):
     name: str
     email: EmailStr
     avatar: str | None = None
-    oauth_github_id: int | None = None
+    oidc_subject: str | None = None

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,5 +1,5 @@
 import src.db as db
-from typing import Any, cast
+from typing import cast
 from fastapi import Request, HTTPException
 from src.env import env
 from src.auth import AVAILABLE_AUTH_METHODS, oauth
@@ -13,84 +13,41 @@ async def login_methods() -> list[str]:
     return AVAILABLE_AUTH_METHODS
 
 
-@router.get('/login/github')
-async def login_github(request: Request):
-    if 'github' not in AVAILABLE_AUTH_METHODS:
+@router.get('/login/oidc')
+async def login_oidc(request: Request):
+    if 'oidc' not in AVAILABLE_AUTH_METHODS:
         raise HTTPException(404, 'Authentication method not available')
 
-    github = cast(StarletteOAuth2App, oauth.create_client('github'))
+    oidc = cast(StarletteOAuth2App, oauth.create_client('oidc'))
 
-    return await github.authorize_redirect(
+    return await oidc.authorize_redirect(
         request,
-        redirect_uri='http://localhost:8000/auth/github',
+        redirect_uri=env.ENV_OIDC_REDIRECT_URI,
     )
 
 
-@router.get('/auth/github')
-async def auth_github(request: Request):
-    if 'github' not in AVAILABLE_AUTH_METHODS:
+@router.get('/auth/oidc')
+async def auth_oidc(request: Request):
+    if 'oidc' not in AVAILABLE_AUTH_METHODS:
         raise HTTPException(404, 'Authentication method not available')
 
-    github = cast(StarletteOAuth2App, oauth.create_client('github'))
+    oidc = cast(StarletteOAuth2App, oauth.create_client('oidc'))
 
-    token = await github.authorize_access_token(request)
-    userinfo = await github.get('user', token=token)
+    token = await oidc.authorize_access_token(request)
+    userinfo = token.get('userinfo')
+    if userinfo is None:
+        userinfo = await oidc.userinfo(token=token)
 
-    github_user = userinfo.json()
-    email = github_user.get('email')
+    subject = str(userinfo['sub'])
+    email = userinfo.get('email') or f'{subject}@users.noreply.oidc'
+    name = userinfo.get('name') or userinfo.get('preferred_username') or email
 
-    if not email:
-        emails_response = await github.get('user/emails', token=token)
-        emails = cast(list[dict[str, Any]], emails_response.json())
-        primary_verified_email = next(
-            (
-                entry.get('email')
-                for entry in emails
-                if entry.get('primary') and entry.get('verified') and entry.get('email')
-            ),
-            None,
-        )
-        email = primary_verified_email
-
-    if not email:
-        email = '{}@users.noreply.github.com'.format(github_user.get('login') or github_user.get('id'))
-
-    # Ensure that the user exists in our database
-    user = await db.users.create(
-        name=github_user.get('name') or github_user.get('login'),
+    user = await db.users.create_or_update_oidc_user(
+        oidc_subject=subject,
         email=email,
-        avatar=github_user.get('avatar_url'),
-        oauth_github_id=github_user.get('id'),
+        name=name,
+        avatar=userinfo.get('picture'),
     )
-
-    request.session['userid'] = user.id
-    return RedirectResponse(env.URL)
-
-
-@router.get('/login/localhost')
-async def login_localhost(request: Request):
-    if not env.DEV or 'localhost' not in AVAILABLE_AUTH_METHODS:
-        raise HTTPException(404, 'Authentication method not available')
-
-    localhost_oauth_id = 0
-    localhost_email = 'localhost@longlick.ch'
-    localhost_name = 'Localhost User'
-
-    user = await db.users.get(localhost_oauth_id, by='github')
-    if user is None:
-        user = await db.users.get(localhost_email, by='email')
-
-    if user is None:
-        user = await db.users.create(
-            name=localhost_name,
-            email=localhost_email,
-            avatar=None,
-            oauth_github_id=localhost_oauth_id,
-        )
-    elif user.email != localhost_email:
-        updated_user = await db.users.update(user.id, email=localhost_email)
-        if updated_user is not None:
-            user = updated_user
 
     request.session['userid'] = user.id
     return RedirectResponse(env.URL)

--- a/api/src/routes/users.py
+++ b/api/src/routes/users.py
@@ -14,7 +14,7 @@ async def list_users(_: db.User = Depends(authuser)) -> list[UserResponse]:
             name=user.name,
             email=user.email,
             avatar=user.avatar,
-            oauth_github_id=user.oauth_github_id,
+            oidc_subject=user.oidc_subject,
         )
         for user in users
     ]

--- a/api/tests/test_hello.py
+++ b/api/tests/test_hello.py
@@ -1,5 +1,0 @@
-from src.hello import hello_world
-
-
-def test_hello_world() -> None:
-    assert 'hello world' == 'hello world'

--- a/api/tests/test_oidc_bridge_keycloak.py
+++ b/api/tests/test_oidc_bridge_keycloak.py
@@ -1,0 +1,131 @@
+import os
+import sys
+import time
+import uuid
+import httpx
+import pytest
+import importlib
+from pathlib import Path
+from docker.errors import DockerException
+from fastapi.testclient import TestClient
+from testcontainers.core.container import DockerContainer
+
+
+def _wait_for_keycloak_ready(base_url: str, timeout_seconds: int = 90) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            response = httpx.get(f'{base_url}/realms/master/.well-known/openid-configuration', timeout=2.0)
+            if response.status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        time.sleep(1)
+
+    raise TimeoutError('Keycloak did not become ready in time.')
+
+
+def _admin_token(base_url: str) -> str:
+    response = httpx.post(
+        f'{base_url}/realms/master/protocol/openid-connect/token',
+        data={
+            'grant_type': 'password',
+            'client_id': 'admin-cli',
+            'username': 'admin',
+            'password': 'admin',
+        },
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    return response.json()['access_token']
+
+
+def _setup_realm(base_url: str, realm: str, client_id: str, client_secret: str) -> None:
+    token = _admin_token(base_url)
+    headers = {'Authorization': f'Bearer {token}'}
+
+    realm_response = httpx.post(
+        f'{base_url}/admin/realms',
+        headers=headers,
+        json={'realm': realm, 'enabled': True},
+        timeout=10.0,
+    )
+    if realm_response.status_code not in (201, 409):
+        realm_response.raise_for_status()
+
+    client_payload = {
+        'clientId': client_id,
+        'enabled': True,
+        'protocol': 'openid-connect',
+        'publicClient': False,
+        'secret': client_secret,
+        'standardFlowEnabled': True,
+        'directAccessGrantsEnabled': True,
+        'redirectUris': [
+            'http://localhost:8000/auth/oidc',
+            'http://testserver/auth/oidc',
+        ],
+        'webOrigins': ['*'],
+    }
+    client_response = httpx.post(
+        f'{base_url}/admin/realms/{realm}/clients',
+        headers=headers,
+        json=client_payload,
+        timeout=10.0,
+    )
+    if client_response.status_code not in (201, 409):
+        client_response.raise_for_status()
+
+
+def _load_app_with_oidc(db_path: Path, issuer: str, client_id: str, client_secret: str):
+    os.environ['DEV'] = 'true'
+    os.environ['ENV_DATABASE_URL'] = f'sqlite+aiosqlite:///{db_path}'
+    os.environ['ENV_OIDC_ISSUER'] = issuer
+    os.environ['ENV_OIDC_CLIENT_ID'] = client_id
+    os.environ['ENV_OIDC_CLIENT_SECRET'] = client_secret
+    os.environ['ENV_OIDC_REDIRECT_URI'] = 'http://testserver/auth/oidc'
+
+    for module_name in ('main', 'src.auth', 'src.env', 'src.routes.auth'):
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+    module = importlib.import_module('main')
+    return module.app
+
+
+@pytest.mark.integration
+def test_pure_oidc_bridge_with_dedicated_control_plane_realm(tmp_path: Path) -> None:
+    realm = f'longlink-control-plane-{uuid.uuid4().hex[:8]}'
+    client_id = 'longlink-api'
+    client_secret = 'longlink-secret'
+
+    try:
+        container = DockerContainer('quay.io/keycloak/keycloak:26.1')
+        container.with_env('KEYCLOAK_ADMIN', 'admin')
+        container.with_env('KEYCLOAK_ADMIN_PASSWORD', 'admin')
+        container.with_exposed_ports(8080)
+        container.with_command('start-dev --http-port=8080')
+
+        with container:
+            host = container.get_container_host_ip()
+            port = container.get_exposed_port(8080)
+            base_url = f'http://{host}:{port}'
+
+            _wait_for_keycloak_ready(base_url)
+            _setup_realm(base_url, realm, client_id, client_secret)
+
+            issuer = f'{base_url}/realms/{realm}'
+            app = _load_app_with_oidc(tmp_path / 'oidc.db', issuer, client_id, client_secret)
+
+            with TestClient(app) as client:
+                methods = client.get('/login')
+                assert methods.status_code == 200
+                assert methods.json() == ['oidc']
+
+                login_redirect = client.get('/login/oidc', follow_redirects=False)
+                assert login_redirect.status_code in (302, 307)
+                redirect_location = login_redirect.headers['location']
+                assert f'/realms/{realm}/protocol/openid-connect/auth' in redirect_location
+                assert f'client_id={client_id}' in redirect_location
+    except DockerException as exc:  # pragma: no cover - integration env dependent
+        pytest.skip(f'Keycloak integration requires a running docker daemon: {exc}')


### PR DESCRIPTION
### Motivation
- Consolidate authentication to a pure OIDC bridge (Authlib) configured via environment variables to support enterprise IdPs and avoid custom provider-specific logic. 
- Treat each LongLink control-plane instance as an isolated realm during testing by provisioning a dedicated Keycloak realm for integration validation. 

### Description
- Replace the existing GitHub/localhost OAuth flows with a single Authlib OIDC bridge using issuer discovery and environment-backed configuration (`ENV_OIDC_ISSUER`, `ENV_OIDC_CLIENT_ID`, `ENV_OIDC_CLIENT_SECRET`, `ENV_OIDC_REDIRECT_URI`, `ENV_OIDC_SCOPES`).
- Expose `/login/oidc` and `/auth/oidc` routes that perform authorization redirect, token exchange, userinfo resolution and session establishment. 
- Migrate user persistence to store `oidc_subject` (DB model and Pydantic responses) and add a service `create_or_update_oidc_user` to upsert by subject/email. 
- Add an integration test `tests/test_oidc_bridge_keycloak.py` which uses Testcontainers to install Keycloak, create a dedicated control-plane realm and client, and assert the OIDC redirect flow; register an `integration` pytest marker and document the new env vars in `api/README.md`; remove the obsolete placeholder test. 

### Testing
- Ran import/formatting with `python -m isort .` which completed successfully. 
- Ran the test suite with `pytest -q` where the integration test is skipped when a Docker daemon is unavailable, and the suite completed with the integration test being skipped (no failing tests locally). 
- The Keycloak test is designed to be skipped in CI environments without Docker and will run end-to-end when a docker daemon is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2974538c08323bdf892b8ab6d05c5)