### PR TITLE
Add Makefile helpers for local Docker/k3d setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: up down
+
+up:
+	docker compose up -d
+	k3d cluster create compute --api-port 6550 || true
+
+down:
+	docker compose down
+	k3d cluster delete compute

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ bun run sdk
 bun run api
 ```
 
+## Local Infrastructure Setup
+
+Use the root `Makefile` to start and stop local infrastructure services:
+
+```bash
+make up
+```
+
+This command:
+
+- starts Docker Compose services in detached mode
+- creates the `compute` k3d cluster on API port `6550` (and ignores the error if it already exists)
+
+To stop services and remove the cluster:
+
+```bash
+make down
+```
+
 ## Git Hooks (Lefthook)
 
 Install Lefthook and enable repository hooks:


### PR DESCRIPTION
### Motivation

- Provide a small, discoverable CLI for starting and stopping local infrastructure instead of embedding cluster lifecycle logic in other tooling.
- Make cluster creation idempotent and easy to run for local development by wrapping `docker compose` and `k3d` commands.

### Description

- Add a root `Makefile` with `up` and `down` targets that run `docker compose up -d` / `docker compose down` and create/delete the `compute` k3d cluster with `k3d cluster create compute --api-port 6550 || true` and `k3d cluster delete compute` respectively.
- Update `README.md` to include a **Local Infrastructure Setup** section showing `make up` and `make down` usage and explaining what each command does.

### Testing

- Ran `make -n up` to verify the `up` target commands are correct, which succeeded.
- Ran `make -n down` to verify the `down` target commands are correct, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d9c9b9b483238f823394e0627ba8)