### PR TITLE
Configure local OIDC bridge defaults for Keycloak development

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,3 +18,14 @@ The API uses a pure OIDC bridge based on Authlib and expects these variables:
 - `ENV_OIDC_CLIENT_SECRET`
 - `ENV_OIDC_REDIRECT_URI` (default: `http://localhost:8000/auth/oidc`)
 - `ENV_OIDC_SCOPES` (default: `openid profile email`)
+
+### Local development defaults (Keycloak)
+
+When `DEV=true`, the API now defaults to local Keycloak bridge credentials:
+
+- `ENV_OIDC_ISSUER=http://localhost:18080/realms/longlink-control-plane`
+- `ENV_OIDC_CLIENT_ID=longlink-api`
+- `ENV_OIDC_CLIENT_SECRET=longlink-secret`
+
+If you run Keycloak directly on your machine (for example on `localhost:8080`) instead of the
+repository `compose.yml`, override `ENV_OIDC_ISSUER` in `api/.env`.

--- a/api/src/env.py
+++ b/api/src/env.py
@@ -31,9 +31,9 @@ class DevEnv(Env):
     ENV_DATABASE_URL: str = 'sqlite+aiosqlite:///./dev.db'
 
     # OIDC bridge credentials
-    ENV_OIDC_CLIENT_ID: str | None = None
-    ENV_OIDC_CLIENT_SECRET: str | None = None
-    ENV_OIDC_ISSUER: str | None = None
+    ENV_OIDC_CLIENT_ID: str | None = 'longlink-api'
+    ENV_OIDC_CLIENT_SECRET: str | None = 'longlink-secret'
+    ENV_OIDC_ISSUER: str | None = 'http://localhost:18080/realms/longlink-control-plane'
     ENV_OIDC_REDIRECT_URI: str = 'http://localhost:8000/auth/oidc'
     ENV_OIDC_SCOPES: str = 'openid profile email'
 


### PR DESCRIPTION
### Motivation
- Provide sensible OIDC bridge defaults for local development so the API works out-of-the-box with the repository Keycloak service when `DEV=true`.

### Description
- Set `DevEnv` defaults for `ENV_OIDC_ISSUER`, `ENV_OIDC_CLIENT_ID`, and `ENV_OIDC_CLIENT_SECRET` in `api/src/env.py` and document these local Keycloak defaults and an override note in `api/README.md`.

### Testing
- Ran `python -m isort .` in `api/` and the pre-commit hook (`python-format-api`) executed successfully during commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d531fd864c8323ba371d518bd546f7)