### PR TITLE
Require OIDC bridge, add Keycloak dev defaults, and switch UI to OIDC SSO

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,3 +18,14 @@ The API uses a pure OIDC bridge based on Authlib and expects these variables:
 - `ENV_OIDC_CLIENT_SECRET`
 - `ENV_OIDC_REDIRECT_URI` (default: `http://localhost:8000/auth/oidc`)
 - `ENV_OIDC_SCOPES` (default: `openid profile email`)
+
+### Local development defaults (Keycloak)
+
+When `DEV=true`, the API now defaults to local Keycloak bridge credentials:
+
+- `ENV_OIDC_ISSUER=http://localhost:18080/realms/longlink-control-plane`
+- `ENV_OIDC_CLIENT_ID=longlink-api`
+- `ENV_OIDC_CLIENT_SECRET=longlink-secret`
+
+If you run Keycloak directly on your machine (for example on `localhost:8080`) instead of the
+repository `compose.yml`, override `ENV_OIDC_ISSUER` in `api/.env`.

--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -4,24 +4,22 @@ from src.env import env
 from authlib.integrations.starlette_client import OAuth
 
 oauth = OAuth()
-AVAILABLE_AUTH_METHODS: list[str] = []
 
 
 def _oidc_enabled() -> bool:
     return bool(env.ENV_OIDC_ISSUER and env.ENV_OIDC_CLIENT_ID and env.ENV_OIDC_CLIENT_SECRET)
 
 
-if _oidc_enabled():
-    oauth.register(
-        name='oidc',
-        client_id=env.ENV_OIDC_CLIENT_ID,
-        client_secret=env.ENV_OIDC_CLIENT_SECRET,
-        server_metadata_url=f"{env.ENV_OIDC_ISSUER.rstrip('/')}/.well-known/openid-configuration",
-        client_kwargs={'scope': env.ENV_OIDC_SCOPES},
-    )
-    AVAILABLE_AUTH_METHODS.append('oidc')
-else:
-    print('OIDC bridge authentication not configured')
+if not _oidc_enabled():
+    raise RuntimeError('OIDC bridge authentication is required but not configured.')
+
+oauth.register(
+    name='oidc',
+    client_id=env.ENV_OIDC_CLIENT_ID,
+    client_secret=env.ENV_OIDC_CLIENT_SECRET,
+    server_metadata_url=f"{env.ENV_OIDC_ISSUER.rstrip('/')}/.well-known/openid-configuration",
+    client_kwargs={'scope': env.ENV_OIDC_SCOPES},
+)
 
 
 async def authuser(request: Request) -> db.User:

--- a/api/src/env.py
+++ b/api/src/env.py
@@ -31,9 +31,9 @@ class DevEnv(Env):
     ENV_DATABASE_URL: str = 'sqlite+aiosqlite:///./dev.db'
 
     # OIDC bridge credentials
-    ENV_OIDC_CLIENT_ID: str | None = None
-    ENV_OIDC_CLIENT_SECRET: str | None = None
-    ENV_OIDC_ISSUER: str | None = None
+    ENV_OIDC_CLIENT_ID: str | None = 'longlink-api'
+    ENV_OIDC_CLIENT_SECRET: str | None = 'longlink-secret'
+    ENV_OIDC_ISSUER: str | None = 'http://localhost:18080/realms/longlink-control-plane'
     ENV_OIDC_REDIRECT_URI: str = 'http://localhost:8000/auth/oidc'
     ENV_OIDC_SCOPES: str = 'openid profile email'
 

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,8 +1,8 @@
 import src.db as db
 from typing import cast
-from fastapi import Request, HTTPException
+from fastapi import Request
 from src.env import env
-from src.auth import AVAILABLE_AUTH_METHODS, oauth
+from src.auth import oauth
 from src.router import router
 from fastapi.responses import RedirectResponse
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
@@ -10,14 +10,11 @@ from authlib.integrations.starlette_client.apps import StarletteOAuth2App
 
 @router.get('/login')
 async def login_methods() -> list[str]:
-    return AVAILABLE_AUTH_METHODS
+    return ['oidc']
 
 
 @router.get('/login/oidc')
 async def login_oidc(request: Request):
-    if 'oidc' not in AVAILABLE_AUTH_METHODS:
-        raise HTTPException(404, 'Authentication method not available')
-
     oidc = cast(StarletteOAuth2App, oauth.create_client('oidc'))
 
     return await oidc.authorize_redirect(
@@ -28,9 +25,6 @@ async def login_oidc(request: Request):
 
 @router.get('/auth/oidc')
 async def auth_oidc(request: Request):
-    if 'oidc' not in AVAILABLE_AUTH_METHODS:
-        raise HTTPException(404, 'Authentication method not available')
-
     oidc = cast(StarletteOAuth2App, oauth.create_client('oidc'))
 
     token = await oidc.authorize_access_token(request)

--- a/web/src/pages/user/Login.tsx
+++ b/web/src/pages/user/Login.tsx
@@ -1,6 +1,6 @@
-import { Chrome, Github, Layers } from 'lucide-react';
+import { ArrowRight, Layers, ShieldCheck } from 'lucide-react';
 import { Button } from '@/ui/button';
-import { Card, CardContent } from '@/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { apiFetch, getApiBaseUrl } from '@/lib/api';
@@ -63,42 +63,51 @@ export default function Login() {
         };
     }, []);
 
-    const hasGoogleMethod = availableMethods.includes('google');
-    const hasGithubMethod = availableMethods.includes('github');
+    const hasOidcMethod = availableMethods.includes('oidc');
 
-    const handleGithubLogin = () => {
-        window.location.href = `${apiBaseUrl}/login/github`;
+    const handleOidcLogin = () => {
+        window.location.href = `${apiBaseUrl}/login/oidc`;
     };
 
     return (
         <div className="flex min-h-screen items-center justify-center px-6 py-12 text-white">
             <Card className="w-full max-w-md border-white/10 bg-white/5">
-                <CardContent className="space-y-6 p-8">
-                    <div className="space-y-2 text-center">
+                <CardHeader className="space-y-4 text-center">
+                    <div className="space-y-2">
                         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-600/20 text-blue-300">
                             <Layers className="h-6 w-6" />
                         </div>
-                        <h1 className="text-2xl font-semibold">Welcome back</h1>
-                        <p className="text-sm text-white/60">Choose a provider to continue to Longlink.</p>
+                        <CardTitle className="text-2xl">Welcome back</CardTitle>
+                        <CardDescription className="text-white/60">
+                            Sign in with your organization identity provider.
+                        </CardDescription>
                     </div>
+                </CardHeader>
 
+                <CardContent className="space-y-4 p-8 pt-0">
+                    <div className="rounded-lg border border-blue-400/30 bg-blue-500/10 p-3 text-sm text-blue-100">
+                        <div className="flex items-center gap-2 font-medium">
+                            <ShieldCheck className="h-4 w-4" />
+                            OIDC secure login
+                        </div>
+                        <p className="mt-1 text-xs text-blue-100/80">
+                            You will be redirected to the configured OpenID Connect provider to authenticate.
+                        </p>
+                    </div>
                     <div className="grid gap-3">
                         <Button
-                            className="h-11 gap-2 bg-white text-slate-900 hover:bg-white/90"
-                            disabled={!hasGoogleMethod}
+                            className="h-11 justify-between gap-2 bg-white text-slate-900 hover:bg-white/90"
+                            disabled={!hasOidcMethod}
+                            onClick={handleOidcLogin}
                         >
-                            <Chrome className="h-4 w-4" />
-                            Login with Google
+                            Continue with Single Sign-On
+                            <ArrowRight className="h-4 w-4" />
                         </Button>
-                        <Button
-                            variant="outline"
-                            className="h-11 gap-2"
-                            disabled={!hasGithubMethod}
-                            onClick={handleGithubLogin}
-                        >
-                            <Github className="h-4 w-4" />
-                            Login with GitHub
-                        </Button>
+                        {!hasOidcMethod && (
+                            <p className="text-center text-xs text-amber-300">
+                                OIDC login is unavailable. Verify API OIDC bridge configuration.
+                            </p>
+                        )}
                     </div>
                 </CardContent>
             </Card>


### PR DESCRIPTION
### Motivation

- Ensure the API always has a configured OpenID Connect bridge and provide sane defaults for local Keycloak development.
- Simplify authentication surface to a single OIDC provider and reflect that in the login UI.

### Description

- Make OIDC mandatory by raising `RuntimeError` in `src/auth.py` when `ENV_OIDC_*` variables are missing and always register the `oidc` client with `authlib`.
- Add local Keycloak defaults in `api/src/env.py` `DevEnv` (`ENV_OIDC_ISSUER=http://localhost:18080/realms/longlink-control-plane`, `ENV_OIDC_CLIENT_ID=longlink-api`, `ENV_OIDC_CLIENT_SECRET=longlink-secret`).
- Remove the `AVAILABLE_AUTH_METHODS` mechanism and corresponding runtime checks, and make `/login` return `['oidc']` while `/login/oidc` and `/auth/oidc` always use the registered `oidc` client (`api/src/routes/auth.py`).
- Update frontend login page `web/src/pages/user/Login.tsx` to present a single OIDC SSO flow with updated card layout and a button that redirects to `/login/oidc`, and show an inline message when OIDC is unavailable.
- Update `api/README.md` with a new "Local development defaults (Keycloak)" section describing the default env vars and advice for overriding `ENV_OIDC_ISSUER`.

### Testing

- No automated tests were added or modified for this change and no automated test run was executed as part of this rollout; please run the repository CI (unit tests, type checks, and linting) to validate integration with your environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d531fd864c8323ba371d518bd546f7)