### PR TITLE
Import Keycloak dev realm and add OIDC error handling

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -29,3 +29,6 @@ When `DEV=true`, the API now defaults to local Keycloak bridge credentials:
 
 If you run Keycloak directly on your machine (for example on `localhost:8080`) instead of the
 repository `compose.yml`, override `ENV_OIDC_ISSUER` in `api/.env`.
+
+`compose.yml` imports a development `longlink-control-plane` realm automatically
+on startup, including the `longlink-api` client and `longlink-secret` credentials.

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,6 +1,7 @@
+import httpx
 import src.db as db
 from typing import cast
-from fastapi import Request
+from fastapi import Request, HTTPException
 from src.env import env
 from src.auth import oauth
 from src.router import router
@@ -17,17 +18,33 @@ async def login_methods() -> list[str]:
 async def login_oidc(request: Request):
     oidc = cast(StarletteOAuth2App, oauth.create_client('oidc'))
 
-    return await oidc.authorize_redirect(
-        request,
-        redirect_uri=env.ENV_OIDC_REDIRECT_URI,
-    )
+    try:
+        return await oidc.authorize_redirect(
+            request,
+            redirect_uri=env.ENV_OIDC_REDIRECT_URI,
+        )
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                'OIDC provider metadata is unavailable. '
+                'Check ENV_OIDC_ISSUER and provider realm configuration.'
+            ),
+        ) from exc
 
 
 @router.get('/auth/oidc')
 async def auth_oidc(request: Request):
     oidc = cast(StarletteOAuth2App, oauth.create_client('oidc'))
 
-    token = await oidc.authorize_access_token(request)
+    try:
+        token = await oidc.authorize_access_token(request)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail='OIDC token exchange failed. Verify provider URL and client credentials.',
+        ) from exc
+
     userinfo = token.get('userinfo')
     if userinfo is None:
         userinfo = await oidc.userinfo(token=token)

--- a/compose.yml
+++ b/compose.yml
@@ -26,10 +26,12 @@ services:
     image: quay.io/keycloak/keycloak:25.0
     container_name: longlink-keycloak
     restart: unless-stopped
-    command: start-dev --http-port=8080
+    command: start-dev --http-port=8080 --import-realm
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_DB: dev-file
     ports:
       - "18080:8080"
+    volumes:
+      - ./keycloak-realm-longlink-control-plane.json:/opt/keycloak/data/import/longlink-control-plane.json:ro

--- a/keycloak-realm-longlink-control-plane.json
+++ b/keycloak-realm-longlink-control-plane.json
@@ -1,0 +1,23 @@
+{
+  "realm": "longlink-control-plane",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "longlink-api",
+      "name": "longlink-api",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "longlink-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8000/auth/oidc"
+      ],
+      "webOrigins": [
+        "http://localhost:8000"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a reproducible local Keycloak setup with preconfigured client credentials for OIDC development. 
- Make OIDC failures in the auth flow surface as clear HTTP 502 errors instead of unhandled exceptions.

### Description

- Added `keycloak-realm-longlink-control-plane.json` that defines the `longlink-control-plane` realm and the `longlink-api` client with secret `longlink-secret` and redirect URI `http://localhost:8000/auth/oidc`.
- Updated `compose.yml` to start Keycloak with `--import-realm` and mount the realm file at `/opt/keycloak/data/import/longlink-control-plane.json` so the realm is imported on container startup.
- Updated `api/README.md` to document local development OIDC defaults and note that `compose.yml` imports the realm and credentials automatically.
- Added HTTP error handling in `api/src/routes/auth.py` by importing `httpx` and catching `httpx.HTTPStatusError` around `authorize_redirect` and `authorize_access_token`, returning `HTTPException` with `502` and explanatory messages.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d541f732008323a089b109f962f794)