### PR TITLE
Add GitHub Pages workflow to build and deploy docs on merged main PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,61 @@
+name: Docs
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: docs
+        run: bun install --frozen-lockfile
+
+      - name: Build docs
+        working-directory: docs
+        run: bun run build
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    if: github.event.pull_request.merged == true
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Provide an automated pipeline to build the VitePress docs and publish them to GitHub Pages when documentation changes are merged into `main`. 
- Limit CI runs to only when a pull request targeting `main` is closed and merged and the changes include the `docs/**` path (or the workflow itself). 

### Description
- Adds `.github/workflows/docs.yml` which triggers on `pull_request` `closed` events for branch `main` and paths `docs/**` and `.github/workflows/docs.yml`. 
- The workflow checks `if: github.event.pull_request.merged == true`, sets `permissions` for `pages` and `id-token`, and configures `concurrency` to avoid overlapping deploys. 
- Build job uses `oven-sh/setup-bun@v2`, runs `bun install --frozen-lockfile` and `bun run build` in the `docs` directory, and uploads `docs/.vitepress/dist` via `actions/upload-pages-artifact@v4`. 
- Deploy job depends on the build and runs `actions/deploy-pages@v4` to publish the uploaded artifact to the `github-pages` environment. 

### Testing
- Validated the workflow file is valid YAML by parsing it with `python` using `yaml.safe_load`, and the parse succeeded. 
- The workflow file was added to the repository and committed as part of the change (no CI run was executed as part of this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54bc4c57083238c5d36d83a7f5c1a)