### PR TITLE
Improve OIDC userinfo fallbacks, add dev Keycloak user fields, and support request credentials in API client

### DIFF
--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -50,8 +50,14 @@ async def auth_oidc(request: Request):
         userinfo = await oidc.userinfo(token=token)
 
     subject = str(userinfo['sub'])
-    email = userinfo.get('email') or f'{subject}@users.noreply.oidc'
-    name = userinfo.get('name') or userinfo.get('preferred_username') or email
+    given_name = userinfo.get('given_name') or 'Example'
+    family_name = userinfo.get('family_name') or 'LongLink'
+    email = userinfo.get('email') or 'example@longlink.dev'
+    name = (
+        userinfo.get('name')
+        or userinfo.get('preferred_username')
+        or f'{given_name} {family_name}'
+    )
 
     user = await db.users.create_or_update_oidc_user(
         oidc_subject=subject,

--- a/dev/keycloak-realm-dev.json
+++ b/dev/keycloak-realm-dev.json
@@ -25,6 +25,9 @@
       "username": "admin",
       "enabled": true,
       "emailVerified": true,
+      "firstName": "Example",
+      "lastName": "LongLink",
+      "email": "example@longlink.dev",
       "credentials": [
         {
           "type": "password",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,7 @@ export const getApiBaseUrl = () => normalizeBaseUrl(apiBaseUrl);
 
 type QueryValue = string | number | boolean | null | undefined;
 export type ApiQueryParams = Record<string, QueryValue>;
+type RequestCredentialsMode = 'omit' | 'same-origin' | 'include';
 
 export type ApiRequestOptions<TBody = unknown> = Omit<
     AxiosRequestConfig<TBody>,
@@ -20,6 +21,7 @@ export type ApiRequestOptions<TBody = unknown> = Omit<
     body?: TBody;
     query?: ApiQueryParams;
     appName?: string;
+    credentials?: RequestCredentialsMode;
 };
 
 const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, '');
@@ -78,7 +80,8 @@ const toApiErrorMessage = (error: AxiosError) => {
 };
 
 export async function apiFetch<TResponse>(path: string, options: ApiRequestOptions = {}): Promise<TResponse> {
-    const { query, body, appName, ...config } = options;
+    const { query, body, appName, credentials, ...config } = options;
+    const withCredentials = credentials === 'include';
 
     try {
         const response = await axios.request<string>({
@@ -86,6 +89,7 @@ export async function apiFetch<TResponse>(path: string, options: ApiRequestOptio
             url: normalizePath(path, appName),
             params: query,
             data: body,
+            withCredentials,
             responseType: 'text',
             headers: {
                 Accept: 'application/json',


### PR DESCRIPTION
### Motivation
- Provide more realistic default user attributes when the OIDC provider omits `name`, `given_name`, `family_name`, or `email` to avoid creating users with placeholder noreply addresses.
- Ensure the local development Keycloak fixture contains the same `firstName`, `lastName`, and `email` used as fallbacks to simplify local testing.
- Allow the frontend API wrapper to send credentials (cookies) for authenticated requests when needed.

### Description
- Updated `api/src/routes/auth.py` to derive `name` from `userinfo` using `given_name` and `family_name` fallbacks and to use a stable default email (`example@longlink.dev`) instead of `@users.noreply.oidc`.
- Added `firstName`, `lastName`, and `email` fields to the `admin` user in `dev/keycloak-realm-dev.json` to match the new OIDC fallback values.
- Extended `web/src/lib/api.ts` with a `RequestCredentialsMode` type and an optional `credentials` option on `ApiRequestOptions`, mapping `credentials: 'include'` to Axios `withCredentials` to enable cookie-bearing requests.

### Testing
- Ran the existing automated test suite for both backend and frontend and verified that tests and type checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54b0992388323b6337f9d83891d45)