### PR TITLE
Fix dynamic Lucide icon rendering in web hero icons

### DIFF
--- a/web/src/longlink/Icon.tsx
+++ b/web/src/longlink/Icon.tsx
@@ -1,38 +1,42 @@
 import React, { Suspense } from 'react';
-import type { LucideProps, LucideIcon } from 'lucide-react';
-
-type IconModule = {
-    default: LucideIcon;
-};
-
-const iconImporters = import.meta.glob<IconModule>('/node_modules/lucide-react/dist/esm/icons/*.js');
-const lazyIcons: Record<string, React.LazyExoticComponent<LucideIcon>> = {};
-
-// Build once at module load
-for (const path in iconImporters) {
-    const match = path.match(/icons\/(.*)\.js$/);
-    if (!match) continue;
-
-    const iconName = match[1]; // already kebab-case
-    lazyIcons[iconName] = React.lazy(iconImporters[path]);
-}
+import type { LucideIcon, LucideProps } from 'lucide-react';
+import dynamicIconImports from 'lucide-react/dynamicIconImports';
 
 type IconProps = LucideProps & {
     name: string;
     fallback?: string;
 };
 
+const lazyIcons: Record<string, React.LazyExoticComponent<LucideIcon>> = {};
+
+function resolveLazyIcon(name: string): React.LazyExoticComponent<LucideIcon> | undefined {
+    if (lazyIcons[name]) {
+        return lazyIcons[name];
+    }
+
+    const importer = dynamicIconImports[name as keyof typeof dynamicIconImports];
+
+    if (!importer) {
+        return undefined;
+    }
+
+    const lazyIcon = React.lazy(importer as () => Promise<{ default: LucideIcon }>);
+    lazyIcons[name] = lazyIcon;
+
+    return lazyIcon;
+}
+
 /* 
     Simple icon component that dynamically imports icons from lucide-react based on the provided name prop.
 */
-export function Icon({ name, fallback = 'box' }: IconProps) {
-    const Component = lazyIcons[name] ?? lazyIcons[fallback];
+export function Icon({ name, fallback = 'box', ...props }: IconProps) {
+    const Component = resolveLazyIcon(name) ?? resolveLazyIcon(fallback);
 
     if (!Component) return null;
 
     return (
         <Suspense fallback={null}>
-            <Component />
+            <Component {...props} />
         </Suspense>
     );
 }


### PR DESCRIPTION
### Motivation
- Hero and menu icons stopped rendering because the prior icon loader used a fragile `import.meta.glob` over `node_modules` which didn't reliably resolve Lucide icons.
- Replace the fragile loader with the library-provided dynamic imports to ensure icons load consistently at runtime.

### Description
- Replaced the `import.meta.glob` approach with `lucide-react/dynamicIconImports` in `web/src/longlink/Icon.tsx` to resolve icons via the package's dynamic importer.
- Implemented a cached `resolveLazyIcon(name)` that lazily creates and reuses `React.lazy` components per icon name.
- Preserved a `fallback` icon (`box`) and made the component forward all `Lucide` props (`className`, `size`, etc.) to the rendered icon.
- The change keeps suspense fallback usage and returns `null` when no icon can be resolved.

### Testing
- Ran formatting with `cd web && bun run format`, which completed successfully.
- Built the web app with `cd web && bun run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55105f1008323b9a15fee5fbc78aa)