### PR TITLE
fix(web): use filtered /apps endpoint for Tools/Spaces/Processes

### DIFF
--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -38,21 +38,30 @@ export function useCreateApp() {
 
 export function useTools() {
     return useQuery({
-        queryKey: ['tools'],
-        queryFn: () => apiFetch<App[]>('/tools'),
+        queryKey: ['apps', 'tool'],
+        queryFn: () =>
+            apiFetch<App[]>('/apps', {
+                query: { type: 'tool' },
+            }),
     });
 }
 
 export function useSpaces() {
     return useQuery({
-        queryKey: ['spaces'],
-        queryFn: () => apiFetch<App[]>('/spaces'),
+        queryKey: ['apps', 'space'],
+        queryFn: () =>
+            apiFetch<App[]>('/apps', {
+                query: { type: 'space' },
+            }),
     });
 }
 
 export function useProcesses() {
     return useQuery({
-        queryKey: ['processes'],
-        queryFn: () => apiFetch<App[]>('/processes'),
+        queryKey: ['apps', 'process'],
+        queryFn: () =>
+            apiFetch<App[]>('/apps', {
+                query: { type: 'process' },
+            }),
     });
 }

--- a/web/src/pages/org/Processes.tsx
+++ b/web/src/pages/org/Processes.tsx
@@ -58,7 +58,7 @@ export default function Processes() {
                     </Empty>
                 </Card>
             ) : (
-                <Table endpoint="/processes" schema={tableSchema} />
+                <Table endpoint="/apps?type=process" schema={tableSchema} />
             )}
         </div>
     );

--- a/web/src/pages/org/Spaces.tsx
+++ b/web/src/pages/org/Spaces.tsx
@@ -58,7 +58,7 @@ export default function Spaces() {
                     </Empty>
                 </Card>
             ) : (
-                <Table endpoint="/spaces" schema={tableSchema} />
+                <Table endpoint="/apps?type=space" schema={tableSchema} />
             )}
         </div>
     );

--- a/web/src/pages/org/Tools.tsx
+++ b/web/src/pages/org/Tools.tsx
@@ -56,7 +56,7 @@ export default function Tools() {
                     </Empty>
                 </Card>
             ) : (
-                <Table endpoint="/tools" schema={tableSchema} />
+                <Table endpoint="/apps?type=tool" schema={tableSchema} />
             )}
         </div>
     );


### PR DESCRIPTION
### Motivation
- The org tabs were calling nonexistent top-level endpoints (`/tools`, `/spaces`, `/processes`) instead of the backend's consolidated `/apps` endpoint with a `type` filter, causing Not Found errors and inconsistent data sources.

### Description
- Updated `useTools`, `useSpaces`, and `useProcesses` in `web/src/hooks/use-apps.ts` to call `GET /apps` with `query: { type: 'tool' | 'space' | 'process' }` and adjusted query keys to `['apps', '<type>']`.
- Changed table data endpoints in the org pages to use `Table endpoint="/apps?type=tool"`, `"/apps?type=space"`, and `"/apps?type=process"` in `web/src/pages/org/Tools.tsx`, `Spaces.tsx`, and `Processes.tsx` so list views and counts use the same backend contract.
- Kept existing `useApps` and `useCreateApp` behaviour unchanged so global app listing and creation still use `/apps`.
- Ran project formatting and build to ensure the changes integrate cleanly into the frontend.

### Testing
- Ran `bun run format`, which completed successfully.
- Ran `bun run build`, which completed successfully and produced a production build without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5512274ac8323964295410d23459b)