### PR TITLE
Add database connection management and database creation endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -41,6 +41,7 @@ import src.routes.auth
 import src.routes.user
 import src.routes.users
 import src.routes.settings
+import src.routes.databases
 
 app.include_router(router)
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     'pydantic==2.12.5',
     'pydantic-settings',
     'python-dotenv==1.2.1',
+    'psycopg2-binary==2.9.11',
     'sqlalchemy==2.0.46',
     'starlette==0.52.1',
     'uvicorn==0.40.0',
@@ -33,7 +34,6 @@ dev = [
     'pytest==8.4.2',
     'isort==8.0.1',
     'testcontainers[postgres]==4.13.2',
-    'psycopg2-binary==2.9.11',
 ]
 
 [tool.setuptools]

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,9 +1,11 @@
-from .models import App, Env, User, Setting, Permission
+from .models import App, Env, User, Setting, Permission, DatabaseConnection
 from .services import (AppsService, EnvsService, UsersService, SettingsService,
-                       PermissionsService)
+                       DatabasesService, PermissionsService)
 
 apps = AppsService()
 envs = EnvsService()
 settings = SettingsService()
 users = UsersService()
 permissions = PermissionsService()
+
+databases = DatabasesService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -4,4 +4,5 @@ from .envs import Env
 from .users import User
 from .__base__ import Base
 from .settings import Setting
+from .databases import DatabaseConnection
 from .permissions import Permission

--- a/api/src/db/models/databases.py
+++ b/api/src/db/models/databases.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from sqlalchemy import String, Integer, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class DatabaseConnection(Base):
+    '''Represent external superuser database credentials managed by the control panel.'''
+
+    __tablename__ = 'database_connections'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    host: Mapped[str] = mapped_column(String(255), nullable=False)
+    port: Mapped[int] = mapped_column(Integer, nullable=False, default=5432)
+    username: Mapped[str] = mapped_column(String(128), nullable=False)
+    password: Mapped[str] = mapped_column(String(255), nullable=False)
+    maintenance_database: Mapped[str] = mapped_column(String(128), nullable=False, default='postgres')
+    sslmode: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -2,4 +2,5 @@ from .apps import AppsService
 from .envs import EnvsService
 from .users import UsersService
 from .settings import SettingsService
+from .databases import DatabasesService
 from .permissions import PermissionsService

--- a/api/src/db/services/databases.py
+++ b/api/src/db/services/databases.py
@@ -1,0 +1,101 @@
+import re
+import asyncio
+import psycopg2
+from psycopg2 import sql
+from sqlalchemy import select
+from src.db.models import DatabaseConnection
+from src.db.session import get_session
+
+_DATABASE_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+
+class DatabasesService:
+    async def list(self) -> list[DatabaseConnection]:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(DatabaseConnection))
+            return list(result.scalars().all())
+
+    async def get(self, name: str) -> DatabaseConnection | None:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(DatabaseConnection).where(DatabaseConnection.name == name))
+            return result.scalar_one_or_none()
+
+    async def set(
+        self,
+        *,
+        name: str,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        maintenance_database: str,
+        sslmode: str | None,
+    ) -> DatabaseConnection:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(DatabaseConnection).where(DatabaseConnection.name == name))
+            connection = result.scalar_one_or_none()
+
+            if connection is None:
+                connection = DatabaseConnection(
+                    name=name,
+                    host=host,
+                    port=port,
+                    username=username,
+                    password=password,
+                    maintenance_database=maintenance_database,
+                    sslmode=sslmode,
+                )
+                session.add(connection)
+            else:
+                connection.host = host
+                connection.port = port
+                connection.username = username
+                connection.password = password
+                connection.maintenance_database = maintenance_database
+                connection.sslmode = sslmode
+
+            await session.commit()
+            await session.refresh(connection)
+            return connection
+
+    async def delete(self, name: str) -> bool:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(DatabaseConnection).where(DatabaseConnection.name == name))
+            connection = result.scalar_one_or_none()
+            if connection is None:
+                return False
+
+            await session.delete(connection)
+            await session.commit()
+            return True
+
+    async def create_database(self, *, connection: DatabaseConnection, database_name: str) -> None:
+        if not _DATABASE_NAME_PATTERN.fullmatch(database_name):
+            raise ValueError('Database name must start with a letter/underscore and contain only letters, numbers, and underscores')
+
+        await asyncio.to_thread(self._create_database_sync, connection, database_name)
+
+    @staticmethod
+    def _create_database_sync(connection: DatabaseConnection, database_name: str) -> None:
+        connection_kwargs: dict[str, str | int] = {
+            'host': connection.host,
+            'port': connection.port,
+            'user': connection.username,
+            'password': connection.password,
+            'dbname': connection.maintenance_database,
+        }
+        if connection.sslmode:
+            connection_kwargs['sslmode'] = connection.sslmode
+
+        with psycopg2.connect(**connection_kwargs) as admin_connection:
+            admin_connection.autocommit = True
+            with admin_connection.cursor() as cursor:
+                cursor.execute('SELECT 1 FROM pg_database WHERE datname = %s', (database_name,))
+                if cursor.fetchone() is not None:
+                    raise ValueError(f"Database '{database_name}' already exists")
+
+                cursor.execute(sql.SQL('CREATE DATABASE {}').format(sql.Identifier(database_name)))

--- a/api/src/models/databases.py
+++ b/api/src/models/databases.py
@@ -1,0 +1,30 @@
+from pydantic import Field, BaseModel
+
+
+class DatabaseConnectionCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    host: str = Field(min_length=1, max_length=255)
+    port: int = Field(default=5432, ge=1, le=65535)
+    username: str = Field(min_length=1, max_length=128)
+    password: str = Field(min_length=1, max_length=255)
+    maintenance_database: str = Field(default='postgres', min_length=1, max_length=128)
+    sslmode: str | None = Field(default=None, max_length=32)
+
+
+class DatabaseConnectionDelete(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+
+
+class DatabaseConnectionResponse(BaseModel):
+    name: str
+    host: str
+    port: int
+    username: str
+    maintenance_database: str
+    sslmode: str | None = None
+
+
+class DatabaseCreateResponse(BaseModel):
+    database: str
+    connection_name: str
+    status: str = 'created'

--- a/api/src/routes/databases.py
+++ b/api/src/routes/databases.py
@@ -1,0 +1,71 @@
+import src.db as db
+import psycopg2
+from fastapi import HTTPException
+from src.router import router
+from src.models.databases import (DatabaseCreateResponse,
+                                  DatabaseConnectionCreate,
+                                  DatabaseConnectionDelete,
+                                  DatabaseConnectionResponse)
+
+
+@router.get('/databases')
+async def list_databases() -> list[DatabaseConnectionResponse]:
+    connections = await db.databases.list()
+    return [
+        DatabaseConnectionResponse(
+            name=connection.name,
+            host=connection.host,
+            port=connection.port,
+            username=connection.username,
+            maintenance_database=connection.maintenance_database,
+            sslmode=connection.sslmode,
+        )
+        for connection in connections
+    ]
+
+
+@router.post('/databases')
+async def set_database_connection(payload: DatabaseConnectionCreate) -> DatabaseConnectionResponse:
+    connection = await db.databases.set(
+        name=payload.name,
+        host=payload.host,
+        port=payload.port,
+        username=payload.username,
+        password=payload.password,
+        maintenance_database=payload.maintenance_database,
+        sslmode=payload.sslmode,
+    )
+
+    return DatabaseConnectionResponse(
+        name=connection.name,
+        host=connection.host,
+        port=connection.port,
+        username=connection.username,
+        maintenance_database=connection.maintenance_database,
+        sslmode=connection.sslmode,
+    )
+
+
+@router.delete('/databases')
+async def delete_database_connection(payload: DatabaseConnectionDelete) -> dict[str, str]:
+    deleted = await db.databases.delete(payload.name)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Database connection '{payload.name}' not found")
+
+    return {'status': 'deleted'}
+
+
+@router.post('/databases/{database_name}')
+async def create_database(database_name: str, connection_name: str = 'default') -> DatabaseCreateResponse:
+    connection = await db.databases.get(connection_name)
+    if connection is None:
+        raise HTTPException(status_code=404, detail=f"Database connection '{connection_name}' not found")
+
+    try:
+        await db.databases.create_database(connection=connection, database_name=database_name)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    except psycopg2.Error as error:
+        raise HTTPException(status_code=502, detail=f'Unable to create database: {error.pgerror or str(error)}') from error
+
+    return DatabaseCreateResponse(database=database_name, connection_name=connection_name)


### PR DESCRIPTION
### Motivation
- Provide the control panel a way to store a superuser database connection and use it to create new PostgreSQL databases programmatically.
- Allow operators to manage multiple superuser connections and create tenant databases from the control plane.

### Description
- Add a new persisted model `DatabaseConnection` to store superuser credentials and connection info (`api/src/db/models/databases.py`).
- Implement `DatabasesService` with `list`, `get`, `set`, `delete` and `create_database` (with database-name validation and safe SQL identifier usage) (`api/src/db/services/databases.py`).
- Add Pydantic schemas for create/delete/list responses and a create-database response (`api/src/models/databases.py`).
- Add FastAPI routes `GET /databases`, `POST /databases`, `DELETE /databases`, and `POST /databases/{database_name}` and register them in the router (`api/src/routes/databases.py` and `api/main.py`).
- Wire the new service into the DB registry (`api/src/db/__init__.py`, `api/src/db/services/__init__.py`, `api/src/db/models/__init__.py`) and promote `psycopg2-binary` to runtime dependencies to support database creation (`api/pyproject.toml`).

### Testing
- Ran import sorting with `python -m isort .` and it completed successfully.
- Verified code compiles with `python -m compileall src main.py` and compilation succeeded.
- No automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d555e75c6c8323b449bf77802a0231)