### PR TITLE
Wire web database settings to backend and normalize local creds

### DIFF
--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -4,9 +4,9 @@ services:
     container_name: longlink-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: longlink
-      POSTGRES_PASSWORD: longlink
-      POSTGRES_DB: longlink
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: admin
     ports:
       - "15432:5432"
 
@@ -16,8 +16,8 @@ services:
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: admin
     ports:
       - "19000:9000"
       - "19001:9001"

--- a/web/src/components/settings/Database.tsx
+++ b/web/src/components/settings/Database.tsx
@@ -1,15 +1,25 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ConnectDatabaseServerDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
+import { apiFetch } from '@/lib/api';
 import { Card } from '@/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 
 type DatabaseServer = {
     name: string;
     host: string;
-    port: string;
+    port: number;
     username: string;
-    status: 'Connected';
+    maintenance_database: string;
+};
+
+type DatabaseConnectionCreate = {
+    name: string;
+    host: string;
+    port: number;
+    username: string;
+    password: string;
+    maintenance_database: string;
 };
 
 export default function Database() {
@@ -30,27 +40,58 @@ export default function Database() {
         );
     }, [host, password, port, serverName, username]);
 
-    const onConnect = () => {
-        if (!canConnect) {
-            return;
-        }
-
-        setConnectedDatabases((current) => [
-            {
-                name: serverName.trim(),
-                host: host.trim(),
-                port: port.trim(),
-                username: username.trim(),
-                status: 'Connected',
-            },
-            ...current,
-        ]);
-
+    const resetForm = () => {
         setServerName('');
         setHost('');
         setPort('5432');
         setUsername('');
         setPassword('');
+    };
+
+    useEffect(() => {
+        const loadDatabaseConnections = async () => {
+            try {
+                const connections = await apiFetch<DatabaseServer[]>('/databases');
+                setConnectedDatabases(connections);
+            } catch {
+                setConnectedDatabases([]);
+            }
+        };
+
+        void loadDatabaseConnections();
+    }, []);
+
+    const onConnect = async () => {
+        if (!canConnect) {
+            return;
+        }
+
+        const parsedPort = Number.parseInt(port.trim(), 10);
+
+        if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+            return;
+        }
+
+        const payload: DatabaseConnectionCreate = {
+            name: serverName.trim(),
+            host: host.trim(),
+            port: parsedPort,
+            username: username.trim(),
+            password: password.trim(),
+            maintenance_database: 'postgres',
+        };
+
+        const connection = await apiFetch<DatabaseServer>('/databases', {
+            method: 'POST',
+            body: payload,
+        });
+
+        setConnectedDatabases((current) => {
+            const next = current.filter((database) => database.name !== connection.name);
+            return [connection, ...next];
+        });
+
+        resetForm();
     };
 
     return (
@@ -68,7 +109,9 @@ export default function Database() {
                     onPortChange={setPort}
                     onUsernameChange={setUsername}
                     onPasswordChange={setPassword}
-                    onConnect={onConnect}
+                    onConnect={() => {
+                        void onConnect();
+                    }}
                 />
             </Hero>
 
@@ -97,7 +140,7 @@ export default function Database() {
                                     <TableCell>{database.host}</TableCell>
                                     <TableCell>{database.port}</TableCell>
                                     <TableCell>{database.username}</TableCell>
-                                    <TableCell>{database.status}</TableCell>
+                                    <TableCell>Connected</TableCell>
                                 </TableRow>
                             ))
                         )}


### PR DESCRIPTION
### Motivation
- Allow the web UI to manage persistent database connections instead of using local-only state by wiring the Database settings screen to the API. 
- Ensure local developer environment credentials are consistent and easy to remember by normalizing Postgres and MinIO credentials to `admin`/`admin`.

### Description
- Connect the Database settings page to the backend by calling `GET /databases` on mount and `POST /databases` when creating/updating a connection, and synchronize the UI list with the API response (`web/src/components/settings/Database.tsx`).
- Add request payload typing, port validation, and deduplication by connection name before updating the UI state (`DatabaseConnectionCreate` type and validation logic).
- Replace the local-only “Connected” insertion flow with real API responses and reset the connection form after successful creation.
- Update `dev/compose.yml` to set `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` to `admin`.

### Testing
- Ran `bun run format` in the `web/` workspace and it completed successfully.
- Ran `bun run build` in the `web/` workspace and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d558276c0483238b0775417acf238d)