### PR TITLE
Add S3-compatible storage connections and per-app bucket provisioning

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -41,6 +41,7 @@ import src.routes.auth
 import src.routes.user
 import src.routes.users
 import src.routes.settings
+import src.routes.storages
 import src.routes.databases
 
 app.include_router(router)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     'sqlalchemy==2.0.46',
     'starlette==0.52.1',
     'uvicorn==0.40.0',
-    'kubernetes==35.0.0'
+    'kubernetes==35.0.0',
+    'boto3==1.40.61'
 ]
 
 [project.optional-dependencies]

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,6 +1,7 @@
-from .models import App, Env, User, Setting, Permission, DatabaseConnection
+from .models import (App, Env, User, Setting, Permission, StorageConnection,
+                     DatabaseConnection)
 from .services import (AppsService, EnvsService, UsersService, SettingsService,
-                       DatabasesService, PermissionsService)
+                       StoragesService, DatabasesService, PermissionsService)
 
 apps = AppsService()
 envs = EnvsService()
@@ -9,3 +10,5 @@ users = UsersService()
 permissions = PermissionsService()
 
 databases = DatabasesService()
+
+storages = StoragesService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -4,5 +4,6 @@ from .envs import Env
 from .users import User
 from .__base__ import Base
 from .settings import Setting
+from .storages import StorageConnection
 from .databases import DatabaseConnection
 from .permissions import Permission

--- a/api/src/db/models/storages.py
+++ b/api/src/db/models/storages.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from sqlalchemy import String, Integer, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class StorageConnection(Base):
+    '''Represent external S3-compatible admin credentials managed by the control panel.'''
+
+    __tablename__ = 'storage_connections'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    endpoint_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    access_key_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    secret_access_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    region_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -2,5 +2,6 @@ from .apps import AppsService
 from .envs import EnvsService
 from .users import UsersService
 from .settings import SettingsService
+from .storages import StoragesService
 from .databases import DatabasesService
 from .permissions import PermissionsService

--- a/api/src/db/services/storages.py
+++ b/api/src/db/services/storages.py
@@ -1,0 +1,100 @@
+import re
+import boto3
+import asyncio
+from sqlalchemy import select
+from src.db.models import StorageConnection
+from src.db.session import get_session
+from botocore.exceptions import ClientError
+
+_BUCKET_NAME_PATTERN = re.compile(r'^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$')
+
+
+class StoragesService:
+    async def list(self) -> list[StorageConnection]:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(StorageConnection))
+            return list(result.scalars().all())
+
+    async def get(self, name: str) -> StorageConnection | None:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(StorageConnection).where(StorageConnection.name == name))
+            return result.scalar_one_or_none()
+
+    async def set(
+        self,
+        *,
+        name: str,
+        endpoint_url: str,
+        access_key_id: str,
+        secret_access_key: str,
+        region_name: str | None,
+    ) -> StorageConnection:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(StorageConnection).where(StorageConnection.name == name))
+            connection = result.scalar_one_or_none()
+
+            if connection is None:
+                connection = StorageConnection(
+                    name=name,
+                    endpoint_url=endpoint_url,
+                    access_key_id=access_key_id,
+                    secret_access_key=secret_access_key,
+                    region_name=region_name,
+                )
+                session.add(connection)
+            else:
+                connection.endpoint_url = endpoint_url
+                connection.access_key_id = access_key_id
+                connection.secret_access_key = secret_access_key
+                connection.region_name = region_name
+
+            await session.commit()
+            await session.refresh(connection)
+            return connection
+
+    async def delete(self, name: str) -> bool:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(StorageConnection).where(StorageConnection.name == name))
+            connection = result.scalar_one_or_none()
+            if connection is None:
+                return False
+
+            await session.delete(connection)
+            await session.commit()
+            return True
+
+    async def create_bucket(self, *, connection: StorageConnection, bucket_name: str) -> None:
+        if not _BUCKET_NAME_PATTERN.fullmatch(bucket_name):
+            raise ValueError('Bucket name must be 3-63 chars, lowercase, numbers or hyphens only')
+
+        await asyncio.to_thread(self._create_bucket_sync, connection, bucket_name)
+
+    @staticmethod
+    def _create_bucket_sync(connection: StorageConnection, bucket_name: str) -> None:
+        client_kwargs: dict[str, str] = {
+            'aws_access_key_id': connection.access_key_id,
+            'aws_secret_access_key': connection.secret_access_key,
+            'endpoint_url': connection.endpoint_url,
+        }
+        if connection.region_name:
+            client_kwargs['region_name'] = connection.region_name
+
+        client = boto3.client('s3', **client_kwargs)
+
+        try:
+            client.head_bucket(Bucket=bucket_name)
+            raise ValueError(f"Bucket '{bucket_name}' already exists")
+        except ClientError as error:
+            error_code = str(error.response.get('Error', {}).get('Code', ''))
+            if error_code not in {'404', 'NoSuchBucket', 'NotFound'}:
+                raise
+
+        create_kwargs: dict[str, str | dict[str, str]] = {'Bucket': bucket_name}
+        if connection.region_name and connection.region_name != 'us-east-1':
+            create_kwargs['CreateBucketConfiguration'] = {'LocationConstraint': connection.region_name}
+
+        client.create_bucket(**create_kwargs)

--- a/api/src/models/storages.py
+++ b/api/src/models/storages.py
@@ -1,0 +1,28 @@
+from pydantic import Field, BaseModel
+
+
+class StorageConnectionCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    endpoint_url: str = Field(min_length=1, max_length=512)
+    access_key_id: str = Field(min_length=1, max_length=255)
+    secret_access_key: str = Field(min_length=1, max_length=255)
+    region_name: str | None = Field(default=None, max_length=64)
+
+
+class StorageConnectionDelete(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+
+
+class StorageConnectionResponse(BaseModel):
+    name: str
+    endpoint_url: str
+    access_key_id: str
+    region_name: str | None = None
+
+
+class StorageBucketCreateResponse(BaseModel):
+    app_id: str
+    app_key: str
+    bucket: str
+    connection_name: str
+    status: str = 'created'

--- a/api/src/routes/storages.py
+++ b/api/src/routes/storages.py
@@ -1,0 +1,85 @@
+import src.db as db
+import botocore
+from fastapi import HTTPException
+from src.router import router
+from src.models.storages import (StorageConnectionCreate,
+                                 StorageConnectionDelete,
+                                 StorageConnectionResponse,
+                                 StorageBucketCreateResponse)
+
+
+def _bucket_name_from_app_key(app_key: str) -> str:
+    normalized = ''.join(character for character in app_key.lower() if character.isalnum() or character == '-')
+    normalized = normalized.strip('-')
+    if not normalized:
+        raise ValueError('App key does not contain valid characters to build a bucket name')
+
+    bucket = f'app-{normalized}'
+    return bucket[:63].rstrip('-')
+
+
+@router.get('/storages')
+async def list_storages() -> list[StorageConnectionResponse]:
+    connections = await db.storages.list()
+    return [
+        StorageConnectionResponse(
+            name=connection.name,
+            endpoint_url=connection.endpoint_url,
+            access_key_id=connection.access_key_id,
+            region_name=connection.region_name,
+        )
+        for connection in connections
+    ]
+
+
+@router.post('/storages')
+async def set_storage_connection(payload: StorageConnectionCreate) -> StorageConnectionResponse:
+    connection = await db.storages.set(
+        name=payload.name,
+        endpoint_url=payload.endpoint_url,
+        access_key_id=payload.access_key_id,
+        secret_access_key=payload.secret_access_key,
+        region_name=payload.region_name,
+    )
+
+    return StorageConnectionResponse(
+        name=connection.name,
+        endpoint_url=connection.endpoint_url,
+        access_key_id=connection.access_key_id,
+        region_name=connection.region_name,
+    )
+
+
+@router.delete('/storages')
+async def delete_storage_connection(payload: StorageConnectionDelete) -> dict[str, str]:
+    deleted = await db.storages.delete(payload.name)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Storage connection '{payload.name}' not found")
+
+    return {'status': 'deleted'}
+
+
+@router.post('/storages/apps/{app_id}/bucket')
+async def create_storage_bucket_for_app(app_id: str, connection_name: str = 'default') -> StorageBucketCreateResponse:
+    app = await db.apps.get_by_uuid(app_id)
+    if app is None:
+        raise HTTPException(status_code=404, detail=f"App '{app_id}' not found")
+
+    connection = await db.storages.get(connection_name)
+    if connection is None:
+        raise HTTPException(status_code=404, detail=f"Storage connection '{connection_name}' not found")
+
+    try:
+        bucket_name = _bucket_name_from_app_key(app.key)
+        await db.storages.create_bucket(connection=connection, bucket_name=bucket_name)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    except botocore.exceptions.BotoCoreError as error:
+        raise HTTPException(status_code=502, detail=f'Unable to create bucket: {str(error)}') from error
+
+    return StorageBucketCreateResponse(
+        app_id=app.id,
+        app_key=app.key,
+        bucket=bucket_name,
+        connection_name=connection_name,
+    )


### PR DESCRIPTION
### Motivation
- Provide a way to register S3-compatible admin credentials (e.g., MinIO) so the control plane can manage object storage similar to how it manages databases. 
- Allow the control plane to provision a dedicated bucket per application using the app's key to isolate app storage. 
- Reuse the same persistence/service/router patterns used for database connections for consistency and maintainability. 

### Description
- Add new API schemas `StorageConnectionCreate`, `StorageConnectionDelete`, `StorageConnectionResponse`, and `StorageBucketCreateResponse` in `api/src/models/storages.py` for request/response validation. 
- Add `StorageConnection` SQLAlchemy model in `api/src/db/models/storages.py` and a `StoragesService` in `api/src/db/services/storages.py` providing CRUD and bucket-creation logic (uses `boto3` and validates bucket names). 
- Add routes under `api/src/routes/storages.py` exposing `GET /storages`, `POST /storages`, `DELETE /storages`, and `POST /storages/apps/{app_id}/bucket` which derives a safe bucket name from an app key and provisions it. 
- Wire the new model/service/router into the application startup and DB wiring, and add `boto3` to the API dependencies in `pyproject.toml`. 

### Testing
- Ran `python -m isort .` in the `api/` directory and it completed successfully. 
- Ran `python -m compileall src` in the `api/` directory to verify modules compile and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d568fa0b8c83238aec1331daa3af7c)