### PR TITLE
Add Kubernetes compute endpoints for registration and pod provisioning

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -40,6 +40,7 @@ import src.routes.apps
 import src.routes.auth
 import src.routes.user
 import src.routes.users
+import src.routes.computes
 import src.routes.settings
 import src.routes.storages
 import src.routes.databases

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,7 +1,8 @@
-from .models import (App, Env, User, Setting, Permission, StorageConnection,
-                     DatabaseConnection)
-from .services import (AppsService, EnvsService, UsersService, SettingsService,
-                       StoragesService, DatabasesService, PermissionsService)
+from .models import (App, Env, User, Setting, Permission, ComputeConnection,
+                     StorageConnection, DatabaseConnection)
+from .services import (AppsService, EnvsService, UsersService, ComputesService,
+                       SettingsService, StoragesService, DatabasesService,
+                       PermissionsService)
 
 apps = AppsService()
 envs = EnvsService()
@@ -12,3 +13,6 @@ permissions = PermissionsService()
 databases = DatabasesService()
 
 storages = StoragesService()
+
+
+computes = ComputesService()

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -3,6 +3,7 @@ from .apps import App
 from .envs import Env
 from .users import User
 from .__base__ import Base
+from .computes import ComputeConnection
 from .settings import Setting
 from .storages import StorageConnection
 from .databases import DatabaseConnection

--- a/api/src/db/models/computes.py
+++ b/api/src/db/models/computes.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from sqlalchemy import String, Boolean, Integer, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.db.models.__base__ import Base
+
+
+class ComputeConnection(Base):
+    '''Represent external Kubernetes admin credentials managed by the control panel.'''
+
+    __tablename__ = 'compute_connections'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    api_server_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    admin_username: Mapped[str] = mapped_column(String(255), nullable=False)
+    admin_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    default_namespace: Mapped[str] = mapped_column(String(63), nullable=False, default='default')
+    verify_ssl: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -1,6 +1,7 @@
 from .apps import AppsService
 from .envs import EnvsService
 from .users import UsersService
+from .computes import ComputesService
 from .settings import SettingsService
 from .storages import StoragesService
 from .databases import DatabasesService

--- a/api/src/db/services/computes.py
+++ b/api/src/db/services/computes.py
@@ -1,0 +1,153 @@
+import re
+import asyncio
+from kubernetes import client
+from sqlalchemy import select
+from src.db.models import ComputeConnection
+from src.db.session import get_session
+from kubernetes.client.exceptions import ApiException
+
+_NAME_PATTERN = re.compile(r'^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$')
+
+
+class ComputesService:
+    async def list(self) -> list[ComputeConnection]:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(ComputeConnection))
+            return list(result.scalars().all())
+
+    async def get(self, name: str) -> ComputeConnection | None:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(ComputeConnection).where(ComputeConnection.name == name))
+            return result.scalar_one_or_none()
+
+    async def set(
+        self,
+        *,
+        name: str,
+        api_server_url: str,
+        admin_username: str,
+        admin_password: str,
+        default_namespace: str,
+        verify_ssl: bool,
+    ) -> ComputeConnection:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(ComputeConnection).where(ComputeConnection.name == name))
+            connection = result.scalar_one_or_none()
+
+            if connection is None:
+                connection = ComputeConnection(
+                    name=name,
+                    api_server_url=api_server_url,
+                    admin_username=admin_username,
+                    admin_password=admin_password,
+                    default_namespace=default_namespace,
+                    verify_ssl=verify_ssl,
+                )
+                session.add(connection)
+            else:
+                connection.api_server_url = api_server_url
+                connection.admin_username = admin_username
+                connection.admin_password = admin_password
+                connection.default_namespace = default_namespace
+                connection.verify_ssl = verify_ssl
+
+            await session.commit()
+            await session.refresh(connection)
+            return connection
+
+    async def delete(self, name: str) -> bool:
+        Session = await get_session()
+        async with Session() as session:
+            result = await session.execute(select(ComputeConnection).where(ComputeConnection.name == name))
+            connection = result.scalar_one_or_none()
+            if connection is None:
+                return False
+
+            await session.delete(connection)
+            await session.commit()
+            return True
+
+    async def create_container(
+        self,
+        *,
+        connection: ComputeConnection,
+        namespace: str,
+        pod_name: str,
+        image: str,
+        command: list[str] | None,
+        args: list[str] | None,
+        env: dict[str, str],
+        container_port: int | None,
+    ) -> None:
+        if not _NAME_PATTERN.fullmatch(namespace):
+            raise ValueError('Namespace must contain only lowercase letters, numbers, dots and dashes')
+
+        if not _NAME_PATTERN.fullmatch(pod_name):
+            raise ValueError('Container name must contain only lowercase letters, numbers, dots and dashes')
+
+        await asyncio.to_thread(
+            self._create_container_sync,
+            connection,
+            namespace,
+            pod_name,
+            image,
+            command,
+            args,
+            env,
+            container_port,
+        )
+
+    @staticmethod
+    def _create_container_sync(
+        connection: ComputeConnection,
+        namespace: str,
+        pod_name: str,
+        image: str,
+        command: list[str] | None,
+        args: list[str] | None,
+        env: dict[str, str],
+        container_port: int | None,
+    ) -> None:
+        configuration = client.Configuration()
+        configuration.host = connection.api_server_url
+        configuration.username = connection.admin_username
+        configuration.password = connection.admin_password
+        configuration.verify_ssl = connection.verify_ssl
+
+        with client.ApiClient(configuration) as api_client:
+            core = client.CoreV1Api(api_client)
+
+            try:
+                core.read_namespace(name=namespace)
+            except ApiException as error:
+                if error.status != 404:
+                    raise
+                core.create_namespace(
+                    body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
+                )
+
+            try:
+                core.read_namespaced_pod(name=pod_name, namespace=namespace)
+                raise ValueError(f"Container '{pod_name}' already exists in namespace '{namespace}'")
+            except ApiException as error:
+                if error.status != 404:
+                    raise
+
+            container = client.V1Container(
+                name=pod_name,
+                image=image,
+                command=command,
+                args=args,
+                env=[client.V1EnvVar(name=name, value=value) for name, value in env.items()],
+                ports=[client.V1ContainerPort(container_port=container_port)] if container_port else None,
+            )
+
+            pod = client.V1Pod(
+                metadata=client.V1ObjectMeta(name=pod_name, labels={'app': pod_name}),
+                spec=client.V1PodSpec(containers=[container], restart_policy='Always'),
+            )
+
+            core.create_namespaced_pod(namespace=namespace, body=pod)

--- a/api/src/models/computes.py
+++ b/api/src/models/computes.py
@@ -1,0 +1,47 @@
+from pydantic import Field, BaseModel
+
+
+class ComputeConnectionCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    api_server_url: str = Field(min_length=1, max_length=512)
+    admin_username: str = Field(min_length=1, max_length=255)
+    admin_password: str = Field(min_length=1, max_length=255)
+    default_namespace: str = Field(default='default', min_length=1, max_length=63)
+    verify_ssl: bool = True
+
+
+class ComputeConnectionDelete(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+
+
+class ComputeConnectionResponse(BaseModel):
+    name: str
+    api_server_url: str
+    admin_username: str
+    default_namespace: str
+    verify_ssl: bool
+
+
+class ComputeContainerEnv(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    value: str = Field(default='')
+
+
+class ComputeContainerCreate(BaseModel):
+    image: str = Field(min_length=1, max_length=255)
+    container_name: str = Field(min_length=1, max_length=63)
+    namespace: str | None = Field(default=None, min_length=1, max_length=63)
+    command: list[str] | None = None
+    args: list[str] | None = None
+    env: list[ComputeContainerEnv] = Field(default_factory=list)
+    container_port: int | None = Field(default=None, ge=1, le=65535)
+
+
+class ComputeContainerCreateResponse(BaseModel):
+    app_id: str
+    app_key: str
+    connection_name: str
+    namespace: str
+    pod_name: str
+    image: str
+    status: str = 'created'

--- a/api/src/routes/computes.py
+++ b/api/src/routes/computes.py
@@ -1,0 +1,108 @@
+import src.db as db
+from fastapi import HTTPException
+from src.router import router
+from src.models.computes import (ComputeContainerCreate,
+                                 ComputeConnectionCreate,
+                                 ComputeConnectionDelete,
+                                 ComputeConnectionResponse,
+                                 ComputeContainerCreateResponse)
+from kubernetes.client.exceptions import ApiException
+
+
+def _pod_name_from_app_key(app_key: str, container_name: str) -> str:
+    app_normalized = ''.join(character for character in app_key.lower() if character.isalnum() or character in {'-', '.'}).strip('-.')
+    container_normalized = ''.join(character for character in container_name.lower() if character.isalnum() or character in {'-', '.'}).strip('-.')
+
+    if not app_normalized or not container_normalized:
+        raise ValueError('App key and container name must include valid lowercase characters')
+
+    pod_name = f'{app_normalized}-{container_normalized}'
+    return pod_name[:63].rstrip('-.')
+
+
+@router.get('/computes')
+async def list_computes() -> list[ComputeConnectionResponse]:
+    connections = await db.computes.list()
+    return [
+        ComputeConnectionResponse(
+            name=connection.name,
+            api_server_url=connection.api_server_url,
+            admin_username=connection.admin_username,
+            default_namespace=connection.default_namespace,
+            verify_ssl=connection.verify_ssl,
+        )
+        for connection in connections
+    ]
+
+
+@router.post('/computes')
+async def set_compute_connection(payload: ComputeConnectionCreate) -> ComputeConnectionResponse:
+    connection = await db.computes.set(
+        name=payload.name,
+        api_server_url=payload.api_server_url,
+        admin_username=payload.admin_username,
+        admin_password=payload.admin_password,
+        default_namespace=payload.default_namespace,
+        verify_ssl=payload.verify_ssl,
+    )
+
+    return ComputeConnectionResponse(
+        name=connection.name,
+        api_server_url=connection.api_server_url,
+        admin_username=connection.admin_username,
+        default_namespace=connection.default_namespace,
+        verify_ssl=connection.verify_ssl,
+    )
+
+
+@router.delete('/computes')
+async def delete_compute_connection(payload: ComputeConnectionDelete) -> dict[str, str]:
+    deleted = await db.computes.delete(payload.name)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Compute connection '{payload.name}' not found")
+
+    return {'status': 'deleted'}
+
+
+@router.post('/computes/apps/{app_id}/containers')
+async def create_compute_container_for_app(
+    app_id: str,
+    payload: ComputeContainerCreate,
+    connection_name: str = 'default',
+) -> ComputeContainerCreateResponse:
+    app = await db.apps.get_by_uuid(app_id)
+    if app is None:
+        raise HTTPException(status_code=404, detail=f"App '{app_id}' not found")
+
+    connection = await db.computes.get(connection_name)
+    if connection is None:
+        raise HTTPException(status_code=404, detail=f"Compute connection '{connection_name}' not found")
+
+    namespace = payload.namespace or connection.default_namespace
+
+    try:
+        pod_name = _pod_name_from_app_key(app.key, payload.container_name)
+        await db.computes.create_container(
+            connection=connection,
+            namespace=namespace,
+            pod_name=pod_name,
+            image=payload.image,
+            command=payload.command,
+            args=payload.args,
+            env={item.name: item.value for item in payload.env},
+            container_port=payload.container_port,
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    except ApiException as error:
+        detail = error.body or str(error)
+        raise HTTPException(status_code=502, detail=f'Unable to create container: {detail}') from error
+
+    return ComputeContainerCreateResponse(
+        app_id=app.id,
+        app_key=app.key,
+        connection_name=connection_name,
+        namespace=namespace,
+        pod_name=pod_name,
+        image=payload.image,
+    )


### PR DESCRIPTION
### Motivation
- Provide a compute API analogous to existing database and storage management so Kubernetes clusters can be registered and used to run app containers.
- Allow the platform to store admin credentials for a Kubernetes API server and create pods on behalf of apps.

### Description
- Introduced Pydantic request/response schemas in `src/models/computes.py` for registering compute connections and requesting container creation. 
- Added a `ComputeConnection` SQLAlchemy model in `src/db/models/computes.py` and registered it in the DB models registry. 
- Implemented `ComputesService` in `src/db/services/computes.py` with CRUD operations and a synchronous Kubernetes provisioning flow (namespace auto-create, duplicate-pod guard, pod creation). 
- Added REST endpoints in `src/routes/computes.py` (`GET /computes`, `POST /computes`, `DELETE /computes`, `POST /computes/apps/{app_id}/containers`) and wired the module into application startup via `main.py` and the DB service registry. 

### Testing
- Ran import sorting with `python -m isort .` which updated and normalized imports across modified files and completed successfully. 
- Ran bytecode/syntax validation with `python -m compileall src main.py` which compiled the project files without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56a4d77748323aee105106ed40a8b)