### PR TITLE
Connect storage settings UI to backend storages API

### DIFF
--- a/web/src/components/dialogs/ConnectStorageProviderDialog.tsx
+++ b/web/src/components/dialogs/ConnectStorageProviderDialog.tsx
@@ -6,13 +6,13 @@ import { Input } from '@/ui/input';
 type ConnectStorageProviderDialogProps = {
     providerName: string;
     endpoint: string;
-    bucket: string;
+    region: string;
     accessKey: string;
     secretKey: string;
     canConnect: boolean;
     onProviderNameChange: (value: string) => void;
     onEndpointChange: (value: string) => void;
-    onBucketChange: (value: string) => void;
+    onRegionChange: (value: string) => void;
     onAccessKeyChange: (value: string) => void;
     onSecretKeyChange: (value: string) => void;
     onConnect: () => void;
@@ -21,13 +21,13 @@ type ConnectStorageProviderDialogProps = {
 export default function ConnectStorageProviderDialog({
     providerName,
     endpoint,
-    bucket,
+    region,
     accessKey,
     secretKey,
     canConnect,
     onProviderNameChange,
     onEndpointChange,
-    onBucketChange,
+    onRegionChange,
     onAccessKeyChange,
     onSecretKeyChange,
     onConnect,
@@ -49,11 +49,15 @@ export default function ConnectStorageProviderDialog({
                     onChange={(event) => onProviderNameChange(event.target.value)}
                 />
                 <Input
-                    placeholder="Endpoint"
+                    placeholder="Endpoint URL"
                     value={endpoint}
                     onChange={(event) => onEndpointChange(event.target.value)}
                 />
-                <Input placeholder="Bucket" value={bucket} onChange={(event) => onBucketChange(event.target.value)} />
+                <Input
+                    placeholder="Region (optional)"
+                    value={region}
+                    onChange={(event) => onRegionChange(event.target.value)}
+                />
                 <Input
                     placeholder="Access key"
                     value={accessKey}

--- a/web/src/components/settings/Storage.tsx
+++ b/web/src/components/settings/Storage.tsx
@@ -1,57 +1,88 @@
 import { HardDrive } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ConnectStorageProviderDialog } from '@/components/dialogs';
 import Hero from '@/longlink/Hero';
+import { apiFetch } from '@/lib/api';
 import { Card } from '@/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 
-type StorageProvider = {
+type StorageConnection = {
     name: string;
-    endpoint: string;
-    bucket: string;
-    accessKey: string;
-    status: 'Connected';
+    endpoint_url: string;
+    access_key_id: string;
+    region_name: string | null;
+};
+
+type StorageConnectionCreate = {
+    name: string;
+    endpoint_url: string;
+    access_key_id: string;
+    secret_access_key: string;
+    region_name: string | null;
 };
 
 export default function Storage() {
     const [providerName, setProviderName] = useState('');
     const [endpoint, setEndpoint] = useState('');
-    const [bucket, setBucket] = useState('');
+    const [region, setRegion] = useState('');
     const [accessKey, setAccessKey] = useState('');
     const [secretKey, setSecretKey] = useState('');
-    const [connectedProviders, setConnectedProviders] = useState<StorageProvider[]>([]);
+    const [connectedProviders, setConnectedProviders] = useState<StorageConnection[]>([]);
 
     const canConnect = useMemo(() => {
         return (
             providerName.trim().length > 0 &&
             endpoint.trim().length > 0 &&
-            bucket.trim().length > 0 &&
             accessKey.trim().length > 0 &&
             secretKey.trim().length > 0
         );
-    }, [accessKey, bucket, endpoint, providerName, secretKey]);
+    }, [accessKey, endpoint, providerName, secretKey]);
 
-    const onConnect = () => {
+    const resetForm = () => {
+        setProviderName('');
+        setEndpoint('');
+        setRegion('');
+        setAccessKey('');
+        setSecretKey('');
+    };
+
+    useEffect(() => {
+        const loadStorageConnections = async () => {
+            try {
+                const connections = await apiFetch<StorageConnection[]>('/storages');
+                setConnectedProviders(connections);
+            } catch {
+                setConnectedProviders([]);
+            }
+        };
+
+        void loadStorageConnections();
+    }, []);
+
+    const onConnect = async () => {
         if (!canConnect) {
             return;
         }
 
-        setConnectedProviders((current) => [
-            {
-                name: providerName.trim(),
-                endpoint: endpoint.trim(),
-                bucket: bucket.trim(),
-                accessKey: accessKey.trim(),
-                status: 'Connected',
-            },
-            ...current,
-        ]);
+        const payload: StorageConnectionCreate = {
+            name: providerName.trim(),
+            endpoint_url: endpoint.trim(),
+            access_key_id: accessKey.trim(),
+            secret_access_key: secretKey.trim(),
+            region_name: region.trim() || null,
+        };
 
-        setProviderName('');
-        setEndpoint('');
-        setBucket('');
-        setAccessKey('');
-        setSecretKey('');
+        const connection = await apiFetch<StorageConnection>('/storages', {
+            method: 'POST',
+            body: payload,
+        });
+
+        setConnectedProviders((current) => {
+            const next = current.filter((provider) => provider.name !== connection.name);
+            return [connection, ...next];
+        });
+
+        resetForm();
     };
 
     return (
@@ -65,16 +96,18 @@ export default function Storage() {
                 <ConnectStorageProviderDialog
                     providerName={providerName}
                     endpoint={endpoint}
-                    bucket={bucket}
+                    region={region}
                     accessKey={accessKey}
                     secretKey={secretKey}
                     canConnect={canConnect}
                     onProviderNameChange={setProviderName}
                     onEndpointChange={setEndpoint}
-                    onBucketChange={setBucket}
+                    onRegionChange={setRegion}
                     onAccessKeyChange={setAccessKey}
                     onSecretKeyChange={setSecretKey}
-                    onConnect={onConnect}
+                    onConnect={() => {
+                        void onConnect();
+                    }}
                 />
             </Hero>
 
@@ -84,7 +117,7 @@ export default function Storage() {
                         <TableRow>
                             <TableHead>Provider</TableHead>
                             <TableHead>Endpoint</TableHead>
-                            <TableHead>Bucket</TableHead>
+                            <TableHead>Region</TableHead>
                             <TableHead>Access key</TableHead>
                             <TableHead>Status</TableHead>
                         </TableRow>
@@ -98,12 +131,12 @@ export default function Storage() {
                             </TableRow>
                         ) : (
                             connectedProviders.map((provider) => (
-                                <TableRow key={`${provider.name}-${provider.bucket}-${provider.endpoint}`}>
+                                <TableRow key={`${provider.name}-${provider.endpoint_url}`}>
                                     <TableCell className="font-medium">{provider.name}</TableCell>
-                                    <TableCell>{provider.endpoint}</TableCell>
-                                    <TableCell>{provider.bucket}</TableCell>
-                                    <TableCell>{provider.accessKey}</TableCell>
-                                    <TableCell>{provider.status}</TableCell>
+                                    <TableCell>{provider.endpoint_url}</TableCell>
+                                    <TableCell>{provider.region_name ?? '-'}</TableCell>
+                                    <TableCell>{provider.access_key_id}</TableCell>
+                                    <TableCell>Connected</TableCell>
                                 </TableRow>
                             ))
                         )}


### PR DESCRIPTION
### Motivation
- Integrate the Storage settings UI with the backend `/storages` API so storage providers are persisted and real connections are displayed.
- Align the frontend form fields and payload with the backend storage model to avoid mismatched keys and ensure correct API usage.

### Description
- Load existing storage connections on component mount via `apiFetch('/storages')` and render the backend response fields in the table.
- Submit new storage connections to `POST /storages` using a `StorageConnectionCreate` payload with backend keys `endpoint_url`, `access_key_id`, `secret_access_key`, and `region_name`.
- Update `ConnectStorageProviderDialog` to match the backend schema by replacing the `bucket` field with an optional `region` field and clarifying the endpoint placeholder to `Endpoint URL`.
- Add typed models (`StorageConnection`, `StorageConnectionCreate`), a `resetForm` helper, and adjust table columns to show `endpoint_url`, `region_name`, and `access_key_id`.

### Testing
- Ran `bun run format` and the formatter completed successfully.
- Ran `bun run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56a736de483238c0586ed63d2fe09)