### PR TITLE
docs: document local Docker Compose connection parameters in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,52 @@ bun --cwd=web install
 bun --cwd=web dev
 ```
 
+### 1.1 Local infrastructure connection parameters
+
+After running `make up`, local dependencies are available from `dev/compose.yml` (PostgreSQL + MinIO) and from the `k3d` cluster created by the Makefile (`compute`). Use the following values when connecting providers in the settings screens.
+
+#### Database (PostgreSQL)
+
+Use these values in **Settings → Database → Connect database server**:
+
+- **Server name**: `local-postgres` (or any label you prefer)
+- **Host**: `localhost`
+- **Port**: `15432`
+- **Username**: `admin`
+- **Password**: `admin`
+- **Maintenance database** (API default): `postgres`
+
+> Docker service source: `postgres` in `dev/compose.yml` with `POSTGRES_USER=admin`, `POSTGRES_PASSWORD=admin`, and port mapping `15432:5432`.
+
+#### Storage (MinIO / S3-compatible)
+
+Use these values in **Settings → Storage → Connect storage provider**:
+
+- **Provider name**: `local-minio` (or any label you prefer)
+- **Endpoint URL**: `http://localhost:19000`
+- **Region**: `us-east-1` (recommended; optional in UI)
+- **Access key**: `admin`
+- **Secret key**: `admin`
+
+> Docker service source: `minio` in `dev/compose.yml` with `MINIO_ROOT_USER=admin`, `MINIO_ROOT_PASSWORD=admin`, and port mapping `19000:9000`.
+
+#### Compute (k3d cluster)
+
+`make up` creates a local cluster named `compute` with Kubernetes API exposed on port `6550`.
+
+- **Cluster name**: `compute`
+- **Kubernetes API server URL**: `https://localhost:6550`
+- **Default namespace**: `default`
+- **TLS verification**: disable if your local certificate is not trusted (`verify_ssl=false`)
+
+If you need exact kubeconfig-auth data for manual API calls, run:
+
+```bash
+k3d kubeconfig get compute
+```
+
+Use the credentials/certificates from that kubeconfig output.
+
 ### 2. Branching
 
 - `main` → stable


### PR DESCRIPTION
### Motivation

- Provide a single, explicit reference for the connection fields the web UI expects when running local infrastructure via `make up` and `dev/compose.yml`. 
- Reduce onboarding friction by documenting the exact host/port/credentials for PostgreSQL, MinIO, and the local `k3d` compute cluster.

### Description

- Added a new `1.1 Local infrastructure connection parameters` section to `CONTRIBUTING.md` containing Database, Storage, and Compute subsections with field-by-field values for the Settings UI. 
- Documented PostgreSQL connection values (`localhost:15432`, `admin`/`admin`, maintenance DB `postgres`) and MinIO/S3-compatible values (`http://localhost:19000`, `admin`/`admin`, region `us-east-1`).
- Documented local compute cluster details for the `k3d` cluster created by `make up` (cluster name `compute`, API `https://localhost:6550`, default namespace `default`, and `verify_ssl=false` guidance) and added a `k3d kubeconfig get compute` reference for retrieving kubeconfig auth materials.

### Testing

- Documentation-only change; no automated tests were run because this PR only updates `CONTRIBUTING.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d575cfedf883238e89a304197d3a40)