### PR TITLE
Create local registry when creating k3d compute cluster in `make up`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 up:
 	docker compose -f dev/compose.yml up -d
-	k3d cluster create compute --api-port 6550 || true
+	k3d cluster create compute --registry-create compute-registry:0.0.0.0:5000 || true
 
 down:
 	docker compose -f dev/compose.yml down

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make up
 This command:
 
 - starts Docker Compose services in detached mode
-- creates the `compute` k3d cluster on API port `6550` (and ignores the error if it already exists)
+- creates the `compute` k3d cluster with a local registry `compute-registry` exposed at `0.0.0.0:5000` (and ignores the error if it already exists)
 
 To stop services and remove the cluster:
 


### PR DESCRIPTION
### Motivation
- Ensure the local `compute` k3d cluster includes a local container registry by default so local images can be pushed and pulled during development.

### Description
- Update `Makefile` to run `k3d cluster create compute --registry-create compute-registry:0.0.0.0:5000 || true` instead of the previous `--api-port` option and update `README.md` to document the registry-based cluster setup.

### Testing
- Ran `make -n up` to validate the `make up` command prints the expected `docker compose -f dev/compose.yml up -d` and `k3d cluster create compute --registry-create compute-registry:0.0.0.0:5000 || true` commands and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57b1de1d48323993a9d00f1a88cba)