### PR TITLE
docs: add Applications SDK index and Pages/Storage/Database section indexes with sidebar groups

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Control Plane', link: '/' },
-      { text: 'Applications SDK', link: '/api-examples' }
+      { text: 'Applications SDK', link: '/applications-sdk/' }
     ],
 
     sidebar: [
@@ -22,8 +22,28 @@ export default defineConfig({
       {
         text: 'Applications SDK',
         items: [
-          { text: 'Runtime API Examples', link: '/api-examples' },
-          { text: 'Markdown Examples', link: '/markdown-examples' }
+          { text: 'Overview', link: '/applications-sdk/' },
+          {
+            text: 'Pages',
+            collapsed: true,
+            items: [
+              { text: 'Introduction', link: '/applications-sdk/pages/' }
+            ]
+          },
+          {
+            text: 'Storage',
+            collapsed: true,
+            items: [
+              { text: 'Introduction', link: '/applications-sdk/storage/' }
+            ]
+          },
+          {
+            text: 'Database',
+            collapsed: true,
+            items: [
+              { text: 'Introduction', link: '/applications-sdk/database/' }
+            ]
+          }
         ]
       }
     ],

--- a/docs/src/applications-sdk/database/index.md
+++ b/docs/src/applications-sdk/database/index.md
@@ -1,0 +1,5 @@
+# Database
+
+The Database section introduces schema and persistence concepts used by SDK applications.
+
+This index is the starting point for future Database subsections.

--- a/docs/src/applications-sdk/index.md
+++ b/docs/src/applications-sdk/index.md
@@ -1,0 +1,11 @@
+# Applications SDK
+
+Welcome to the Applications SDK documentation.
+
+Use this section to learn how to build application features for LongLink with a clear structure across pages, storage, and database capabilities.
+
+## Sections
+
+- [Pages](/applications-sdk/pages/)
+- [Storage](/applications-sdk/storage/)
+- [Database](/applications-sdk/database/)

--- a/docs/src/applications-sdk/pages/index.md
+++ b/docs/src/applications-sdk/pages/index.md
@@ -1,0 +1,5 @@
+# Pages
+
+The Pages section explains how to define and organize application pages rendered in the web interface.
+
+This index is the starting point for future Pages subsections.

--- a/docs/src/applications-sdk/storage/index.md
+++ b/docs/src/applications-sdk/storage/index.md
@@ -1,0 +1,5 @@
+# Storage
+
+The Storage section introduces how application data and files are stored and managed.
+
+This index is the starting point for future Storage subsections.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,4 +5,4 @@ This site now uses a docs-only layout. The root route opens the documentation in
 ## Sections
 
 - [Control Plane](/)
-- [Applications SDK](/api-examples)
+- [Applications SDK](/applications-sdk/)


### PR DESCRIPTION
### Motivation

- Provide a dedicated `Applications SDK` documentation area to organize SDK guidance and allow adding subsections under Pages, Storage, and Database.

### Description

- Added `docs/src/applications-sdk/index.md` as the landing page for the Applications SDK section with links to the new subsection indexes.
- Created subsection index pages at `docs/src/applications-sdk/pages/index.md`, `docs/src/applications-sdk/storage/index.md`, and `docs/src/applications-sdk/database/index.md` as introduction placeholders.
- Updated `docs/.vitepress/config.ts` to point the nav entry to `/applications-sdk/` and to add `Pages`, `Storage`, and `Database` as collapsed sidebar dropdown groups with `Introduction` entries.
- Updated `docs/src/index.md` to link the root docs index to the new Applications SDK route.

### Testing

- Ran `cd docs && bun run build` (VitePress build) and the site built and rendered pages successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91079e8608323a4d8240c108fce9f)