### PR TITLE
docs: add icons to left sidebar menu items

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -14,34 +14,34 @@ export default defineConfig({
 
     sidebar: [
       {
-        text: 'Control Plane',
+        text: '🧭 Control Plane',
         items: [
-          { text: 'Overview', link: '/' }
+          { text: '📄 Overview', link: '/' }
         ]
       },
       {
-        text: 'Applications SDK',
+        text: '🧩 Applications SDK',
         items: [
-          { text: 'Overview', link: '/applications-sdk/' },
+          { text: '📄 Overview', link: '/applications-sdk/' },
           {
-            text: 'Pages',
+            text: '📚 Pages',
             collapsed: true,
             items: [
-              { text: 'Introduction', link: '/applications-sdk/pages/' }
+              { text: '📄 Introduction', link: '/applications-sdk/pages/' }
             ]
           },
           {
-            text: 'Storage',
+            text: '🗂️ Storage',
             collapsed: true,
             items: [
-              { text: 'Introduction', link: '/applications-sdk/storage/' }
+              { text: '📄 Introduction', link: '/applications-sdk/storage/' }
             ]
           },
           {
-            text: 'Database',
+            text: '🗄️ Database',
             collapsed: true,
             items: [
-              { text: 'Introduction', link: '/applications-sdk/database/' }
+              { text: '📄 Introduction', link: '/applications-sdk/database/' }
             ]
           }
         ]


### PR DESCRIPTION
### Motivation
- Improve the docs left-sidebar visual affordance by adding an icon in front of each section and page label to make navigation easier to scan.

### Description
- Updated the VitePress sidebar configuration in `docs/.vitepress/config.ts` to prepend emoji icons to each sidebar group `text` and page `text` entry. 
- No route or link targets were modified; this change only updates visible labels in the sidebar. 
- The rest of the docs configuration and navigation structure remain unchanged.

### Testing
- Ran `bun run build` from the `docs/` directory which triggers `vitepress build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93c88d57c8323920f1bd45922af6b)