### PR TITLE
docs: show banner logo in navbar without title text

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     ['link', { rel: 'apple-touch-icon', href: '/banner.png' }]
   ],
   themeConfig: {
+    logo: '/banner.png',
+    siteTitle: false,
     search: {
       provider: 'local'
     },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,5 +1,5 @@
 :root {
-	--vp-nav-logo-height: 16px;
+	--vp-nav-logo-height: 28px;
 	--vp-font-family-base: 'Toss Product Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
 		'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 


### PR DESCRIPTION
### Motivation
- Make the documentation show the project banner/logo in the top-left brand area and remove the text title so the logo is the visible brand element.

### Description
- Configure VitePress by adding `logo: '/banner.png'` and `siteTitle: false` in `docs/.vitepress/config.ts` and increase `--vp-nav-logo-height` from `16px` to `28px` in `docs/.vitepress/theme/custom.css` so the banner/logo is clearly visible.

### Testing
- Ran the docs build with `cd docs && bun run build` (which invokes `vitepress build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd141a786c8323b310da1545a6a8a4)