### PR TITLE
Extend `make format` to include Markdown and YAML formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ format: $(VENV_BIN)/python
 	cd api && $(PYTHON) -m isort .
 	cd sdk && $(PYTHON) -m isort .
 	cd web && bun run format
+	cd web && bunx prettier --write $$(git -C .. ls-files '*.md' '*.yml' '*.yaml' | sed 's#^#../#')
 
 
 up:


### PR DESCRIPTION
### Motivation
- Ensure documentation and YAML configuration files are formatted by the existing `make format` flow so docs and config remain consistent with code formatting.

### Description
- Updated the root `format` target in the `Makefile` to run `cd web && bunx prettier --write $(git -C .. ls-files '*.md' '*.yml' '*.yaml' | sed 's#^#../#')`, reusing the `web` Prettier toolchain to format tracked Markdown and YAML files.

### Testing
- Ran `make -n format` to verify the `format` target now includes the new Markdown/YAML formatting step, and the dry-run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd725a19a0832387c559e85936fa30)