### PR TITLE
Refactor provisioning to use environment-backed configs; add usage summaries and update UI

### DIFF
--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,5 +1,4 @@
-from .models import (App, Env, User, Setting, Permission, ComputeConnection,
-                     StorageConnection, DatabaseConnection)
+from .models import App, Env, User, Setting, Permission
 from .services import (AppsService, EnvsService, UsersService, ComputesService,
                        SettingsService, StoragesService, DatabasesService,
                        PermissionsService)

--- a/api/src/db/models/__init__.py
+++ b/api/src/db/models/__init__.py
@@ -3,8 +3,5 @@ from .apps import App
 from .envs import Env
 from .users import User
 from .__base__ import Base
-from .computes import ComputeConnection
 from .settings import Setting
-from .storages import StorageConnection
-from .databases import DatabaseConnection
 from .permissions import Permission

--- a/api/src/db/services/computes.py
+++ b/api/src/db/services/computes.py
@@ -2,80 +2,54 @@ from __future__ import annotations
 
 import re
 import asyncio
+from src.env import env
 from kubernetes import client
-from sqlalchemy import select
-from src.db.models import ComputeConnection
-from src.db.session import get_session
+from dataclasses import dataclass
 from kubernetes.client.exceptions import ApiException
 
 _NAME_PATTERN = re.compile(r'^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$')
 
 
+@dataclass
+class ComputeProvisionConfig:
+    api_server_url: str
+    admin_username: str
+    admin_password: str
+    default_namespace: str
+    verify_ssl: bool
+
+
+@dataclass
+class ComputeUsage:
+    running_pods: int
+    namespaces: int
+    free_bytes: int | None
+
+
 class ComputesService:
-    async def list(self) -> list[ComputeConnection]:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(ComputeConnection))
-            return list(result.scalars().all())
+    def get_config(self) -> ComputeProvisionConfig:
+        if not env.ENV_PROVISION_COMPUTE_API_SERVER_URL:
+            raise ValueError('ENV_PROVISION_COMPUTE_API_SERVER_URL is not configured')
+        if not env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME:
+            raise ValueError('ENV_PROVISION_COMPUTE_ADMIN_USERNAME is not configured')
+        if not env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD:
+            raise ValueError('ENV_PROVISION_COMPUTE_ADMIN_PASSWORD is not configured')
 
-    async def get(self, name: str) -> ComputeConnection | None:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(ComputeConnection).where(ComputeConnection.name == name))
-            return result.scalar_one_or_none()
+        return ComputeProvisionConfig(
+            api_server_url=env.ENV_PROVISION_COMPUTE_API_SERVER_URL,
+            admin_username=env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME,
+            admin_password=env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD,
+            default_namespace=env.ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE,
+            verify_ssl=env.ENV_PROVISION_COMPUTE_VERIFY_SSL,
+        )
 
-    async def set(
-        self,
-        *,
-        name: str,
-        api_server_url: str,
-        admin_username: str,
-        admin_password: str,
-        default_namespace: str,
-        verify_ssl: bool,
-    ) -> ComputeConnection:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(ComputeConnection).where(ComputeConnection.name == name))
-            connection = result.scalar_one_or_none()
-
-            if connection is None:
-                connection = ComputeConnection(
-                    name=name,
-                    api_server_url=api_server_url,
-                    admin_username=admin_username,
-                    admin_password=admin_password,
-                    default_namespace=default_namespace,
-                    verify_ssl=verify_ssl,
-                )
-                session.add(connection)
-            else:
-                connection.api_server_url = api_server_url
-                connection.admin_username = admin_username
-                connection.admin_password = admin_password
-                connection.default_namespace = default_namespace
-                connection.verify_ssl = verify_ssl
-
-            await session.commit()
-            await session.refresh(connection)
-            return connection
-
-    async def delete(self, name: str) -> bool:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(ComputeConnection).where(ComputeConnection.name == name))
-            connection = result.scalar_one_or_none()
-            if connection is None:
-                return False
-
-            await session.delete(connection)
-            await session.commit()
-            return True
+    async def usage(self) -> ComputeUsage:
+        config = self.get_config()
+        return await asyncio.to_thread(self._usage_sync, config)
 
     async def create_container(
         self,
         *,
-        connection: ComputeConnection,
         namespace: str,
         pod_name: str,
         image: str,
@@ -90,9 +64,10 @@ class ComputesService:
         if not _NAME_PATTERN.fullmatch(pod_name):
             raise ValueError('Container name must contain only lowercase letters, numbers, dots and dashes')
 
+        config = self.get_config()
         await asyncio.to_thread(
             self._create_container_sync,
-            connection,
+            config,
             namespace,
             pod_name,
             image,
@@ -103,8 +78,26 @@ class ComputesService:
         )
 
     @staticmethod
+    def _client(config: ComputeProvisionConfig) -> client.CoreV1Api:
+        configuration = client.Configuration()
+        configuration.host = config.api_server_url
+        configuration.username = config.admin_username
+        configuration.password = config.admin_password
+        configuration.verify_ssl = config.verify_ssl
+
+        return client.CoreV1Api(client.ApiClient(configuration))
+
+    @staticmethod
+    def _usage_sync(config: ComputeProvisionConfig) -> ComputeUsage:
+        core = ComputesService._client(config)
+        namespaces = core.list_namespace().items
+        pods = core.list_pod_for_all_namespaces().items
+        running_pods = len([pod for pod in pods if pod.status and pod.status.phase == 'Running'])
+        return ComputeUsage(running_pods=running_pods, namespaces=len(namespaces), free_bytes=None)
+
+    @staticmethod
     def _create_container_sync(
-        connection: ComputeConnection,
+        config: ComputeProvisionConfig,
         namespace: str,
         pod_name: str,
         image: str,
@@ -114,10 +107,10 @@ class ComputesService:
         container_port: int | None,
     ) -> None:
         configuration = client.Configuration()
-        configuration.host = connection.api_server_url
-        configuration.username = connection.admin_username
-        configuration.password = connection.admin_password
-        configuration.verify_ssl = connection.verify_ssl
+        configuration.host = config.api_server_url
+        configuration.username = config.admin_username
+        configuration.password = config.admin_password
+        configuration.verify_ssl = config.verify_ssl
 
         with client.ApiClient(configuration) as api_client:
             core = client.CoreV1Api(api_client)

--- a/api/src/db/services/databases.py
+++ b/api/src/db/services/databases.py
@@ -1,97 +1,87 @@
 import re
 import asyncio
 import psycopg2
+from src.env import env
 from psycopg2 import sql
-from sqlalchemy import select
-from src.db.models import DatabaseConnection
-from src.db.session import get_session
+from dataclasses import dataclass
 
 _DATABASE_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
 
+@dataclass
+class DatabaseProvisionConfig:
+    host: str
+    port: int
+    username: str
+    password: str
+    maintenance_database: str
+    sslmode: str | None
+
+
+@dataclass
+class DatabaseUsage:
+    used_bytes: int | None
+    free_bytes: int | None
+
+
 class DatabasesService:
-    async def list(self) -> list[DatabaseConnection]:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(DatabaseConnection))
-            return list(result.scalars().all())
+    def get_config(self) -> DatabaseProvisionConfig:
+        if not env.ENV_PROVISION_DATABASE_HOST:
+            raise ValueError('ENV_PROVISION_DATABASE_HOST is not configured')
+        if not env.ENV_PROVISION_DATABASE_USERNAME:
+            raise ValueError('ENV_PROVISION_DATABASE_USERNAME is not configured')
+        if not env.ENV_PROVISION_DATABASE_PASSWORD:
+            raise ValueError('ENV_PROVISION_DATABASE_PASSWORD is not configured')
 
-    async def get(self, name: str) -> DatabaseConnection | None:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(DatabaseConnection).where(DatabaseConnection.name == name))
-            return result.scalar_one_or_none()
+        return DatabaseProvisionConfig(
+            host=env.ENV_PROVISION_DATABASE_HOST,
+            port=env.ENV_PROVISION_DATABASE_PORT,
+            username=env.ENV_PROVISION_DATABASE_USERNAME,
+            password=env.ENV_PROVISION_DATABASE_PASSWORD,
+            maintenance_database=env.ENV_PROVISION_DATABASE_NAME,
+            sslmode=env.ENV_PROVISION_DATABASE_SSLMODE,
+        )
 
-    async def set(
-        self,
-        *,
-        name: str,
-        host: str,
-        port: int,
-        username: str,
-        password: str,
-        maintenance_database: str,
-        sslmode: str | None,
-    ) -> DatabaseConnection:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(DatabaseConnection).where(DatabaseConnection.name == name))
-            connection = result.scalar_one_or_none()
+    async def usage(self) -> DatabaseUsage:
+        config = self.get_config()
+        return await asyncio.to_thread(self._usage_sync, config)
 
-            if connection is None:
-                connection = DatabaseConnection(
-                    name=name,
-                    host=host,
-                    port=port,
-                    username=username,
-                    password=password,
-                    maintenance_database=maintenance_database,
-                    sslmode=sslmode,
-                )
-                session.add(connection)
-            else:
-                connection.host = host
-                connection.port = port
-                connection.username = username
-                connection.password = password
-                connection.maintenance_database = maintenance_database
-                connection.sslmode = sslmode
-
-            await session.commit()
-            await session.refresh(connection)
-            return connection
-
-    async def delete(self, name: str) -> bool:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(DatabaseConnection).where(DatabaseConnection.name == name))
-            connection = result.scalar_one_or_none()
-            if connection is None:
-                return False
-
-            await session.delete(connection)
-            await session.commit()
-            return True
-
-    async def create_database(self, *, connection: DatabaseConnection, database_name: str) -> None:
+    async def create_database(self, *, database_name: str) -> None:
         if not _DATABASE_NAME_PATTERN.fullmatch(database_name):
             raise ValueError('Database name must start with a letter/underscore and contain only letters, numbers, and underscores')
 
-        await asyncio.to_thread(self._create_database_sync, connection, database_name)
+        config = self.get_config()
+        await asyncio.to_thread(self._create_database_sync, config, database_name)
 
     @staticmethod
-    def _create_database_sync(connection: DatabaseConnection, database_name: str) -> None:
+    def _connection_kwargs(config: DatabaseProvisionConfig) -> dict[str, str | int]:
         connection_kwargs: dict[str, str | int] = {
-            'host': connection.host,
-            'port': connection.port,
-            'user': connection.username,
-            'password': connection.password,
-            'dbname': connection.maintenance_database,
+            'host': config.host,
+            'port': config.port,
+            'user': config.username,
+            'password': config.password,
+            'dbname': config.maintenance_database,
         }
-        if connection.sslmode:
-            connection_kwargs['sslmode'] = connection.sslmode
+        if config.sslmode:
+            connection_kwargs['sslmode'] = config.sslmode
+        return connection_kwargs
 
-        admin_connection = psycopg2.connect(**connection_kwargs)
+    @staticmethod
+    def _usage_sync(config: DatabaseProvisionConfig) -> DatabaseUsage:
+        admin_connection = psycopg2.connect(**DatabasesService._connection_kwargs(config))
+        try:
+            with admin_connection.cursor() as cursor:
+                cursor.execute('SELECT COALESCE(SUM(pg_database_size(datname)), 0) FROM pg_database WHERE datistemplate = false')
+                used_bytes = cursor.fetchone()
+                total_used = int(used_bytes[0]) if used_bytes and used_bytes[0] is not None else 0
+
+            return DatabaseUsage(used_bytes=total_used, free_bytes=None)
+        finally:
+            admin_connection.close()
+
+    @staticmethod
+    def _create_database_sync(config: DatabaseProvisionConfig, database_name: str) -> None:
+        admin_connection = psycopg2.connect(**DatabasesService._connection_kwargs(config))
         try:
             admin_connection.autocommit = True
             with admin_connection.cursor() as cursor:

--- a/api/src/db/services/storages.py
+++ b/api/src/db/services/storages.py
@@ -1,89 +1,95 @@
 import re
 import boto3
 import asyncio
-from sqlalchemy import select
-from src.db.models import StorageConnection
-from src.db.session import get_session
+from src.env import env
+from dataclasses import dataclass
 from botocore.exceptions import ClientError
 
 _BUCKET_NAME_PATTERN = re.compile(r'^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$')
 
 
+@dataclass
+class StorageProvisionConfig:
+    endpoint_url: str
+    access_key_id: str
+    secret_access_key: str
+    region_name: str | None
+
+
+@dataclass
+class StorageUsage:
+    used_bytes: int | None
+    free_bytes: int | None
+    bucket_count: int
+
+
 class StoragesService:
-    async def list(self) -> list[StorageConnection]:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(StorageConnection))
-            return list(result.scalars().all())
+    def get_config(self) -> StorageProvisionConfig:
+        if not env.ENV_PROVISION_STORAGE_ENDPOINT_URL:
+            raise ValueError('ENV_PROVISION_STORAGE_ENDPOINT_URL is not configured')
+        if not env.ENV_PROVISION_STORAGE_ACCESS_KEY_ID:
+            raise ValueError('ENV_PROVISION_STORAGE_ACCESS_KEY_ID is not configured')
+        if not env.ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY:
+            raise ValueError('ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY is not configured')
 
-    async def get(self, name: str) -> StorageConnection | None:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(StorageConnection).where(StorageConnection.name == name))
-            return result.scalar_one_or_none()
+        return StorageProvisionConfig(
+            endpoint_url=env.ENV_PROVISION_STORAGE_ENDPOINT_URL,
+            access_key_id=env.ENV_PROVISION_STORAGE_ACCESS_KEY_ID,
+            secret_access_key=env.ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY,
+            region_name=env.ENV_PROVISION_STORAGE_REGION_NAME,
+        )
 
-    async def set(
-        self,
-        *,
-        name: str,
-        endpoint_url: str,
-        access_key_id: str,
-        secret_access_key: str,
-        region_name: str | None,
-    ) -> StorageConnection:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(StorageConnection).where(StorageConnection.name == name))
-            connection = result.scalar_one_or_none()
+    async def usage(self) -> StorageUsage:
+        config = self.get_config()
+        return await asyncio.to_thread(self._usage_sync, config)
 
-            if connection is None:
-                connection = StorageConnection(
-                    name=name,
-                    endpoint_url=endpoint_url,
-                    access_key_id=access_key_id,
-                    secret_access_key=secret_access_key,
-                    region_name=region_name,
-                )
-                session.add(connection)
-            else:
-                connection.endpoint_url = endpoint_url
-                connection.access_key_id = access_key_id
-                connection.secret_access_key = secret_access_key
-                connection.region_name = region_name
-
-            await session.commit()
-            await session.refresh(connection)
-            return connection
-
-    async def delete(self, name: str) -> bool:
-        Session = await get_session()
-        async with Session() as session:
-            result = await session.execute(select(StorageConnection).where(StorageConnection.name == name))
-            connection = result.scalar_one_or_none()
-            if connection is None:
-                return False
-
-            await session.delete(connection)
-            await session.commit()
-            return True
-
-    async def create_bucket(self, *, connection: StorageConnection, bucket_name: str) -> None:
+    async def create_bucket(self, *, bucket_name: str) -> None:
         if not _BUCKET_NAME_PATTERN.fullmatch(bucket_name):
             raise ValueError('Bucket name must be 3-63 chars, lowercase, numbers or hyphens only')
 
-        await asyncio.to_thread(self._create_bucket_sync, connection, bucket_name)
+        config = self.get_config()
+        await asyncio.to_thread(self._create_bucket_sync, config, bucket_name)
 
     @staticmethod
-    def _create_bucket_sync(connection: StorageConnection, bucket_name: str) -> None:
+    def _client_kwargs(config: StorageProvisionConfig) -> dict[str, str]:
         client_kwargs: dict[str, str] = {
-            'aws_access_key_id': connection.access_key_id,
-            'aws_secret_access_key': connection.secret_access_key,
-            'endpoint_url': connection.endpoint_url,
+            'aws_access_key_id': config.access_key_id,
+            'aws_secret_access_key': config.secret_access_key,
+            'endpoint_url': config.endpoint_url,
         }
-        if connection.region_name:
-            client_kwargs['region_name'] = connection.region_name
+        if config.region_name:
+            client_kwargs['region_name'] = config.region_name
+        return client_kwargs
 
-        client = boto3.client('s3', **client_kwargs)
+    @staticmethod
+    def _usage_sync(config: StorageProvisionConfig) -> StorageUsage:
+        client = boto3.client('s3', **StoragesService._client_kwargs(config))
+        buckets = client.list_buckets().get('Buckets', [])
+        total_size = 0
+
+        for bucket in buckets:
+            bucket_name = str(bucket.get('Name', ''))
+            continuation_token: str | None = None
+
+            while True:
+                list_kwargs: dict[str, str] = {'Bucket': bucket_name}
+                if continuation_token:
+                    list_kwargs['ContinuationToken'] = continuation_token
+
+                response = client.list_objects_v2(**list_kwargs)
+                for item in response.get('Contents', []):
+                    total_size += int(item.get('Size', 0))
+
+                if not response.get('IsTruncated'):
+                    break
+
+                continuation_token = response.get('NextContinuationToken')
+
+        return StorageUsage(used_bytes=total_size, free_bytes=None, bucket_count=len(buckets))
+
+    @staticmethod
+    def _create_bucket_sync(config: StorageProvisionConfig, bucket_name: str) -> None:
+        client = boto3.client('s3', **StoragesService._client_kwargs(config))
 
         try:
             client.head_bucket(Bucket=bucket_name)
@@ -94,7 +100,7 @@ class StoragesService:
                 raise
 
         create_kwargs: dict[str, str | dict[str, str]] = {'Bucket': bucket_name}
-        if connection.region_name and connection.region_name != 'us-east-1':
-            create_kwargs['CreateBucketConfiguration'] = {'LocationConstraint': connection.region_name}
+        if config.region_name and config.region_name != 'us-east-1':
+            create_kwargs['CreateBucketConfiguration'] = {'LocationConstraint': config.region_name}
 
         client.create_bucket(**create_kwargs)

--- a/api/src/env.py
+++ b/api/src/env.py
@@ -17,6 +17,27 @@ class Env(BaseSettings):
     ENV_OIDC_REDIRECT_URI: str = 'http://localhost:8000/auth/oidc'
     ENV_OIDC_SCOPES: str = 'openid profile email'
 
+    # Platform database provisioning credentials
+    ENV_PROVISION_DATABASE_HOST: str | None = None
+    ENV_PROVISION_DATABASE_PORT: int = 5432
+    ENV_PROVISION_DATABASE_USERNAME: str | None = None
+    ENV_PROVISION_DATABASE_PASSWORD: str | None = None
+    ENV_PROVISION_DATABASE_NAME: str = 'postgres'
+    ENV_PROVISION_DATABASE_SSLMODE: str | None = None
+
+    # Platform storage provisioning credentials
+    ENV_PROVISION_STORAGE_ENDPOINT_URL: str | None = None
+    ENV_PROVISION_STORAGE_ACCESS_KEY_ID: str | None = None
+    ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY: str | None = None
+    ENV_PROVISION_STORAGE_REGION_NAME: str | None = None
+
+    # Platform compute provisioning credentials
+    ENV_PROVISION_COMPUTE_API_SERVER_URL: str | None = None
+    ENV_PROVISION_COMPUTE_ADMIN_USERNAME: str | None = None
+    ENV_PROVISION_COMPUTE_ADMIN_PASSWORD: str | None = None
+    ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE: str = 'default'
+    ENV_PROVISION_COMPUTE_VERIFY_SSL: bool = True
+
     # Web URL used for auth redirects
     URL: str = 'http://localhost:5173'
 
@@ -36,6 +57,27 @@ class DevEnv(Env):
     ENV_OIDC_ISSUER: str | None = 'http://localhost:18080/realms/dev'
     ENV_OIDC_REDIRECT_URI: str = 'http://localhost:8000/auth/oidc'
     ENV_OIDC_SCOPES: str = 'openid profile email'
+
+    # Platform database provisioning credentials (dev/compose.yml)
+    ENV_PROVISION_DATABASE_HOST: str | None = 'localhost'
+    ENV_PROVISION_DATABASE_PORT: int = 15432
+    ENV_PROVISION_DATABASE_USERNAME: str | None = 'admin'
+    ENV_PROVISION_DATABASE_PASSWORD: str | None = 'admin'
+    ENV_PROVISION_DATABASE_NAME: str = 'admin'
+    ENV_PROVISION_DATABASE_SSLMODE: str | None = None
+
+    # Platform storage provisioning credentials (dev/compose.yml)
+    ENV_PROVISION_STORAGE_ENDPOINT_URL: str | None = 'http://localhost:19000'
+    ENV_PROVISION_STORAGE_ACCESS_KEY_ID: str | None = 'admin'
+    ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY: str | None = 'admin'
+    ENV_PROVISION_STORAGE_REGION_NAME: str | None = 'us-east-1'
+
+    # Platform compute provisioning credentials
+    ENV_PROVISION_COMPUTE_API_SERVER_URL: str | None = None
+    ENV_PROVISION_COMPUTE_ADMIN_USERNAME: str | None = None
+    ENV_PROVISION_COMPUTE_ADMIN_PASSWORD: str | None = None
+    ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE: str = 'default'
+    ENV_PROVISION_COMPUTE_VERIFY_SSL: bool = False
 
     # Web URL used for auth redirects
     URL: str = 'http://localhost:5173'

--- a/api/src/models/computes.py
+++ b/api/src/models/computes.py
@@ -1,25 +1,23 @@
 from pydantic import Field, BaseModel
 
 
-class ComputeConnectionCreate(BaseModel):
-    name: str = Field(min_length=1, max_length=128)
-    api_server_url: str = Field(min_length=1, max_length=512)
-    admin_username: str = Field(min_length=1, max_length=255)
-    admin_password: str = Field(min_length=1, max_length=255)
-    default_namespace: str = Field(default='default', min_length=1, max_length=63)
-    verify_ssl: bool = True
+class ComputeUsageSummary(BaseModel):
+    running_pods: int = 0
+    namespaces: int = 0
+    free_bytes: int | None = None
 
 
-class ComputeConnectionDelete(BaseModel):
-    name: str = Field(min_length=1, max_length=128)
-
-
-class ComputeConnectionResponse(BaseModel):
-    name: str
+class ComputeConfigSummary(BaseModel):
     api_server_url: str
     admin_username: str
     default_namespace: str
     verify_ssl: bool
+
+
+class ComputeSummaryResponse(BaseModel):
+    configured: bool
+    config: ComputeConfigSummary | None = None
+    usage: ComputeUsageSummary = ComputeUsageSummary()
 
 
 class ComputeContainerEnv(BaseModel):
@@ -40,7 +38,6 @@ class ComputeContainerCreate(BaseModel):
 class ComputeContainerCreateResponse(BaseModel):
     app_id: str
     app_key: str
-    connection_name: str
     namespace: str
     pod_name: str
     image: str

--- a/api/src/models/databases.py
+++ b/api/src/models/databases.py
@@ -1,22 +1,12 @@
-from pydantic import Field, BaseModel
+from pydantic import BaseModel
 
 
-class DatabaseConnectionCreate(BaseModel):
-    name: str = Field(min_length=1, max_length=128)
-    host: str = Field(min_length=1, max_length=255)
-    port: int = Field(default=5432, ge=1, le=65535)
-    username: str = Field(min_length=1, max_length=128)
-    password: str = Field(min_length=1, max_length=255)
-    maintenance_database: str = Field(default='postgres', min_length=1, max_length=128)
-    sslmode: str | None = Field(default=None, max_length=32)
+class DatabaseUsageSummary(BaseModel):
+    used_bytes: int | None = None
+    free_bytes: int | None = None
 
 
-class DatabaseConnectionDelete(BaseModel):
-    name: str = Field(min_length=1, max_length=128)
-
-
-class DatabaseConnectionResponse(BaseModel):
-    name: str
+class DatabaseConfigSummary(BaseModel):
     host: str
     port: int
     username: str
@@ -24,7 +14,12 @@ class DatabaseConnectionResponse(BaseModel):
     sslmode: str | None = None
 
 
+class DatabaseSummaryResponse(BaseModel):
+    configured: bool
+    config: DatabaseConfigSummary | None = None
+    usage: DatabaseUsageSummary = DatabaseUsageSummary()
+
+
 class DatabaseCreateResponse(BaseModel):
     database: str
-    connection_name: str
     status: str = 'created'

--- a/api/src/models/storages.py
+++ b/api/src/models/storages.py
@@ -1,28 +1,26 @@
-from pydantic import Field, BaseModel
+from pydantic import BaseModel
 
 
-class StorageConnectionCreate(BaseModel):
-    name: str = Field(min_length=1, max_length=128)
-    endpoint_url: str = Field(min_length=1, max_length=512)
-    access_key_id: str = Field(min_length=1, max_length=255)
-    secret_access_key: str = Field(min_length=1, max_length=255)
-    region_name: str | None = Field(default=None, max_length=64)
+class StorageUsageSummary(BaseModel):
+    used_bytes: int | None = None
+    free_bytes: int | None = None
+    bucket_count: int = 0
 
 
-class StorageConnectionDelete(BaseModel):
-    name: str = Field(min_length=1, max_length=128)
-
-
-class StorageConnectionResponse(BaseModel):
-    name: str
+class StorageConfigSummary(BaseModel):
     endpoint_url: str
     access_key_id: str
     region_name: str | None = None
+
+
+class StorageSummaryResponse(BaseModel):
+    configured: bool
+    config: StorageConfigSummary | None = None
+    usage: StorageUsageSummary = StorageUsageSummary()
 
 
 class StorageBucketCreateResponse(BaseModel):
     app_id: str
     app_key: str
     bucket: str
-    connection_name: str
     status: str = 'created'

--- a/api/src/routes/compute.py
+++ b/api/src/routes/compute.py
@@ -1,10 +1,9 @@
 import src.db as db
 from fastapi import HTTPException
 from src.router import router
-from src.models.computes import (ComputeContainerCreate,
-                                 ComputeConnectionCreate,
-                                 ComputeConnectionDelete,
-                                 ComputeConnectionResponse,
+from src.models.computes import (ComputeUsageSummary, ComputeConfigSummary,
+                                 ComputeContainerCreate,
+                                 ComputeSummaryResponse,
                                  ComputeContainerCreateResponse)
 from kubernetes.client.exceptions import ApiException
 
@@ -21,69 +20,49 @@ def _pod_name_from_app_key(app_key: str, container_name: str) -> str:
 
 
 @router.get('/compute')
-async def list_computes() -> list[ComputeConnectionResponse]:
-    connections = await db.computes.list()
-    return [
-        ComputeConnectionResponse(
-            name=connection.name,
-            api_server_url=connection.api_server_url,
-            admin_username=connection.admin_username,
-            default_namespace=connection.default_namespace,
-            verify_ssl=connection.verify_ssl,
+async def get_compute_summary() -> ComputeSummaryResponse:
+    try:
+        config = db.computes.get_config()
+    except ValueError:
+        return ComputeSummaryResponse(configured=False)
+
+    usage = ComputeUsageSummary()
+    try:
+        measured = await db.computes.usage()
+        usage = ComputeUsageSummary(
+            running_pods=measured.running_pods,
+            namespaces=measured.namespaces,
+            free_bytes=measured.free_bytes,
         )
-        for connection in connections
-    ]
+    except (ValueError, ApiException):
+        usage = ComputeUsageSummary()
 
-
-@router.post('/compute')
-async def set_compute_connection(payload: ComputeConnectionCreate) -> ComputeConnectionResponse:
-    connection = await db.computes.set(
-        name=payload.name,
-        api_server_url=payload.api_server_url,
-        admin_username=payload.admin_username,
-        admin_password=payload.admin_password,
-        default_namespace=payload.default_namespace,
-        verify_ssl=payload.verify_ssl,
+    return ComputeSummaryResponse(
+        configured=True,
+        config=ComputeConfigSummary(
+            api_server_url=config.api_server_url,
+            admin_username=config.admin_username,
+            default_namespace=config.default_namespace,
+            verify_ssl=config.verify_ssl,
+        ),
+        usage=usage,
     )
-
-    return ComputeConnectionResponse(
-        name=connection.name,
-        api_server_url=connection.api_server_url,
-        admin_username=connection.admin_username,
-        default_namespace=connection.default_namespace,
-        verify_ssl=connection.verify_ssl,
-    )
-
-
-@router.delete('/compute')
-async def delete_compute_connection(payload: ComputeConnectionDelete) -> dict[str, str]:
-    deleted = await db.computes.delete(payload.name)
-    if not deleted:
-        raise HTTPException(status_code=404, detail=f"Compute connection '{payload.name}' not found")
-
-    return {'status': 'deleted'}
 
 
 @router.post('/compute/apps/{app_id}/containers')
 async def create_compute_container_for_app(
     app_id: str,
     payload: ComputeContainerCreate,
-    connection_name: str = 'default',
 ) -> ComputeContainerCreateResponse:
     app = await db.apps.get_by_uuid(app_id)
     if app is None:
         raise HTTPException(status_code=404, detail=f"App '{app_id}' not found")
 
-    connection = await db.computes.get(connection_name)
-    if connection is None:
-        raise HTTPException(status_code=404, detail=f"Compute connection '{connection_name}' not found")
-
-    namespace = payload.namespace or connection.default_namespace
-
     try:
+        config = db.computes.get_config()
+        namespace = payload.namespace or config.default_namespace
         pod_name = _pod_name_from_app_key(app.key, payload.container_name)
         await db.computes.create_container(
-            connection=connection,
             namespace=namespace,
             pod_name=pod_name,
             image=payload.image,
@@ -93,7 +72,11 @@ async def create_compute_container_for_app(
             container_port=payload.container_port,
         )
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        detail = str(error)
+        status_code = 400
+        if 'not configured' in detail:
+            status_code = 503
+        raise HTTPException(status_code=status_code, detail=detail) from error
     except ApiException as error:
         detail = error.body or str(error)
         raise HTTPException(status_code=502, detail=f'Unable to create container: {detail}') from error
@@ -101,7 +84,6 @@ async def create_compute_container_for_app(
     return ComputeContainerCreateResponse(
         app_id=app.id,
         app_key=app.key,
-        connection_name=connection_name,
         namespace=namespace,
         pod_name=pod_name,
         image=payload.image,

--- a/api/src/routes/database.py
+++ b/api/src/routes/database.py
@@ -2,70 +2,49 @@ import src.db as db
 import psycopg2
 from fastapi import HTTPException
 from src.router import router
-from src.models.databases import (DatabaseCreateResponse,
-                                  DatabaseConnectionCreate,
-                                  DatabaseConnectionDelete,
-                                  DatabaseConnectionResponse)
+from src.models.databases import (DatabaseUsageSummary, DatabaseConfigSummary,
+                                  DatabaseCreateResponse,
+                                  DatabaseSummaryResponse)
 
 
 @router.get('/database')
-async def list_databases() -> list[DatabaseConnectionResponse]:
-    connections = await db.databases.list()
-    return [
-        DatabaseConnectionResponse(
-            name=connection.name,
-            host=connection.host,
-            port=connection.port,
-            username=connection.username,
-            maintenance_database=connection.maintenance_database,
-            sslmode=connection.sslmode,
-        )
-        for connection in connections
-    ]
+async def get_database_summary() -> DatabaseSummaryResponse:
+    try:
+        config = db.databases.get_config()
+    except ValueError:
+        return DatabaseSummaryResponse(configured=False)
 
+    usage = DatabaseUsageSummary()
+    try:
+        measured = await db.databases.usage()
+        usage = DatabaseUsageSummary(used_bytes=measured.used_bytes, free_bytes=measured.free_bytes)
+    except (ValueError, psycopg2.Error):
+        usage = DatabaseUsageSummary()
 
-@router.post('/database')
-async def set_database_connection(payload: DatabaseConnectionCreate) -> DatabaseConnectionResponse:
-    connection = await db.databases.set(
-        name=payload.name,
-        host=payload.host,
-        port=payload.port,
-        username=payload.username,
-        password=payload.password,
-        maintenance_database=payload.maintenance_database,
-        sslmode=payload.sslmode,
+    return DatabaseSummaryResponse(
+        configured=True,
+        config=DatabaseConfigSummary(
+            host=config.host,
+            port=config.port,
+            username=config.username,
+            maintenance_database=config.maintenance_database,
+            sslmode=config.sslmode,
+        ),
+        usage=usage,
     )
-
-    return DatabaseConnectionResponse(
-        name=connection.name,
-        host=connection.host,
-        port=connection.port,
-        username=connection.username,
-        maintenance_database=connection.maintenance_database,
-        sslmode=connection.sslmode,
-    )
-
-
-@router.delete('/database')
-async def delete_database_connection(payload: DatabaseConnectionDelete) -> dict[str, str]:
-    deleted = await db.databases.delete(payload.name)
-    if not deleted:
-        raise HTTPException(status_code=404, detail=f"Database connection '{payload.name}' not found")
-
-    return {'status': 'deleted'}
 
 
 @router.post('/database/{database_name}')
-async def create_database(database_name: str, connection_name: str = 'default') -> DatabaseCreateResponse:
-    connection = await db.databases.get(connection_name)
-    if connection is None:
-        raise HTTPException(status_code=404, detail=f"Database connection '{connection_name}' not found")
-
+async def create_database(database_name: str) -> DatabaseCreateResponse:
     try:
-        await db.databases.create_database(connection=connection, database_name=database_name)
+        await db.databases.create_database(database_name=database_name)
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        detail = str(error)
+        status_code = 400
+        if 'not configured' in detail:
+            status_code = 503
+        raise HTTPException(status_code=status_code, detail=detail) from error
     except psycopg2.Error as error:
         raise HTTPException(status_code=502, detail=f'Unable to create database: {error.pgerror or str(error)}') from error
 
-    return DatabaseCreateResponse(database=database_name, connection_name=connection_name)
+    return DatabaseCreateResponse(database=database_name)

--- a/api/src/routes/storage.py
+++ b/api/src/routes/storage.py
@@ -2,9 +2,8 @@ import src.db as db
 import botocore
 from fastapi import HTTPException
 from src.router import router
-from src.models.storages import (StorageConnectionCreate,
-                                 StorageConnectionDelete,
-                                 StorageConnectionResponse,
+from src.models.storages import (StorageUsageSummary, StorageConfigSummary,
+                                 StorageSummaryResponse,
                                  StorageBucketCreateResponse)
 
 
@@ -19,61 +18,49 @@ def _bucket_name_from_app_key(app_key: str) -> str:
 
 
 @router.get('/storage')
-async def list_storages() -> list[StorageConnectionResponse]:
-    connections = await db.storages.list()
-    return [
-        StorageConnectionResponse(
-            name=connection.name,
-            endpoint_url=connection.endpoint_url,
-            access_key_id=connection.access_key_id,
-            region_name=connection.region_name,
+async def get_storage_summary() -> StorageSummaryResponse:
+    try:
+        config = db.storages.get_config()
+    except ValueError:
+        return StorageSummaryResponse(configured=False)
+
+    usage = StorageUsageSummary()
+    try:
+        measured = await db.storages.usage()
+        usage = StorageUsageSummary(
+            used_bytes=measured.used_bytes,
+            free_bytes=measured.free_bytes,
+            bucket_count=measured.bucket_count,
         )
-        for connection in connections
-    ]
+    except (ValueError, botocore.exceptions.BotoCoreError):
+        usage = StorageUsageSummary()
 
-
-@router.post('/storage')
-async def set_storage_connection(payload: StorageConnectionCreate) -> StorageConnectionResponse:
-    connection = await db.storages.set(
-        name=payload.name,
-        endpoint_url=payload.endpoint_url,
-        access_key_id=payload.access_key_id,
-        secret_access_key=payload.secret_access_key,
-        region_name=payload.region_name,
+    return StorageSummaryResponse(
+        configured=True,
+        config=StorageConfigSummary(
+            endpoint_url=config.endpoint_url,
+            access_key_id=config.access_key_id,
+            region_name=config.region_name,
+        ),
+        usage=usage,
     )
-
-    return StorageConnectionResponse(
-        name=connection.name,
-        endpoint_url=connection.endpoint_url,
-        access_key_id=connection.access_key_id,
-        region_name=connection.region_name,
-    )
-
-
-@router.delete('/storage')
-async def delete_storage_connection(payload: StorageConnectionDelete) -> dict[str, str]:
-    deleted = await db.storages.delete(payload.name)
-    if not deleted:
-        raise HTTPException(status_code=404, detail=f"Storage connection '{payload.name}' not found")
-
-    return {'status': 'deleted'}
 
 
 @router.post('/storage/apps/{app_id}/bucket')
-async def create_storage_bucket_for_app(app_id: str, connection_name: str = 'default') -> StorageBucketCreateResponse:
+async def create_storage_bucket_for_app(app_id: str) -> StorageBucketCreateResponse:
     app = await db.apps.get_by_uuid(app_id)
     if app is None:
         raise HTTPException(status_code=404, detail=f"App '{app_id}' not found")
 
-    connection = await db.storages.get(connection_name)
-    if connection is None:
-        raise HTTPException(status_code=404, detail=f"Storage connection '{connection_name}' not found")
-
     try:
         bucket_name = _bucket_name_from_app_key(app.key)
-        await db.storages.create_bucket(connection=connection, bucket_name=bucket_name)
+        await db.storages.create_bucket(bucket_name=bucket_name)
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        detail = str(error)
+        status_code = 400
+        if 'not configured' in detail:
+            status_code = 503
+        raise HTTPException(status_code=status_code, detail=detail) from error
     except botocore.exceptions.BotoCoreError as error:
         raise HTTPException(status_code=502, detail=f'Unable to create bucket: {str(error)}') from error
 
@@ -81,5 +68,4 @@ async def create_storage_bucket_for_app(app_id: str, connection_name: str = 'def
         app_id=app.id,
         app_key=app.key,
         bucket=bucket_name,
-        connection_name=connection_name,
     )

--- a/web/src/components/settings/Container.tsx
+++ b/web/src/components/settings/Container.tsx
@@ -1,113 +1,95 @@
-import { useMemo, useState } from 'react';
-import { ConnectContainerRuntimeDialog } from '@/components/dialogs';
+import { useEffect, useState } from 'react';
 import Hero from '@/longlink/Hero';
+import { apiFetch } from '@/lib/api';
 import { Card } from '@/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 
-type ContainerRuntime = {
-    name: string;
-    registry: string;
-    namespace: string;
-    cpuLimit: string;
-    status: 'Connected';
+type ComputeSummary = {
+    configured: boolean;
+    config: {
+        api_server_url: string;
+        admin_username: string;
+        default_namespace: string;
+        verify_ssl: boolean;
+    } | null;
+    usage: {
+        running_pods: number;
+        namespaces: number;
+        free_bytes: number | null;
+    };
+};
+
+const formatBytes = (value: number | null) => {
+    if (value === null) {
+        return 'Not available';
+    }
+
+    if (value < 1024) {
+        return `${value} B`;
+    }
+
+    if (value < 1024 ** 2) {
+        return `${(value / 1024).toFixed(1)} KB`;
+    }
+
+    if (value < 1024 ** 3) {
+        return `${(value / 1024 ** 2).toFixed(1)} MB`;
+    }
+
+    return `${(value / 1024 ** 3).toFixed(2)} GB`;
 };
 
 export default function Container() {
-    const [runtimeName, setRuntimeName] = useState('');
-    const [registry, setRegistry] = useState('');
-    const [namespace, setNamespace] = useState('');
-    const [cpuLimit, setCpuLimit] = useState('1000m');
-    const [apiToken, setApiToken] = useState('');
-    const [connectedRuntimes, setConnectedRuntimes] = useState<ContainerRuntime[]>([]);
+    const [summary, setSummary] = useState<ComputeSummary | null>(null);
 
-    const canConnect = useMemo(() => {
-        return (
-            runtimeName.trim().length > 0 &&
-            registry.trim().length > 0 &&
-            namespace.trim().length > 0 &&
-            cpuLimit.trim().length > 0 &&
-            apiToken.trim().length > 0
-        );
-    }, [apiToken, cpuLimit, namespace, registry, runtimeName]);
+    useEffect(() => {
+        const loadSummary = async () => {
+            try {
+                const result = await apiFetch<ComputeSummary>('/compute');
+                setSummary(result);
+            } catch {
+                setSummary(null);
+            }
+        };
 
-    const onConnect = () => {
-        if (!canConnect) {
-            return;
-        }
+        void loadSummary();
+    }, []);
 
-        setConnectedRuntimes((current) => [
-            {
-                name: runtimeName.trim(),
-                registry: registry.trim(),
-                namespace: namespace.trim(),
-                cpuLimit: cpuLimit.trim(),
-                status: 'Connected',
-            },
-            ...current,
-        ]);
-
-        setRuntimeName('');
-        setRegistry('');
-        setNamespace('');
-        setCpuLimit('1000m');
-        setApiToken('');
-    };
+    const isConfigured = summary?.configured ?? false;
 
     return (
         <div className="space-y-6">
             <Hero
                 title="Compute Settings"
-                subtitle="Configure compute runtimes, registries, and quotas"
+                subtitle="Compute provisioning is configured once from environment variables"
                 icon="cpu"
-                action="Connect"
-            >
-                <ConnectContainerRuntimeDialog
-                    runtimeName={runtimeName}
-                    registry={registry}
-                    namespace={namespace}
-                    cpuLimit={cpuLimit}
-                    apiToken={apiToken}
-                    canConnect={canConnect}
-                    onRuntimeNameChange={setRuntimeName}
-                    onRegistryChange={setRegistry}
-                    onNamespaceChange={setNamespace}
-                    onCpuLimitChange={setCpuLimit}
-                    onApiTokenChange={setApiToken}
-                    onConnect={onConnect}
-                />
-            </Hero>
+            />
 
-            <Card className="gap-0 overflow-hidden py-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Runtime</TableHead>
-                            <TableHead>Registry</TableHead>
-                            <TableHead>Namespace</TableHead>
-                            <TableHead>CPU limit</TableHead>
-                            <TableHead>Status</TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {connectedRuntimes.length === 0 ? (
-                            <TableRow>
-                                <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
-                                    No connected container runtimes yet.
-                                </TableCell>
-                            </TableRow>
-                        ) : (
-                            connectedRuntimes.map((runtime) => (
-                                <TableRow key={`${runtime.name}-${runtime.namespace}-${runtime.registry}`}>
-                                    <TableCell className="font-medium">{runtime.name}</TableCell>
-                                    <TableCell>{runtime.registry}</TableCell>
-                                    <TableCell>{runtime.namespace}</TableCell>
-                                    <TableCell>{runtime.cpuLimit}</TableCell>
-                                    <TableCell>{runtime.status}</TableCell>
-                                </TableRow>
-                            ))
-                        )}
-                    </TableBody>
-                </Table>
+            <Card className="space-y-4 p-6">
+                <h3 className="text-base font-semibold">Configuration</h3>
+                <p className="text-sm text-muted-foreground">
+                    Status: {isConfigured ? 'Configured' : 'Not configured'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    API server: {summary?.config?.api_server_url ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Admin user: {summary?.config?.admin_username ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Default namespace: {summary?.config?.default_namespace ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    SSL verification: {summary?.config?.verify_ssl ? 'Enabled' : 'Disabled'}
+                </p>
+            </Card>
+
+            <Card className="space-y-4 p-6">
+                <h3 className="text-base font-semibold">Usage</h3>
+                <p className="text-sm text-muted-foreground">Namespaces: {summary?.usage.namespaces ?? 0}</p>
+                <p className="text-sm text-muted-foreground">Running pods: {summary?.usage.running_pods ?? 0}</p>
+                <p className="text-sm text-muted-foreground">
+                    Free space: {formatBytes(summary?.usage.free_bytes ?? null)}
+                </p>
             </Card>
         </div>
     );

--- a/web/src/components/settings/Database.tsx
+++ b/web/src/components/settings/Database.tsx
@@ -1,151 +1,93 @@
-import { useEffect, useMemo, useState } from 'react';
-import { ConnectDatabaseServerDialog } from '@/components/dialogs';
+import { useEffect, useState } from 'react';
 import Hero from '@/longlink/Hero';
 import { apiFetch } from '@/lib/api';
 import { Card } from '@/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 
-type DatabaseServer = {
-    name: string;
-    host: string;
-    port: number;
-    username: string;
-    maintenance_database: string;
+type DatabaseSummary = {
+    configured: boolean;
+    config: {
+        host: string;
+        port: number;
+        username: string;
+        maintenance_database: string;
+        sslmode: string | null;
+    } | null;
+    usage: {
+        used_bytes: number | null;
+        free_bytes: number | null;
+    };
 };
 
-type DatabaseConnectionCreate = {
-    name: string;
-    host: string;
-    port: number;
-    username: string;
-    password: string;
-    maintenance_database: string;
+const formatBytes = (value: number | null) => {
+    if (value === null) {
+        return 'Not available';
+    }
+
+    if (value < 1024) {
+        return `${value} B`;
+    }
+
+    if (value < 1024 ** 2) {
+        return `${(value / 1024).toFixed(1)} KB`;
+    }
+
+    if (value < 1024 ** 3) {
+        return `${(value / 1024 ** 2).toFixed(1)} MB`;
+    }
+
+    return `${(value / 1024 ** 3).toFixed(2)} GB`;
 };
 
 export default function Database() {
-    const [serverName, setServerName] = useState('');
-    const [host, setHost] = useState('');
-    const [port, setPort] = useState('5432');
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const [connectedDatabases, setConnectedDatabases] = useState<DatabaseServer[]>([]);
-
-    const canConnect = useMemo(() => {
-        return (
-            serverName.trim().length > 0 &&
-            host.trim().length > 0 &&
-            port.trim().length > 0 &&
-            username.trim().length > 0 &&
-            password.trim().length > 0
-        );
-    }, [host, password, port, serverName, username]);
-
-    const resetForm = () => {
-        setServerName('');
-        setHost('');
-        setPort('5432');
-        setUsername('');
-        setPassword('');
-    };
+    const [summary, setSummary] = useState<DatabaseSummary | null>(null);
 
     useEffect(() => {
-        const loadDatabaseConnections = async () => {
+        const loadSummary = async () => {
             try {
-                const connections = await apiFetch<DatabaseServer[]>('/databases');
-                setConnectedDatabases(connections);
+                const result = await apiFetch<DatabaseSummary>('/database');
+                setSummary(result);
             } catch {
-                setConnectedDatabases([]);
+                setSummary(null);
             }
         };
 
-        void loadDatabaseConnections();
+        void loadSummary();
     }, []);
 
-    const onConnect = async () => {
-        if (!canConnect) {
-            return;
-        }
-
-        const parsedPort = Number.parseInt(port.trim(), 10);
-
-        if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
-            return;
-        }
-
-        const payload: DatabaseConnectionCreate = {
-            name: serverName.trim(),
-            host: host.trim(),
-            port: parsedPort,
-            username: username.trim(),
-            password: password.trim(),
-            maintenance_database: 'postgres',
-        };
-
-        const connection = await apiFetch<DatabaseServer>('/databases', {
-            method: 'POST',
-            body: payload,
-        });
-
-        setConnectedDatabases((current) => {
-            const next = current.filter((database) => database.name !== connection.name);
-            return [connection, ...next];
-        });
-
-        resetForm();
-    };
+    const isConfigured = summary?.configured ?? false;
 
     return (
         <div className="space-y-6">
-            <Hero title="Database Settings" subtitle="Connect a database instance." icon="settings" action="Connect">
-                <ConnectDatabaseServerDialog
-                    serverName={serverName}
-                    host={host}
-                    port={port}
-                    username={username}
-                    password={password}
-                    canConnect={canConnect}
-                    onServerNameChange={setServerName}
-                    onHostChange={setHost}
-                    onPortChange={setPort}
-                    onUsernameChange={setUsername}
-                    onPasswordChange={setPassword}
-                    onConnect={() => {
-                        void onConnect();
-                    }}
-                />
-            </Hero>
+            <Hero
+                title="Database Settings"
+                subtitle="Database provisioning is configured once from environment variables"
+                icon="settings"
+            />
 
-            <Card className="gap-0 overflow-hidden py-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Server</TableHead>
-                            <TableHead>Host</TableHead>
-                            <TableHead>Port</TableHead>
-                            <TableHead>Username</TableHead>
-                            <TableHead>Status</TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {connectedDatabases.length === 0 ? (
-                            <TableRow>
-                                <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
-                                    No connected database servers yet.
-                                </TableCell>
-                            </TableRow>
-                        ) : (
-                            connectedDatabases.map((database) => (
-                                <TableRow key={`${database.name}-${database.host}-${database.port}`}>
-                                    <TableCell className="font-medium">{database.name}</TableCell>
-                                    <TableCell>{database.host}</TableCell>
-                                    <TableCell>{database.port}</TableCell>
-                                    <TableCell>{database.username}</TableCell>
-                                    <TableCell>Connected</TableCell>
-                                </TableRow>
-                            ))
-                        )}
-                    </TableBody>
-                </Table>
+            <Card className="space-y-4 p-6">
+                <h3 className="text-base font-semibold">Configuration</h3>
+                <p className="text-sm text-muted-foreground">
+                    Status: {isConfigured ? 'Configured' : 'Not configured'}
+                </p>
+                <p className="text-sm text-muted-foreground">Host: {summary?.config?.host ?? 'Not available'}</p>
+                <p className="text-sm text-muted-foreground">Port: {summary?.config?.port ?? 'Not available'}</p>
+                <p className="text-sm text-muted-foreground">
+                    Username: {summary?.config?.username ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Maintenance database: {summary?.config?.maintenance_database ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">SSL mode: {summary?.config?.sslmode ?? 'Not set'}</p>
+            </Card>
+
+            <Card className="space-y-4 p-6">
+                <h3 className="text-base font-semibold">Usage</h3>
+                <p className="text-sm text-muted-foreground">
+                    Used space: {formatBytes(summary?.usage.used_bytes ?? null)}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Free space: {formatBytes(summary?.usage.free_bytes ?? null)}
+                </p>
             </Card>
         </div>
     );

--- a/web/src/components/settings/Storage.tsx
+++ b/web/src/components/settings/Storage.tsx
@@ -1,157 +1,91 @@
-import { HardDrive } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
-import { ConnectStorageProviderDialog } from '@/components/dialogs';
+import { useEffect, useState } from 'react';
 import Hero from '@/longlink/Hero';
 import { apiFetch } from '@/lib/api';
 import { Card } from '@/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 
-type StorageConnection = {
-    name: string;
-    endpoint_url: string;
-    access_key_id: string;
-    region_name: string | null;
+type StorageSummary = {
+    configured: boolean;
+    config: {
+        endpoint_url: string;
+        access_key_id: string;
+        region_name: string | null;
+    } | null;
+    usage: {
+        used_bytes: number | null;
+        free_bytes: number | null;
+        bucket_count: number;
+    };
 };
 
-type StorageConnectionCreate = {
-    name: string;
-    endpoint_url: string;
-    access_key_id: string;
-    secret_access_key: string;
-    region_name: string | null;
+const formatBytes = (value: number | null) => {
+    if (value === null) {
+        return 'Not available';
+    }
+
+    if (value < 1024) {
+        return `${value} B`;
+    }
+
+    if (value < 1024 ** 2) {
+        return `${(value / 1024).toFixed(1)} KB`;
+    }
+
+    if (value < 1024 ** 3) {
+        return `${(value / 1024 ** 2).toFixed(1)} MB`;
+    }
+
+    return `${(value / 1024 ** 3).toFixed(2)} GB`;
 };
 
 export default function Storage() {
-    const [providerName, setProviderName] = useState('');
-    const [endpoint, setEndpoint] = useState('');
-    const [region, setRegion] = useState('');
-    const [accessKey, setAccessKey] = useState('');
-    const [secretKey, setSecretKey] = useState('');
-    const [connectedProviders, setConnectedProviders] = useState<StorageConnection[]>([]);
-
-    const canConnect = useMemo(() => {
-        return (
-            providerName.trim().length > 0 &&
-            endpoint.trim().length > 0 &&
-            accessKey.trim().length > 0 &&
-            secretKey.trim().length > 0
-        );
-    }, [accessKey, endpoint, providerName, secretKey]);
-
-    const resetForm = () => {
-        setProviderName('');
-        setEndpoint('');
-        setRegion('');
-        setAccessKey('');
-        setSecretKey('');
-    };
+    const [summary, setSummary] = useState<StorageSummary | null>(null);
 
     useEffect(() => {
-        const loadStorageConnections = async () => {
+        const loadSummary = async () => {
             try {
-                const connections = await apiFetch<StorageConnection[]>('/storages');
-                setConnectedProviders(connections);
+                const result = await apiFetch<StorageSummary>('/storage');
+                setSummary(result);
             } catch {
-                setConnectedProviders([]);
+                setSummary(null);
             }
         };
 
-        void loadStorageConnections();
+        void loadSummary();
     }, []);
 
-    const onConnect = async () => {
-        if (!canConnect) {
-            return;
-        }
-
-        const payload: StorageConnectionCreate = {
-            name: providerName.trim(),
-            endpoint_url: endpoint.trim(),
-            access_key_id: accessKey.trim(),
-            secret_access_key: secretKey.trim(),
-            region_name: region.trim() || null,
-        };
-
-        const connection = await apiFetch<StorageConnection>('/storages', {
-            method: 'POST',
-            body: payload,
-        });
-
-        setConnectedProviders((current) => {
-            const next = current.filter((provider) => provider.name !== connection.name);
-            return [connection, ...next];
-        });
-
-        resetForm();
-    };
+    const isConfigured = summary?.configured ?? false;
 
     return (
         <div className="space-y-6">
             <Hero
                 title="Storage Settings"
-                subtitle="Manage storage providers, quotas, and file policies"
+                subtitle="Storage provisioning is configured once from environment variables"
                 icon="settings"
-                action="Connect"
-            >
-                <ConnectStorageProviderDialog
-                    providerName={providerName}
-                    endpoint={endpoint}
-                    region={region}
-                    accessKey={accessKey}
-                    secretKey={secretKey}
-                    canConnect={canConnect}
-                    onProviderNameChange={setProviderName}
-                    onEndpointChange={setEndpoint}
-                    onRegionChange={setRegion}
-                    onAccessKeyChange={setAccessKey}
-                    onSecretKeyChange={setSecretKey}
-                    onConnect={() => {
-                        void onConnect();
-                    }}
-                />
-            </Hero>
+            />
 
-            <Card className="gap-0 overflow-hidden py-0">
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Provider</TableHead>
-                            <TableHead>Endpoint</TableHead>
-                            <TableHead>Region</TableHead>
-                            <TableHead>Access key</TableHead>
-                            <TableHead>Status</TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {connectedProviders.length === 0 ? (
-                            <TableRow>
-                                <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
-                                    No connected storage providers yet.
-                                </TableCell>
-                            </TableRow>
-                        ) : (
-                            connectedProviders.map((provider) => (
-                                <TableRow key={`${provider.name}-${provider.endpoint_url}`}>
-                                    <TableCell className="font-medium">{provider.name}</TableCell>
-                                    <TableCell>{provider.endpoint_url}</TableCell>
-                                    <TableCell>{provider.region_name ?? '-'}</TableCell>
-                                    <TableCell>{provider.access_key_id}</TableCell>
-                                    <TableCell>Connected</TableCell>
-                                </TableRow>
-                            ))
-                        )}
-                    </TableBody>
-                </Table>
+            <Card className="space-y-4 p-6">
+                <h3 className="text-base font-semibold">Configuration</h3>
+                <p className="text-sm text-muted-foreground">
+                    Status: {isConfigured ? 'Configured' : 'Not configured'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Endpoint: {summary?.config?.endpoint_url ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Access key: {summary?.config?.access_key_id ?? 'Not available'}
+                </p>
+                <p className="text-sm text-muted-foreground">Region: {summary?.config?.region_name ?? 'Not set'}</p>
             </Card>
 
-            <Card className="border-dashed p-4 text-sm text-muted-foreground">
-                <div className="flex items-start gap-2">
-                    <HardDrive className="mt-0.5 h-4 w-4" />
-                    <p>
-                        Connected entries represent shared object storage providers. Applications can link dedicated
-                        buckets and file policies to one of these providers.
-                    </p>
-                </div>
+            <Card className="space-y-4 p-6">
+                <h3 className="text-base font-semibold">Usage</h3>
+                <p className="text-sm text-muted-foreground">Buckets: {summary?.usage.bucket_count ?? 0}</p>
+                <p className="text-sm text-muted-foreground">
+                    Used space: {formatBytes(summary?.usage.used_bytes ?? null)}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Free space: {formatBytes(summary?.usage.free_bytes ?? null)}
+                </p>
             </Card>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Centralize provisioning credentials into environment variables instead of storing per-connection records in the control-plane database to simplify deployment and reduce operational surface.
- Provide runtime usage/summary endpoints for compute, storage, and database backends so the platform can report configuration status and basic usage metrics.
- Simplify create operations to use the centralized environment configuration rather than a selected DB-backed connection, and reflect that change in the web UI.

### Description
- Added environment-backed provisioning settings and dev defaults in `src/env.py` and introduced dataclasses for provision configs and usage (`ComputeProvisionConfig`, `DatabaseProvisionConfig`, `StorageProvisionConfig`, and usage types).
- Reworked services: `ComputesService`, `DatabasesService`, and `StoragesService` now provide `get_config()` and `usage()` and accept config objects for `create_*` operations, removing DB-backed connection CRUD and switching to direct provisioner clients (kubernetes/boto3/psycopg2) using env values.
- Introduced new Pydantic response models for summaries and configs (`*UsageSummary`, `*ConfigSummary`, `*SummaryResponse`) and removed the old connection create/delete/response models.
- Updated routes to return configuration + usage summaries for `GET /compute`, `GET /database`, `GET /storage`, simplified create endpoints to rely on env-configured provisioners, and return `503` when provisioning is not configured; frontend settings components were updated to fetch these summaries and display configuration and usage instead of connection-management UIs.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6d715ae0832390836161fe576e25)