### PR TITLE
Fix release workflow to run on published releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: write
@@ -11,13 +11,13 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'release' && github.event.release.draft == true
+    if: github.event_name == 'release' && github.event.release.draft == false
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.release_tag.outputs.tag }}
 
     steps:
-      - name: Resolve release tag from draft release event
+      - name: Resolve release tag from release event
         id: release_tag
         run: |
           RAW_TAG="${{ github.event.release.tag_name }}"


### PR DESCRIPTION
### Motivation
- The release workflow was not firing for published releases because it listened to `release.created` while also expecting `github.event.release.draft == true`, so published releases were skipped. 

### Description
- Change the workflow trigger from `release.created` to `release.published` by updating `on: release: types` to `[published]`. 
- Update the job gate to require `github.event.release.draft == false` so the job runs for published (non-draft) releases. 
- Rename the tag resolution step from `Resolve release tag from draft release event` to `Resolve release tag from release event` to match the new trigger. 

### Testing
- Inspected the updated workflow file with `sed -n '1,80p' .github/workflows/release.yml` and verified the trigger and condition lines were updated. 
- Verified the file contents with `nl -ba .github/workflows/release.yml | sed -n '1,70p'` to confirm the step name and condition changes. 
- Checked repository status with `git status --short` to ensure the working tree reflected the intended change and applied patch operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7cf0bc9083238ccd38da1e012010)