### PR TITLE
Release workflow: run on tag pushes or manual tag dispatch (v* tags)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,15 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,17 +18,31 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'release' && github.event.release.draft == false
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.release_tag.outputs.tag }}
 
     steps:
-      - name: Resolve release tag from release event
+      - name: Resolve release tag
         id: release_tag
         run: |
-          RAW_TAG="${{ github.event.release.tag_name }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            RAW_TAG="${{ github.event.inputs.tag }}"
+          else
+            RAW_TAG="${{ github.ref_name }}"
+          fi
+
+          if [[ -z "$RAW_TAG" ]]; then
+            echo "Release tag is required."
+            exit 1
+          fi
+
           TAG="${RAW_TAG#v}"
+
+          if [[ ! "$RAW_TAG" =~ ^v.+$ ]]; then
+            echo "Invalid release tag: $RAW_TAG. It must start with 'v'."
+            exit 1
+          fi
 
           if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid release tag: $RAW_TAG"


### PR DESCRIPTION
### Motivation
- Allow running the release pipeline directly from a tag push or from a manual workflow dispatch that references an existing tag rather than only from GitHub Release publish events.
- Enforce that releases use tags that start with `v` and retain semantic version validation (`vX.Y.Z`).

### Description
- Change workflow triggers from `release: published` to `push` on tags matching `v*` and add `workflow_dispatch` with a required `tag` input.
- Update tag resolution logic to use `github.ref_name` for tag pushes and `github.event.inputs.tag` for manual dispatch.
- Add validation to ensure the provided tag starts with `v` and continue validating the semantic version format after stripping the `v` prefix.
- Emit the resolved tag via the `release` job output so downstream jobs (SDK publish and API image publish) continue to consume the same value.

### Testing
- Ran `git diff --check` to ensure no whitespace issues, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de16d20cf483239f23b84d1cdb610d)