### PR TITLE
Add compute environments endpoint and centralized compute creation utility

### DIFF
--- a/api/src/db/services/computes.py
+++ b/api/src/db/services/computes.py
@@ -1,12 +1,4 @@
-from __future__ import annotations
-
-import re
-import asyncio
-from src.env import env
-from kubernetes import client
-from kubernetes.client.exceptions import ApiException
-
-_NAME_PATTERN = re.compile(r'^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$')
+from src.utils import compute
 
 
 class ComputesService:
@@ -21,70 +13,12 @@ class ComputesService:
         env_vars: dict[str, str],
         container_port: int | None,
     ) -> None:
-        if not _NAME_PATTERN.fullmatch(namespace):
-            raise ValueError('Namespace must contain only lowercase letters, numbers, dots and dashes')
-
-        if not _NAME_PATTERN.fullmatch(pod_name):
-            raise ValueError('Container name must contain only lowercase letters, numbers, dots and dashes')
-
-        await asyncio.to_thread(
-            self._create_container_sync,
-            namespace,
-            pod_name,
-            image,
-            command,
-            args,
-            env_vars,
-            container_port,
+        await compute.create(
+            namespace=namespace,
+            pod_name=pod_name,
+            image=image,
+            command=command,
+            args=args,
+            env_vars=env_vars,
+            container_port=container_port,
         )
-
-    @staticmethod
-    def _create_container_sync(
-        namespace: str,
-        pod_name: str,
-        image: str,
-        command: list[str] | None,
-        args: list[str] | None,
-        env_vars: dict[str, str],
-        container_port: int | None,
-    ) -> None:
-        configuration = client.Configuration()
-        configuration.host = env.ENV_PROVISION_COMPUTE_API_SERVER_URL
-        configuration.username = env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME
-        configuration.password = env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD
-        configuration.verify_ssl = env.ENV_PROVISION_COMPUTE_VERIFY_SSL
-
-        with client.ApiClient(configuration) as api_client:
-            core = client.CoreV1Api(api_client)
-
-            try:
-                core.read_namespace(name=namespace)
-            except ApiException as error:
-                if error.status != 404:
-                    raise
-                core.create_namespace(
-                    body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
-                )
-
-            try:
-                core.read_namespaced_pod(name=pod_name, namespace=namespace)
-                raise ValueError(f"Container '{pod_name}' already exists in namespace '{namespace}'")
-            except ApiException as error:
-                if error.status != 404:
-                    raise
-
-            container = client.V1Container(
-                name=pod_name,
-                image=image,
-                command=command,
-                args=args,
-                env=[client.V1EnvVar(name=name, value=value) for name, value in env_vars.items()],
-                ports=[client.V1ContainerPort(container_port=container_port)] if container_port else None,
-            )
-
-            pod = client.V1Pod(
-                metadata=client.V1ObjectMeta(name=pod_name, labels={'app': pod_name}),
-                spec=client.V1PodSpec(containers=[container], restart_policy='Always'),
-            )
-
-            core.create_namespaced_pod(namespace=namespace, body=pod)

--- a/api/src/models/computes.py
+++ b/api/src/models/computes.py
@@ -1,6 +1,13 @@
 from pydantic import Field, BaseModel
 
 
+class ComputeEnvironment(BaseModel):
+    key: str
+    api_server_url: str
+    default_namespace: str
+    verify_ssl: bool
+
+
 class ComputeContainerEnv(BaseModel):
     name: str = Field(min_length=1, max_length=128)
     value: str = Field(default='')

--- a/api/src/routes/compute.py
+++ b/api/src/routes/compute.py
@@ -2,7 +2,7 @@ import src.db as db
 from fastapi import HTTPException
 from src.env import env
 from src.router import router
-from src.models.computes import (ComputeContainerCreate,
+from src.models.computes import (ComputeEnvironment, ComputeContainerCreate,
                                  ComputeContainerCreateResponse)
 from kubernetes.client.exceptions import ApiException
 
@@ -16,6 +16,18 @@ def _pod_name_from_app_key(app_key: str, container_name: str) -> str:
 
     pod_name = f'{app_normalized}-{container_normalized}'
     return pod_name[:63].rstrip('-.')
+
+
+@router.get('/compute')
+async def list_compute_environments() -> list[ComputeEnvironment]:
+    return [
+        ComputeEnvironment(
+            key='default',
+            api_server_url=env.ENV_PROVISION_COMPUTE_API_SERVER_URL,
+            default_namespace=env.ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE,
+            verify_ssl=env.ENV_PROVISION_COMPUTE_VERIFY_SSL,
+        )
+    ]
 
 
 @router.post('/compute/apps/{app_id}/containers')

--- a/api/src/utils/compute.py
+++ b/api/src/utils/compute.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import re
+import asyncio
+from src.env import env
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+
+_NAME_PATTERN = re.compile(r'^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$')
+
+
+async def create(
+    *,
+    namespace: str,
+    pod_name: str,
+    image: str,
+    command: list[str] | None,
+    args: list[str] | None,
+    env_vars: dict[str, str],
+    container_port: int | None,
+) -> None:
+    if not _NAME_PATTERN.fullmatch(namespace):
+        raise ValueError('Namespace must contain only lowercase letters, numbers, dots and dashes')
+
+    if not _NAME_PATTERN.fullmatch(pod_name):
+        raise ValueError('Container name must contain only lowercase letters, numbers, dots and dashes')
+
+    await asyncio.to_thread(
+        _create_sync,
+        namespace,
+        pod_name,
+        image,
+        command,
+        args,
+        env_vars,
+        container_port,
+    )
+
+
+
+def _create_sync(
+    namespace: str,
+    pod_name: str,
+    image: str,
+    command: list[str] | None,
+    args: list[str] | None,
+    env_vars: dict[str, str],
+    container_port: int | None,
+) -> None:
+    configuration = client.Configuration()
+    configuration.host = env.ENV_PROVISION_COMPUTE_API_SERVER_URL
+    configuration.username = env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME
+    configuration.password = env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD
+    configuration.verify_ssl = env.ENV_PROVISION_COMPUTE_VERIFY_SSL
+
+    with client.ApiClient(configuration) as api_client:
+        core = client.CoreV1Api(api_client)
+
+        try:
+            core.read_namespace(name=namespace)
+        except ApiException as error:
+            if error.status != 404:
+                raise
+            core.create_namespace(
+                body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
+            )
+
+        try:
+            core.read_namespaced_pod(name=pod_name, namespace=namespace)
+            raise ValueError(f"Container '{pod_name}' already exists in namespace '{namespace}'")
+        except ApiException as error:
+            if error.status != 404:
+                raise
+
+        container = client.V1Container(
+            name=pod_name,
+            image=image,
+            command=command,
+            args=args,
+            env=[client.V1EnvVar(name=name, value=value) for name, value in env_vars.items()],
+            ports=[client.V1ContainerPort(container_port=container_port)] if container_port else None,
+        )
+
+        pod = client.V1Pod(
+            metadata=client.V1ObjectMeta(name=pod_name, labels={'app': pod_name}),
+            spec=client.V1PodSpec(containers=[container], restart_policy='Always'),
+        )
+
+        core.create_namespaced_pod(namespace=namespace, body=pod)


### PR DESCRIPTION
### Motivation

- Expose available compute environments so the web UI can discover runtimes from the control plane via a `GET /compute` endpoint.
- Centralize container creation/deployment logic to a reusable utility so compute provisioning is shared and easier to test and maintain.

### Description

- Added a `GET /compute` route that returns a list of `ComputeEnvironment` objects sourced from API env settings (currently emits a single `default` environment using `ENV_PROVISION_COMPUTE_*` values). 
- Introduced `src/utils/compute.py` with a `create()` function that validates namespace and pod names and synchronously deploys a pod to Kubernetes (including creating the namespace if missing). 
- Added a `ComputeEnvironment` Pydantic model in `src/models/computes.py` to type the `/compute` response. 
- Refactored `ComputesService.create_container()` to delegate to `src.utils.compute.create()` and removed duplicate kube client logic from the service.

### Testing

- Ran `python -m isort .` in `api` to fix imports, which completed successfully. 
- Ran `python -m compileall src/routes/compute.py src/utils/compute.py src/models/computes.py src/db/services/computes.py` in `api`, and compilation succeeded for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de18390bcc83239c821352ddcb17f0)