### PR TITLE
Refactor storage route to list configured backends and extract bucket creation util

### DIFF
--- a/api/src/db/services/storages.py
+++ b/api/src/db/services/storages.py
@@ -1,41 +1,18 @@
-import re
-import boto3
 import asyncio
 from src.env import env
-from botocore.exceptions import ClientError
-
-_BUCKET_NAME_PATTERN = re.compile(r'^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$')
+from src.utils import storage as storage_utils
+from src.models.storages import StorageConnection
 
 
 class StoragesService:
+    async def list(self) -> list[StorageConnection]:
+        return [
+            StorageConnection(
+                name='default',
+                endpoint_url=env.ENV_PROVISION_STORAGE_ENDPOINT_URL,
+                region_name=env.ENV_PROVISION_STORAGE_REGION_NAME,
+            ),
+        ]
+
     async def create_bucket(self, *, bucket_name: str) -> None:
-        if not _BUCKET_NAME_PATTERN.fullmatch(bucket_name):
-            raise ValueError('Bucket name must be 3-63 chars, lowercase, numbers or hyphens only')
-
-        await asyncio.to_thread(self._create_bucket_sync, bucket_name)
-
-    @staticmethod
-    def _create_bucket_sync(bucket_name: str) -> None:
-        client_kwargs: dict[str, str] = {
-            'aws_access_key_id': env.ENV_PROVISION_STORAGE_ACCESS_KEY_ID,
-            'aws_secret_access_key': env.ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY,
-            'endpoint_url': env.ENV_PROVISION_STORAGE_ENDPOINT_URL,
-        }
-        if env.ENV_PROVISION_STORAGE_REGION_NAME:
-            client_kwargs['region_name'] = env.ENV_PROVISION_STORAGE_REGION_NAME
-
-        client = boto3.client('s3', **client_kwargs)
-
-        try:
-            client.head_bucket(Bucket=bucket_name)
-            raise ValueError(f"Bucket '{bucket_name}' already exists")
-        except ClientError as error:
-            error_code = str(error.response.get('Error', {}).get('Code', ''))
-            if error_code not in {'404', 'NoSuchBucket', 'NotFound'}:
-                raise
-
-        create_kwargs: dict[str, str | dict[str, str]] = {'Bucket': bucket_name}
-        if env.ENV_PROVISION_STORAGE_REGION_NAME and env.ENV_PROVISION_STORAGE_REGION_NAME != 'us-east-1':
-            create_kwargs['CreateBucketConfiguration'] = {'LocationConstraint': env.ENV_PROVISION_STORAGE_REGION_NAME}
-
-        client.create_bucket(**create_kwargs)
+        await asyncio.to_thread(storage_utils.create, bucket_name)

--- a/api/src/models/storages.py
+++ b/api/src/models/storages.py
@@ -1,6 +1,12 @@
 from pydantic import BaseModel
 
 
+class StorageConnection(BaseModel):
+    name: str
+    endpoint_url: str
+    region_name: str | None = None
+
+
 class StorageBucketCreateResponse(BaseModel):
     app_id: str
     app_key: str

--- a/api/src/routes/storage.py
+++ b/api/src/routes/storage.py
@@ -1,36 +1,8 @@
 import src.db as db
-import botocore
-from fastapi import HTTPException
 from src.router import router
-from src.models.storages import StorageBucketCreateResponse
+from src.models.storages import StorageConnection
 
 
-def _bucket_name_from_app_key(app_key: str) -> str:
-    normalized = ''.join(character for character in app_key.lower() if character.isalnum() or character == '-')
-    normalized = normalized.strip('-')
-    if not normalized:
-        raise ValueError('App key does not contain valid characters to build a bucket name')
-
-    bucket = f'app-{normalized}'
-    return bucket[:63].rstrip('-')
-
-
-@router.post('/storage/apps/{app_id}/bucket')
-async def create_storage_bucket_for_app(app_id: str) -> StorageBucketCreateResponse:
-    app = await db.apps.get_by_uuid(app_id)
-    if app is None:
-        raise HTTPException(status_code=404, detail=f"App '{app_id}' not found")
-
-    try:
-        bucket_name = _bucket_name_from_app_key(app.key)
-        await db.storages.create_bucket(bucket_name=bucket_name)
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
-    except botocore.exceptions.BotoCoreError as error:
-        raise HTTPException(status_code=502, detail=f'Unable to create bucket: {str(error)}') from error
-
-    return StorageBucketCreateResponse(
-        app_id=app.id,
-        app_key=app.key,
-        bucket=bucket_name,
-    )
+@router.get('/storage')
+async def list_storages() -> list[StorageConnection]:
+    return await db.storages.list()

--- a/api/src/utils/storage.py
+++ b/api/src/utils/storage.py
@@ -1,0 +1,35 @@
+import re
+import boto3
+from src.env import env
+from botocore.exceptions import ClientError
+
+_BUCKET_NAME_PATTERN = re.compile(r'^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$')
+
+
+def create(bucket_name: str) -> None:
+    if not _BUCKET_NAME_PATTERN.fullmatch(bucket_name):
+        raise ValueError('Bucket name must be 3-63 chars, lowercase, numbers or hyphens only')
+
+    client_kwargs: dict[str, str] = {
+        'aws_access_key_id': env.ENV_PROVISION_STORAGE_ACCESS_KEY_ID,
+        'aws_secret_access_key': env.ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY,
+        'endpoint_url': env.ENV_PROVISION_STORAGE_ENDPOINT_URL,
+    }
+    if env.ENV_PROVISION_STORAGE_REGION_NAME:
+        client_kwargs['region_name'] = env.ENV_PROVISION_STORAGE_REGION_NAME
+
+    client = boto3.client('s3', **client_kwargs)
+
+    try:
+        client.head_bucket(Bucket=bucket_name)
+        raise ValueError(f"Bucket '{bucket_name}' already exists")
+    except ClientError as error:
+        error_code = str(error.response.get('Error', {}).get('Code', ''))
+        if error_code not in {'404', 'NoSuchBucket', 'NotFound'}:
+            raise
+
+    create_kwargs: dict[str, str | dict[str, str]] = {'Bucket': bucket_name}
+    if env.ENV_PROVISION_STORAGE_REGION_NAME and env.ENV_PROVISION_STORAGE_REGION_NAME != 'us-east-1':
+        create_kwargs['CreateBucketConfiguration'] = {'LocationConstraint': env.ENV_PROVISION_STORAGE_REGION_NAME}
+
+    client.create_bucket(**create_kwargs)


### PR DESCRIPTION
### Motivation
- Centralize S3 bucket creation logic so it can be reused across the API and services via a single util instead of being embedded in a route or service implementation. 
- Expose the currently configured storage backends (env-driven) via a listing endpoint instead of providing an inline bucket-creation route. 

### Description
- Removed the `POST /storage/apps/{app_id}/bucket` route and replaced it with a `GET /storage` endpoint that returns configured backends via `StorageConnection`.
- Added a reusable utility `src/utils/storage.py` exposing `create(bucket_name)` which performs bucket-name validation and S3 bucket creation using env provisioning settings.
- Updated `StoragesService` in `src/db/services/storages.py` to expose `list()` that returns the env-configured connection(s) and to delegate bucket creation to `src.utils.storage.create`.
- Introduced the `StorageConnection` Pydantic model in `src/models/storages.py` used by the new listing endpoint.

### Testing
- Ran `python -m isort .` in `api` and it completed successfully (imports fixed).
- Ran `python -m compileall src` in `api` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de18d47f088323a6ba626f2b227852)