### PR TITLE
docs: simplify and split contribution guides by area

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,188 +1,57 @@
 # Contributing to LongLink
 
-This document defines how to contribute to the LongLink project. The goal is to maintain architectural consistency, enforce platform principles, and ensure long-term scalability.
+Thanks for contributing.
 
-## Guiding Principles
+This guide explains the essentials so you can move quickly without breaking the platform model.
 
-All contributions must respect the core design constraints:
+## Before you start
 
-1. **Control plane owns infrastructure concerns**
-   - Authentication, permissions, storage, logging, execution policies
+- Read `AGENTS.md` in the folder you are changing.
+- Keep the current architecture direction.
+- Prefer the current development model over backward compatibility.
 
-2. **Applications contain only business logic**
-   - No custom auth, no custom storage policies
+## Project map
 
-3. **Deterministic execution**
-   - All state transitions occur server-side
+- `api/` → Control plane (auth, permissions, lifecycle, orchestration)
+- `sdk/` → Python SDK for application development
+- `web/` → Frontend runtime and control-plane UI integration
+- `xml/` → ReactXML runtime (XML to React rendering)
+- `docs/` → Platform and SDK documentation
 
-4. **Single source of truth**
-   - Actions define logic, UI, and API simultaneously
+Each area has its own local `CONTRIBUTING.md` with focused rules.
 
-## Repository Structure
-
-- `api/` → Control plane (FastAPI)
-- `sdk/` → Python SDK
-- `web/` → Frontend renderer
-
-## Development Workflow
-
-### 1. Setup Environment
+## Quick setup
 
 ```bash
 uv venv
 source .venv/bin/activate
 uv pip install -e './api[dev]'
 uv pip install -e './sdk'
-```
-
-Frontend:
-
-```bash
 bun --cwd=web install
-bun --cwd=web dev
 ```
 
-### 1.1 Local infrastructure connection parameters
+## Working style
 
-After running `make up`, local dependencies are available from `dev/compose.yml` (PostgreSQL + MinIO) and from the `k3d` cluster created by the Makefile (`compute`). Use the following values when connecting providers in the settings screens.
+- Keep changes small and clear.
+- Remove obsolete code when replacing old flows.
+- Keep responsibilities separated:
+  - Control plane handles governance/infrastructure concerns.
+  - Applications handle business logic.
+  - Web and XML layers render UI/runtime behavior.
 
-#### Database (PostgreSQL)
+## Formatting
 
-Use these values in **Settings → Database → Connect database server**:
-
-- **Server name**: `local-postgres` (or any label you prefer)
-- **Host**: `localhost`
-- **Port**: `15432`
-- **Username**: `admin`
-- **Password**: `admin`
-- **Maintenance database** (API default): `postgres`
-
-> Docker service source: `postgres` in `dev/compose.yml` with `POSTGRES_USER=admin`, `POSTGRES_PASSWORD=admin`, and port mapping `15432:5432`.
-
-#### Storage (MinIO / S3-compatible)
-
-Use these values in **Settings → Storage → Connect storage provider**:
-
-- **Provider name**: `local-minio` (or any label you prefer)
-- **Endpoint URL**: `http://localhost:19000`
-- **Region**: `us-east-1` (recommended; optional in UI)
-- **Access key**: `admin`
-- **Secret key**: `admin`
-
-> Docker service source: `minio` in `dev/compose.yml` with `MINIO_ROOT_USER=admin`, `MINIO_ROOT_PASSWORD=admin`, and port mapping `19000:9000`.
-
-#### Compute (k3d cluster)
-
-`make up` creates a local cluster named `compute` with Kubernetes API exposed on port `6550`.
-
-- **Cluster name**: `compute`
-- **Kubernetes API server URL**: `https://localhost:6550`
-- **Default namespace**: `default`
-- **TLS verification**: disable if your local certificate is not trusted (`verify_ssl=false`)
-
-If you need exact kubeconfig-auth data for manual API calls, run:
+When you are done:
 
 ```bash
-k3d kubeconfig get compute
+make format
 ```
 
-Use the credentials/certificates from that kubeconfig output.
+## Pull requests
 
-### 2. Branching
+A good PR should:
 
-- `main` → stable
-- `dev` → integration
-- feature branches → `feature/<name>`
-
-### 3. Code Standards
-
-#### Python
-
-- Use type hints everywhere
-- Follow PEP8
-- Prefer explicit over implicit
-- No hidden side effects
-
-#### API (Control Plane)
-
-- Must enforce permissions centrally
-- No business logic leakage from apps
-
-#### SDK
-
-- Must remain opinionated and constrained
-- Avoid introducing flexibility that breaks consistency
-
-#### Web
-
-- Pure renderer
-- No business logic in frontend
-
-## Actions Design Rules
-
-When adding new functionality:
-
-- Must be defined as an **action**
-
-- Must be:
-  - Typed
-  - Stateless (unless explicitly part of workflow)
-  - Deterministic
-
-- Must automatically support:
-  - UI rendering
-  - API access
-  - SDK invocation
-
-## Database Changes
-
-- Use migration system via CLI:
-
-```bash
-longlink db migrate
-```
-
-- No manual schema drift
-- All models must be defined in SDK
-
-## Testing
-
-- Unit tests for:
-  - SDK logic
-  - Control plane services
-
-- Integration tests for:
-  - Action execution
-  - Permission enforcement
-
-## Pull Requests
-
-Each PR must:
-
-- Clearly state purpose
-- Explain architectural impact
-- Avoid breaking platform invariants
-- Include tests (if applicable)
-
-## What NOT to Do
-
-- ❌ Add authentication inside apps
-- ❌ Introduce client-side logic
-- ❌ Duplicate infrastructure concerns
-- ❌ Bypass control plane
-- ❌ Add unstructured APIs outside actions
-
-## Open Areas
-
-- Permissions system design
-- Workflow engine implementation
-- Application lifecycle management
-- UI schema standardization
-
-## Communication
-
-Be precise. Avoid ambiguity. All design discussions should be grounded in system constraints.
-
-## License
-
-[TODO]
+- explain what changed
+- explain why it changed
+- mention any architectural impact
+- include validation steps you ran

--- a/api/contributing.md
+++ b/api/contributing.md
@@ -1,0 +1,30 @@
+# Contributing in `api/`
+
+Thanks for helping improve the control plane.
+
+## What this folder owns
+
+The API is the control plane. It is responsible for authentication, permissions, governance, and orchestration.
+
+## Keep changes aligned
+
+- Keep validation in Pydantic schemas.
+- Use shared enums for constrained values.
+- Let FastAPI typing handle request/query validation.
+- Keep route handlers focused on orchestration.
+- Normalize external input at boundaries.
+- Translate meaningful exceptions into proper HTTP responses.
+
+## Practical rules
+
+- Reuse schemas/enums across layers when possible.
+- Avoid embedding validation logic directly in route handlers.
+- Remove outdated paths when introducing the new model.
+
+## Formatting
+
+Before opening a PR:
+
+```bash
+python -m isort .
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,34 @@
+# Contributing in `docs/`
+
+Thanks for improving LongLink documentation.
+
+## Goal
+
+Write docs that are clear, direct, and easy to translate.
+
+## Writing rules
+
+- Use short, concrete sentences.
+- Prefer explicit nouns over ambiguous pronouns.
+- Avoid marketing language.
+- Explain platform responsibilities clearly (control plane vs SDK vs app).
+- Use consistent terms (application, control plane, SDK, API, XML page).
+
+## Recommended structure
+
+When relevant, include:
+
+1. What this feature is for
+2. How to use it (step by step)
+3. Request/response models or parameters
+4. A minimal example
+
+## VitePress containers
+
+You can use:
+
+- `info`
+- `tip`
+- `warning`
+- `danger`
+- `details`

--- a/sdk/contributing.md
+++ b/sdk/contributing.md
@@ -1,0 +1,28 @@
+# Contributing in `sdk/`
+
+Thanks for contributing to the Python SDK.
+
+## What this folder owns
+
+The SDK defines how applications are built on LongLink.
+
+## Keep changes aligned
+
+- Keep the SDK opinionated and consistent.
+- Prefer simple, explicit APIs.
+- Remove obsolete code when replacing behavior.
+- Do not add tests right now (project rule in current phase).
+
+## Useful commands
+
+Install SDK in editable mode:
+
+```bash
+pip install -e './sdk'
+```
+
+Format imports before PR:
+
+```bash
+python -m isort .
+```

--- a/web/contributing.md
+++ b/web/contributing.md
@@ -1,0 +1,23 @@
+# Contributing in `web/`
+
+Thanks for contributing to the web layer.
+
+## What this folder owns
+
+This project renders LongLink UI and connects to platform APIs.
+
+## Keep changes aligned
+
+- Use shadcn components for reusable UI.
+- Keep UI behavior consistent across screens.
+- For static content, write JSX elements explicitly (do not use `.map()`).
+- Prefer `src/lib/api.ts` utilities (`apiFetch`) over raw `fetch`.
+- Remove legacy rendering paths when replacing flows.
+
+## Formatting
+
+Before PR:
+
+```bash
+bun run format
+```

--- a/xml/contributing.md
+++ b/xml/contributing.md
@@ -1,0 +1,23 @@
+# Contributing in `xml/`
+
+Thanks for improving the ReactXML runtime.
+
+## What this folder owns
+
+A focused XML-to-React runtime pipeline:
+
+- compiler
+- runtime
+- primitives
+- renderer
+- registry
+- shared types
+
+## Keep changes aligned
+
+- Keep XML structure concerns separate from runtime evaluation.
+- Keep runtime evaluation separate from React rendering.
+- Keep changes concise and local to the right pipeline stage.
+- Prefer the current model over backward compatibility.
+- Remove obsolete code when introducing new behavior.
+- Do not add tests right now (current project rule).


### PR DESCRIPTION
### Motivation
- Simplify and shorten the global contribution guide so new contributors can get started quickly without losing alignment with the platform architecture. 
- Surface area-specific rules next to the code they apply to by adding focused `contributing.md` files in each major folder. 
- Remove non-essential operational detail from the root guide while preserving essential setup and formatting steps. 

### Description
- Rewrote the root `CONTRIBUTING.md` to be friendlier and more concise and to point contributors to area-specific guides. 
- Added `api/contributing.md` with concise control-plane guidance (Pydantic/FastAPI validation rules and formatting note). 
- Added `docs/contributing.md` with simplified documentation style rules and recommended structure. 
- Added `sdk/contributing.md`, `web/contributing.md`, and `xml/contributing.md` with short, focused rules and a small set of practical commands (e.g., `pip install -e './sdk'`, `bun run format`). 

### Testing
- Attempted to run `make format` from the repository root and it failed due to the environment Python version (current Python `3.10.19` while `longlink-api[dev]` requires `>= 3.12`). 
- No other automated tests were added or run because this is a documentation-only change and the repository guidance currently discourages adding tests in this phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8e0aa7608323afa531e6a917014d)