### PR TITLE
xml: ignore XML directives (<!doctype>, <?xml?>) during AST conversion

### DIFF
--- a/xml/src/compiler/parseXML.ts
+++ b/xml/src/compiler/parseXML.ts
@@ -34,6 +34,11 @@ function convertNode(entry: PreserveOrderNode): ASTNode | null {
     const nodeName = Object.keys(entry).find((key) => key !== ATTRIBUTES_NODE_NAME);
     if (!nodeName) return null;
 
+    // Ignore XML declarations/directives (e.g. <!doctype ...>, <?xml ...?>)
+    if (nodeName.startsWith('!') || nodeName.startsWith('?')) {
+        return null;
+    }
+
     /* Text Node */
     if (nodeName === TEXT_NODE_NAME) {
         const text = entry[TEXT_NODE_NAME];


### PR DESCRIPTION
### Motivation
- Prevent the runtime from treating XML declarations/directives (e.g. `<!doctype ...>` and `<?xml ...?>`) as renderable components, which produced errors like `Unknown component "!doctype"`.

### Description
- Add a guard in `convertNode` (`xml/src/compiler/parseXML.ts`) to return `null` when `nodeName` starts with `!` or `?`, skipping directive/declaration nodes during `xmlToAST` conversion.

### Testing
- Ran `bun run format` in `xml/` successfully to apply formatting. 
- Attempted `make format` at the repository root but it failed due to the environment Python version not meeting the API package requirement (available Python `3.10.19` vs required `>=3.12`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df905c1bec832387d2229a58dcb212)