### PR TITLE
fix(web): register Table component in XML registry

### DIFF
--- a/web/src/lib/registry.ts
+++ b/web/src/lib/registry.ts
@@ -22,7 +22,7 @@ import Separator from '@/longlink/Separator';
 import Slider from '@/longlink/Slider';
 import Stack from '@/longlink/Stack';
 import Switch from '@/longlink/Switch';
-import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/longlink/Table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/longlink/Table';
 import Textarea from '@/longlink/Textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/longlink/Tabs';
 import { Blockquote, Code, H1, H2, H3, H4, Li, P, Ul } from '@/longlink/Typography';
@@ -73,6 +73,7 @@ export const Components = {
     Slider,
     Stack,
     Switch,
+    Table,
     TableBody,
     TableCell,
     TableHead,


### PR DESCRIPTION
### Motivation
- XML pages using a top-level `<Table>` (e.g. `/people`) failed at runtime with `Unknown component "Table"` because the registry only exposed table subcomponents and not the `Table` component itself.

### Description
- Import `Table` from `@/longlink/Table` and add `Table` to the `Components` map in `web/src/lib/registry.ts` so `<Table .../>` tags resolve correctly at runtime.

### Testing
- Ran `bun run format` and `bun run build` in `web/` successfully, while `make format` at the repo root failed in this environment because the `api` package requires Python >= 3.12 (container has 3.10.19).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9287657083239adf3dc1db15fe5c)