### PR TITLE
Set SDK version from release tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,35 @@ jobs:
 
           echo "value=$SDK_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Build the distribution
+      - name: Set SDK version
         working-directory: sdk
         env:
-          LONG_LINK_VERSION: ${{ steps.sdk_version.outputs.value }}
+          SDK_VERSION: ${{ steps.sdk_version.outputs.value }}
+        run: |
+          python - <<'PYTHON'
+          from pathlib import Path
+          import os
+          import tomllib
+
+          version = os.environ["SDK_VERSION"]
+          pyproject_path = Path("pyproject.toml")
+          data = tomllib.loads(pyproject_path.read_text())
+          old_version = data["project"]["version"]
+
+          if old_version == version:
+              raise SystemExit("SDK version is already set.")
+
+          pyproject_path.write_text(
+              pyproject_path.read_text().replace(
+                  f'version = "{old_version}"',
+                  f'version = "{version}"',
+                  1,
+              )
+          )
+          PYTHON
+
+      - name: Build the distribution
+        working-directory: sdk
         run: python -m build
 
       - name: Publish to PyPI (OIDC)


### PR DESCRIPTION
### Motivation
- PyPI rejects uploads when the built wheel's filename/version already exists, and the SDK was always built with `project.version = "0.0.0"` causing releases like `v0.0.1` to fail. 
- The release flow needs to propagate the Git tag-derived semantic version into the static `sdk/pyproject.toml` field so built artifacts carry the correct version.

### Description
- Updated `.github/workflows/release.yml` to resolve the SDK version from the release tag and expose it as `SDK_VERSION` for the job. 
- Added a `Set SDK version` step that runs a short Python snippet to read `sdk/pyproject.toml`, replace the `project.version` value with the tag-derived `SDK_VERSION`, and bail if it's already set. 
- Removed reliance on the previous `LONG_LINK_VERSION` build-time env injection and placed the version directly into the static `pyproject.toml` before running `python -m build` in `sdk`.
- Committed the workflow change that ensures distributions built in the job carry the correct version.

### Testing
- Ran the repository formatting step via `make format`, which failed in this environment because the formatter bootstraps a Python 3.10 virtualenv while `api` requires `>=3.12`, so `make format` did not complete successfully. (Failure)
- Verified the workflow file change locally by inspecting the updated `.github/workflows/release.yml` and committing the change; no CI run was available in this environment. (Inspection only)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df93172e648323872ae73af32de65e)