### PR TITLE
Normalize XML API payloads before rendering organization and app pages

### DIFF
--- a/web/src/lib/xml.ts
+++ b/web/src/lib/xml.ts
@@ -1,0 +1,25 @@
+export type XmlApiResponse =
+    | string
+    | { xml?: string | null; content?: string | null; page?: string | null }
+    | null
+    | undefined;
+
+export function resolveXmlPayload(payload: XmlApiResponse): string | null {
+    if (typeof payload === 'string') {
+        const trimmedPayload = payload.trim();
+        return trimmedPayload.length > 0 ? trimmedPayload : null;
+    }
+
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    const xmlCandidate = payload.xml ?? payload.content ?? payload.page;
+
+    if (typeof xmlCandidate !== 'string') {
+        return null;
+    }
+
+    const trimmedCandidate = xmlCandidate.trim();
+    return trimmedCandidate.length > 0 ? trimmedCandidate : null;
+}

--- a/web/src/pages/org/Longlink.tsx
+++ b/web/src/pages/org/Longlink.tsx
@@ -1,6 +1,7 @@
 import Render from '@/components/Render';
 import { useApiData } from '@/hooks/use-data';
 import { type AppNavigationPage } from '@/lib/navigation';
+import { resolveXmlPayload } from '@/lib/xml';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
 
@@ -29,7 +30,10 @@ export default function Longlink() {
     const activePagePath = normalizedRoutePath || fallbackPagePath;
     const pageEndpoint = appId ? (activePagePath.length > 0 ? `/apps/${appId}/pages/${activePagePath}` : null) : null;
 
-    const { data, isLoading, error } = useApiData<string>(pageEndpoint);
+    const { data, isLoading, error } = useApiData<string | { xml?: string | null; content?: string | null }>(
+        pageEndpoint
+    );
+    const xml = resolveXmlPayload(data);
 
     if (error) {
         return <div>{error.message}</div>;
@@ -43,9 +47,9 @@ export default function Longlink() {
         return <div>No pages configured for this app.</div>;
     }
 
-    if (!data) {
+    if (!xml) {
         return <div>Unexpected response format for {pageEndpoint}</div>;
     }
 
-    return <Render xml={data} />;
+    return <Render xml={xml} />;
 }

--- a/web/src/pages/org/OrganizationPage.tsx
+++ b/web/src/pages/org/OrganizationPage.tsx
@@ -1,5 +1,6 @@
 import Render from '@/components/Render';
 import { useApiData } from '@/hooks/use-data';
+import { resolveXmlPayload } from '@/lib/xml';
 
 type OrganizationPageProps = {
     page: 'overview' | 'tools' | 'spaces' | 'processes' | 'people' | 'settings';
@@ -7,7 +8,8 @@ type OrganizationPageProps = {
 
 export default function OrganizationPage({ page }: OrganizationPageProps) {
     const endpoint = `/pages/${page}`;
-    const { data, isLoading, error } = useApiData<string>(endpoint);
+    const { data, isLoading, error } = useApiData<string | { xml?: string | null; content?: string | null }>(endpoint);
+    const xml = resolveXmlPayload(data);
 
     if (error) {
         return <div>{error.message}</div>;
@@ -17,9 +19,9 @@ export default function OrganizationPage({ page }: OrganizationPageProps) {
         return <div>Loading...</div>;
     }
 
-    if (!data) {
+    if (!xml) {
         return <div>Unexpected response format for {endpoint}</div>;
     }
 
-    return <Render xml={data} />;
+    return <Render xml={xml} />;
 }


### PR DESCRIPTION
### Motivation
- Organization and app pages could return object-shaped payloads (e.g. { xml, content, page }) which were passed directly into the XML renderer and produced an empty/blank UI. 
- Normalize responses so `Render` always receives a valid XML string and pages like Overview and Settings render reliably.

### Description
- Add `resolveXmlPayload` utility to `web/src/lib/xml.ts` that accepts a string or object wrapper and returns a trimmed XML string or `null` if none found. 
- Update `OrganizationPage` (`web/src/pages/org/OrganizationPage.tsx`) to accept object/string responses and use `resolveXmlPayload` before calling `Render`. 
- Update app page renderer `Longlink` (`web/src/pages/org/Longlink.tsx`) to use the same normalization and adjust `useApiData` typings to accept object-wrapped payloads. 

### Testing
- Ran `cd web && bun run format` which completed successfully. 
- Ran `cd web && bun run build:api` which completed successfully and produced a build. 
- Ran `make format` which failed in this environment due to the repo requiring Python >= 3.12 while the container provides Python 3.10.19.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df950e291c8323899190be7a2ab9ec)