### PR TITLE
fix(api): include XML dependency in web-builder Docker stage

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,7 @@ FROM oven/bun:1 AS web-builder
 
 WORKDIR /web
 COPY web/package.json web/bun.lock ./
+COPY xml /xml
 RUN bun install --frozen-lockfile
 COPY web/ ./
 RUN bun run build


### PR DESCRIPTION
### Motivation
- The web-builder stage failed at `bun install --frozen-lockfile` because the local package referenced as `reactxml: file:../xml` in `web/package.json` was not present in the build context.

### Description
- Add `COPY xml /xml` to `api/Dockerfile` so the local `xml` package is available inside the web-builder image before running `bun install --frozen-lockfile`.

### Testing
- Ran `cd web && bun install --frozen-lockfile`, which failed in this environment due to repeated npm registry `403` errors so install did not complete.
- Ran `make format`, which failed because the environment Python is `3.10.19` while the project requires Python `>=3.12` for the `longlink-api[dev]` extras.
- Attempted `docker build -f api/Dockerfile -t longlink-api-test .`, which could not be executed here because the `docker` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb1228010832391fe4e4305e7d868)