### PR TITLE
Fix settings page rendering by using Icon wrapper for menu section icons

### DIFF
--- a/web/src/longlink/Menu.tsx
+++ b/web/src/longlink/Menu.tsx
@@ -2,16 +2,16 @@ import {
     Children,
     Fragment,
     isValidElement,
-    lazy,
     useEffect,
     useMemo,
     useState,
     type ReactElement,
-    type LazyExoticComponent,
     type ReactNode,
 } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { AppWindow } from 'lucide-react';
+import type { LucideProps } from 'lucide-react';
+import { Icon } from '@/longlink/Icon';
 
 // import { getIconByName } from '@/components/Icon';
 
@@ -62,22 +62,9 @@ type NormalizedSection = {
     subSections: NormalizedSubSection[];
 };
 
-type IconModule = {
-    default: LucideIcon;
-};
-
-const iconImporters = import.meta.glob<IconModule>('/node_modules/lucide-react/dist/esm/icons/*.js');
-const lazyIcons: Record<string, LazyExoticComponent<LucideIcon>> = {};
-
-for (const path in iconImporters) {
-    const match = path.match(/icons\/(.*)\.js$/);
-
-    if (!match) {
-        continue;
-    }
-
-    lazyIcons[match[1]] = lazy(iconImporters[path]);
-}
+const MenuSectionIcon = ({ iconName, ...props }: { iconName: string } & LucideProps) => (
+    <Icon name={iconName} fallback="app-window" {...props} />
+);
 
 function flattenParsedProps<T extends object>(props: T & { props?: T }): T {
     if (!props.props) {
@@ -98,8 +85,13 @@ function resolveSectionIcon(props: ParsedMenuSectionProps): LucideIcon {
     if (!iconName) {
         return AppWindow;
     }
+    const resolvedIconName = iconName;
 
-    return (lazyIcons[iconName] ?? AppWindow) as LucideIcon;
+    function ResolvedMenuSectionIcon(iconProps: LucideProps) {
+        return <MenuSectionIcon iconName={resolvedIconName} {...iconProps} />;
+    }
+
+    return ResolvedMenuSectionIcon as LucideIcon;
 }
 
 function resolveSubSectionIsRoot(props: ParsedMenuSubSectionProps): boolean {


### PR DESCRIPTION
### Motivation
- Settings page failed to render because menu section icons were resolved to `React.lazy` components without a surrounding `Suspense`, which could throw at runtime when XML used `<MenuSection icon="...">`.

### Description
- Replaced the `import.meta.glob` + `React.lazy` icon loader with a small `MenuSectionIcon` helper that renders the existing `Icon` wrapper (`<Icon name=... fallback="app-window" />`).
- Updated `resolveSectionIcon` in `web/src/longlink/Menu.tsx` to return a lightweight component that calls `MenuSectionIcon` so icons render safely inside the menu tree.
- Removed unused `lazy` and `LazyExoticComponent` usage and preserved the `app-window` fallback behavior.
- Modified file: `web/src/longlink/Menu.tsx`.

### Testing
- `cd web && bun run format` — succeeded.
- `cd web && bun run build` — succeeded after the fix (production build completed).
- `cd /workspace/longlink && make format` — failed in this environment because the repo requires Python `>=3.12` while the container has Python `3.10.19` (environment constraint, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb2c7ee4483239017486eb47c072f)