### PR TITLE
Fix settings page rendering by improving Menu XML node matching

### DIFF
--- a/web/src/longlink/Menu.tsx
+++ b/web/src/longlink/Menu.tsx
@@ -103,13 +103,26 @@ function collectElementsOfType<T extends object>(
     component: (props: T) => ReactElement | null
 ): ReactElement<T>[] {
     const elements: ReactElement<T>[] = [];
+    const typedComponent = component as { displayName?: string; name?: string };
+    const componentName = typedComponent.displayName ?? typedComponent.name;
+
+    const isMatchingComponent = (child: ReactElement) => {
+        if (child.type === component) {
+            return true;
+        }
+
+        const childType = child.type as { displayName?: string; name?: string };
+        const childTypeName = childType.displayName ?? childType.name;
+
+        return Boolean(componentName && childTypeName && childTypeName === componentName);
+    };
 
     for (const child of Children.toArray(children)) {
         if (!isValidElement(child)) {
             continue;
         }
 
-        if (child.type === component) {
+        if (isMatchingComponent(child)) {
             elements.push(child as ReactElement<T>);
             continue;
         }


### PR DESCRIPTION
### Motivation

- The Settings page rendered empty because the XML-driven `MenuSection`/`MenuSubSection` nodes produced by the XML renderer were not matched by the menu normalization logic. 
- The goal is to make the XML-to-React menu parsing resilient to wrapped component types so XML menu nodes are detected reliably.

### Description

- Updated `collectElementsOfType` in `web/src/longlink/Menu.tsx` to fall back to matching components by `displayName`/`name` in addition to direct identity, and added a typed component helper to avoid TypeScript errors. 
- The change adds a local `isMatchingComponent` helper that recognizes ReactXML-wrapped components by name so `MenuSection` and `MenuSubSection` are correctly detected. 
- The fix is scoped to menu normalization and does not change routing, API endpoints, or page XML files.

### Testing

- Ran web formatter: `bun run format` and it completed successfully. 
- Ran web build and typecheck: `bun run build` and it completed successfully. 
- Ran root formatting attempt: `make format` failed due to environment Python version mismatch (local Python 3.10 vs required >=3.12) which prevented formatting the `api` package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb5edbb408323828f2010ac33f719)