### PR TITLE
Install xml package dependencies in web-builder stage of api Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /web
 COPY web/package.json web/bun.lock ./
 COPY xml /xml
 RUN bun install --frozen-lockfile
+WORKDIR /xml
+RUN bun install --frozen-lockfile
+WORKDIR /web
 COPY web/ ./
 RUN bun run build
 


### PR DESCRIPTION
### Motivation
- The web TypeScript build imports files from the local `xml` package which failed to resolve peer/dependency modules during the image build, causing missing-module errors like `react`, `@tanstack/react-query`, and `fast-xml-parser`.

### Description
- Update `api/Dockerfile` web-builder stage to run `bun install --frozen-lockfile` in `/xml` before switching back to `/web` and running `bun run build`, so the linked `xml` package has its dependencies installed during the web bundle step.

### Testing
- Ran `make format`, which failed due to the environment Python version mismatch (project requires Python `>=3.12`).
- Attempted `docker build -f api/Dockerfile . --target web-builder`, which could not be executed because `docker` is not available in this environment.
- Attempted `bun install --frozen-lockfile` in `web/`, which failed in this environment due to HTTP 403 responses from the npm registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc1e619088323a71b85a0733eb116)