### PR TITLE
Fix API image build by copying Vite output from correct path

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 COPY api /app
 RUN pip install --no-cache-dir .
-COPY --from=web-builder /web/dist /app/static
+COPY --from=web-builder /api/static /app/static
 
 EXPOSE 8000
 


### PR DESCRIPTION
### Motivation
- The multi-stage Docker build failed because the web build emits API-mode assets to `../api/static` (resolved as `/api/static`) while the Dockerfile was attempting to copy `/web/dist`, which is not produced.

### Description
- Update `api/Dockerfile` to replace `COPY --from=web-builder /web/dist /app/static` with `COPY --from=web-builder /api/static /app/static` so the runtime stage copies the actual Vite output.

### Testing
- Ran `make format`, which failed due to the environment Python version (3.10.19) not satisfying the project's `Python>=3.12` requirement, and attempted `docker build -f api/Dockerfile .`, which could not run because `docker` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dc8d6b1083239b3de2e01cb6e1a6)