### PR TITLE
Make `resolveSet` use functional updates and add Bun unit tests for XML runtime/renderers/compiler/registry

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,8 @@
         "lint": "eslint . --fix",
         "preview": "vite preview",
         "format": "bunx prettier . --write",
-        "dev": "vite"
+        "dev": "vite",
+        "test": "bun test"
     },
     "dependencies": {
         "@base-ui/react": "^1.4.0",

--- a/web/src/xml/runtime.tsx
+++ b/web/src/xml/runtime.tsx
@@ -124,9 +124,16 @@ export function resolveSet(target: string, valueExpr: string, ctx: ExecutionCont
 
     /* Return a closure that evaluates the expression and writes to state */
     return () => {
-        const [current, setter] = stateEntry;
+        const [, setter] = stateEntry;
         const newValue = evaluate(valueExpr, ctx);
-        setter(propPath.length === 0 ? newValue : setDeep(current, propPath, newValue));
+
+        if (propPath.length === 0) {
+            setter(newValue);
+            return;
+        }
+
+        // Use functional setter update so multiple set: handlers in one click compose safely.
+        setter((previous: unknown) => setDeep(previous, propPath, newValue));
     };
 }
 

--- a/web/test/xml/compiler.test.ts
+++ b/web/test/xml/compiler.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+const xmlInputs = {
+    rich: '<Page></Page>',
+    attrs: '<Button />',
+};
+
+mock.module('fast-xml-parser', () => {
+    return {
+        XMLParser: class {
+            parse(xml: string) {
+                if (xml === xmlInputs.rich) {
+                    return [
+                        {
+                            '?xml': [],
+                        },
+                        {
+                            '#text': '   ',
+                        },
+                        {
+                            Page: [
+                                {
+                                    Text: [{ '#text': 'Hello' }],
+                                },
+                                {
+                                    '#text': ' world ',
+                                },
+                                {
+                                    '!DOCTYPE': [],
+                                },
+                            ],
+                        },
+                    ];
+                }
+
+                if (xml === xmlInputs.attrs) {
+                    return [
+                        {
+                            Button: [],
+                            ':@': {
+                                title: 'Submit',
+                                valid: true,
+                                'set:filter.value': "'week'",
+                            },
+                        },
+                    ];
+                }
+
+                return [];
+            }
+        },
+    };
+});
+
+describe('xmlToAST', () => {
+    it('converts preserve-order structure into filtered AST nodes', async () => {
+        const { xmlToAST } = await import('../../src/xml/compiler');
+        const ast = xmlToAST(xmlInputs.rich);
+
+        expect(ast).toEqual([
+            {
+                name: 'Page',
+                children: [
+                    {
+                        name: 'Text',
+                        children: [{ name: 'text', value: 'Hello' }],
+                    },
+                    { name: 'text', value: ' world ' },
+                ],
+            },
+        ]);
+    });
+
+    it('keeps string attrs only and preserves namespaced-like attr names', async () => {
+        const { xmlToAST } = await import('../../src/xml/compiler');
+        const ast = xmlToAST(xmlInputs.attrs);
+
+        expect(ast).toEqual([
+            {
+                name: 'Button',
+                params: {
+                    title: 'Submit',
+                    'set:filter.value': "'week'",
+                },
+            },
+        ]);
+    });
+});

--- a/web/test/xml/registry.test.ts
+++ b/web/test/xml/registry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { createContext, createRegistry } from '../../src/xml/registry';
+
+describe('createContext', () => {
+    it('builds default empty context', () => {
+        expect(createContext()).toEqual({
+            state: {},
+            queries: {},
+            scope: {},
+            baseUrl: '',
+        });
+    });
+
+    it('keeps provided partial values', () => {
+        expect(
+            createContext({
+                scope: { item: 1 },
+                baseUrl: '/api',
+            })
+        ).toEqual({
+            state: {},
+            queries: {},
+            scope: { item: 1 },
+            baseUrl: '/api',
+        });
+    });
+});
+
+describe('createRegistry', () => {
+    it('merges defaults with custom components', () => {
+        const Custom = () => null;
+        const merged = createRegistry({ Custom });
+
+        expect(merged.Custom).toBe(Custom);
+        expect(merged.Page).toBeDefined();
+    });
+
+    it('lets custom components override defaults', () => {
+        const OverridePage = () => null;
+        const merged = createRegistry({ Page: OverridePage });
+
+        expect(merged.Page).toBe(OverridePage);
+    });
+});

--- a/web/test/xml/renderers.test.ts
+++ b/web/test/xml/renderers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+import type { ComponentType } from 'react';
+import { render, renderNode } from '../../src/xml/renderers';
+import type { ASTNode, ExecutionContext, RegistryShape } from '../../src/xml/types';
+
+describe('renderNode', () => {
+    it('returns null for missing node input', () => {
+        const ctx: ExecutionContext = { state: {}, queries: {}, scope: {} };
+
+        expect(renderNode(null, {}, ctx)).toBeNull();
+    });
+
+    it('interpolates text nodes', () => {
+        const ctx: ExecutionContext = {
+            state: { count: [7, () => {}] },
+            queries: {},
+            scope: {},
+        };
+
+        expect(renderNode({ name: 'text', value: 'Count {count}' }, {}, ctx)).toBe('Count 7');
+    });
+
+    it('skips nodes when if condition is false', () => {
+        const ctx: ExecutionContext = { state: {}, queries: {}, scope: {} };
+        const node: ASTNode = { name: 'Widget', params: { if: '{false}' } };
+
+        expect(renderNode(node, { Widget: (() => null) as ComponentType<any> }, ctx)).toBeNull();
+    });
+
+    it('throws on unknown component', () => {
+        const ctx: ExecutionContext = { state: {}, queries: {}, scope: {} };
+
+        expect(() => renderNode({ name: 'Unknown' }, {}, ctx)).toThrow('Unknown component "Unknown"');
+    });
+
+    it('resolves props and composes multiple set handlers into one onClick', () => {
+        let latestValue: unknown;
+        let currentValue = { range: { from: 1, to: 2 }, mode: 'day' };
+        const ctx: ExecutionContext = {
+            state: {
+                filter: [
+                    currentValue,
+                    (value: unknown) => {
+                        latestValue =
+                            typeof value === 'function' ? (value as (prev: unknown) => unknown)(currentValue) : value;
+                        currentValue = latestValue as typeof currentValue;
+                    },
+                ],
+                count: [2, () => {}],
+            },
+            queries: {},
+            scope: {},
+        };
+
+        const registry: RegistryShape = {
+            Widget: (() => null) as ComponentType<any>,
+        };
+
+        const node: ASTNode = {
+            name: 'Widget',
+            params: {
+                label: 'Count: {count}',
+                'set:filter.range.to': '3',
+                'set:filter.mode': "'week'",
+            },
+        };
+
+        const runtimeProviderElement = renderNode(node, registry, ctx) as any;
+        const widgetElement = runtimeProviderElement.props.children;
+
+        expect(widgetElement.props.label).toBe('Count: 2');
+
+        widgetElement.props.onClick();
+
+        expect(latestValue).toEqual({ range: { from: 1, to: 3 }, mode: 'week' });
+    });
+
+    it('adds base url prop to rendered component', () => {
+        const ctx: ExecutionContext = {
+            state: {},
+            queries: {},
+            scope: {},
+            baseUrl: '/api',
+        };
+        const registry: RegistryShape = {
+            Widget: (() => null) as ComponentType<any>,
+        };
+
+        const runtimeProviderElement = renderNode({ name: 'Widget' }, registry, ctx) as any;
+        const widgetElement = runtimeProviderElement.props.children;
+
+        expect(widgetElement.props._baseUrl).toBe('/api');
+    });
+});
+
+describe('render', () => {
+    it('renders each root node wrapped as fragments', () => {
+        const ctx: ExecutionContext = { state: {}, queries: {}, scope: {} };
+        const registry: RegistryShape = {
+            Widget: (() => null) as ComponentType<any>,
+        };
+
+        const output = render([{ name: 'Widget' }, { name: 'Widget' }], registry, ctx) as any[];
+
+        expect(Array.isArray(output)).toBe(true);
+        expect(output).toHaveLength(2);
+    });
+});

--- a/web/test/xml/runtime.test.ts
+++ b/web/test/xml/runtime.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'bun:test';
+import { evaluate, interpolate, resolveCondition, resolveSet, resolveValue } from '../../src/xml/runtime';
+import type { ExecutionContext } from '../../src/xml/types';
+
+describe('evaluate', () => {
+    it('resolves state, queries, and scope with scope precedence', () => {
+        const ctx: ExecutionContext = {
+            state: {
+                count: [1, () => {}],
+                name: ['from-state', () => {}],
+            },
+            queries: {
+                total: 10,
+                name: 'from-query',
+            },
+            scope: {
+                name: 'from-scope',
+            },
+        };
+
+        expect(evaluate('count + total', ctx)).toBe(11);
+        expect(evaluate('name', ctx)).toBe('from-scope');
+    });
+});
+
+describe('interpolate', () => {
+    it('injects evaluated expression values into templates', () => {
+        const ctx: ExecutionContext = {
+            state: { count: [3, () => {}] },
+            queries: {},
+            scope: { label: 'items' },
+        };
+
+        expect(interpolate('Total {count} {label}', ctx)).toBe('Total 3 items');
+    });
+});
+
+describe('resolveValue', () => {
+    it('interpolates non-braced values as templates', () => {
+        const ctx: ExecutionContext = {
+            state: { count: [4, () => {}] },
+            queries: {},
+            scope: {},
+        };
+
+        expect(resolveValue('Count: {count}', ctx)).toBe('Count: 4');
+    });
+
+    it('returns typed value for single expression', () => {
+        const ctx: ExecutionContext = {
+            state: { count: [4, () => {}] },
+            queries: {},
+            scope: {},
+        };
+
+        expect(resolveValue('{count * 2}', ctx)).toBe(8);
+    });
+
+    it('parses object literals wrapped in braces', () => {
+        const ctx: ExecutionContext = {
+            state: { value: [5, () => {}] },
+            queries: {},
+            scope: {},
+        };
+
+        expect(resolveValue('{next: value + 1}', ctx)).toEqual({ next: 6 });
+    });
+});
+
+describe('resolveCondition', () => {
+    it('handles empty and missing conditions', () => {
+        const ctx: ExecutionContext = { state: {}, queries: {}, scope: {} };
+
+        expect(resolveCondition(undefined, ctx)).toBe(true);
+        expect(resolveCondition('   ', ctx)).toBe(false);
+    });
+
+    it('evaluates braced and plain conditions', () => {
+        const ctx: ExecutionContext = {
+            state: { count: [2, () => {}] },
+            queries: {},
+            scope: {},
+        };
+
+        expect(resolveCondition('{count > 1}', ctx)).toBe(true);
+        expect(resolveCondition('count < 1', ctx)).toBe(false);
+    });
+});
+
+describe('resolveSet', () => {
+    it('sets whole state when target has no path', () => {
+        let latestValue: unknown;
+        const setter = (value: unknown) => {
+            latestValue = value;
+        };
+
+        const ctx: ExecutionContext = {
+            state: { filter: ['day', setter] },
+            queries: {},
+            scope: {},
+        };
+
+        const handler = resolveSet('filter', "'week'", ctx);
+        handler();
+
+        expect(latestValue).toBe('week');
+    });
+
+    it('sets nested value immutably when target has deep path', () => {
+        let latestValue: unknown;
+        const current = { range: { from: 1, to: 2 }, untouched: true };
+        const setter = (value: unknown) => {
+            latestValue = typeof value === 'function' ? (value as (prev: unknown) => unknown)(current) : value;
+        };
+
+        const ctx: ExecutionContext = {
+            state: { filter: [current, setter] },
+            queries: {},
+            scope: {},
+        };
+
+        const handler = resolveSet('filter.range.to', '3', ctx);
+        handler();
+
+        expect(latestValue).toEqual({ range: { from: 1, to: 3 }, untouched: true });
+        expect(current).toEqual({ range: { from: 1, to: 2 }, untouched: true });
+    });
+
+    it('throws when target state key is missing', () => {
+        const ctx: ExecutionContext = { state: {}, queries: {}, scope: {} };
+
+        expect(() => resolveSet('missing.value', '1', ctx)).toThrow('set: unknown state "missing"');
+    });
+});


### PR DESCRIPTION
### Motivation
- Ensure multiple `set:` handlers composed in one event update state safely and immutably by applying updates functionally.
- Add targeted unit tests to cover XML compilation, registry merging, rendering, and runtime evaluation behaviors.

### Description
- Update `resolveSet` in `web/src/xml/runtime.tsx` to use a functional setter when writing deep paths and fix the state tuple destructuring to only grab the setter via `const [, setter] = stateEntry`.
- Keep shallow `set` behavior calling `setter(newValue)` when there is no property path, and use `setter(prev => setDeep(prev, propPath, newValue))` for deep updates to preserve immutability and composition.
- Add unit tests under `web/test/xml/` covering `compiler`, `registry`, `renderers`, and `runtime` behaviors, including a mock for `fast-xml-parser` to exercise parsing scenarios.
- Add a `test` script to `web/package.json` as `"test": "bun test"` to enable running the new test suite.

### Testing
- Ran the test suite with `bun test` targeting the new files under `web/test/xml/*` and the added tests for `evaluate`, `interpolate`, `resolveSet`, `renderNode`, `xmlToAST`, and `createRegistry`.
- All added unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e136ea8d388323a56406b99a484cb2)