### PR TITLE
Add SDK CLI tests for init, build, and migrate commands

### DIFF
--- a/sdk/tests/cli/test_build.py
+++ b/sdk/tests/cli/test_build.py
@@ -1,0 +1,38 @@
+import json
+import re
+
+from click.testing import CliRunner
+
+from longlink.cli.build import build_app, build_command
+
+
+def test_build_app_creates_dockerfile_and_manifest(tmp_path, monkeypatch):
+    """Ensure build_app writes Dockerfile and manifest with expected keys."""
+    # Force metadata lookup to happen inside temp project directory.
+    monkeypatch.chdir(tmp_path)
+
+    dockerfile_path, manifest_path, version = build_app(base_path=tmp_path)
+
+    assert dockerfile_path.exists()
+    assert manifest_path.exists()
+    assert dockerfile_path.name == 'Dockerfile'
+    assert re.match(r'^\d{8}_\d{6}$', version)
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest['version'] == version
+    assert manifest['dockerfile'] == 'Dockerfile'
+    assert 'generated_at' in manifest
+    assert manifest['metadata']['name']
+
+
+def test_build_command_prints_created_artifacts(monkeypatch):
+    """Ensure build command exits cleanly and prints artifact paths."""
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(build_command)
+
+    assert result.exit_code == 0
+    assert 'Build artifacts created for version' in result.output
+    assert '- Dockerfile:' in result.output
+    assert '- Manifest:' in result.output

--- a/sdk/tests/cli/test_init.py
+++ b/sdk/tests/cli/test_init.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from click.testing import CliRunner
+
+from longlink.cli.init import init_command, setup
+
+
+def test_setup_creates_folder_and_copies_sample(monkeypatch, tmp_path):
+    """Ensure setup creates target folder and copies sample files into it."""
+    copied = {}
+
+    def fake_copytree(src: Path, dst: Path, dirs_exist_ok: bool):
+        """Capture copytree call parameters for assertions."""
+        copied['src'] = src
+        copied['dst'] = dst
+        copied['dirs_exist_ok'] = dirs_exist_ok
+
+    monkeypatch.setattr('shutil.copytree', fake_copytree)
+
+    target = tmp_path / 'my-app'
+    setup(target)
+
+    assert target.exists()
+    assert copied['dst'] == target
+    assert copied['dirs_exist_ok'] is True
+
+
+def test_init_command_calls_setup(monkeypatch):
+    """Ensure init CLI command delegates project creation to setup."""
+    runner = CliRunner()
+    called = {}
+
+    def fake_setup(folder_path: Path):
+        """Record folder value passed from CLI for assertions."""
+        called['folder'] = folder_path
+
+    monkeypatch.setattr('longlink.cli.init.setup', fake_setup)
+
+    result = runner.invoke(init_command, ['--folder', 'demo-app'])
+
+    assert result.exit_code == 0
+    assert called['folder'] == Path('demo-app')

--- a/sdk/tests/cli/test_migrate.py
+++ b/sdk/tests/cli/test_migrate.py
@@ -1,0 +1,26 @@
+from click.testing import CliRunner
+
+from longlink.cli.migrate import migrate_command
+
+
+def test_migrate_command_runs_generation_then_migration(monkeypatch):
+    """Ensure migrate command executes make_migrations before migrate."""
+    runner = CliRunner()
+    call_order = []
+
+    def fake_make_migrations():
+        """Record migration-generation call in execution order."""
+        call_order.append('make_migrations')
+
+    def fake_migrate():
+        """Record migrate call in execution order."""
+        call_order.append('migrate')
+
+    monkeypatch.setattr('longlink.cli.migrate.make_migrations', fake_make_migrations)
+    monkeypatch.setattr('longlink.cli.migrate.migrate', fake_migrate)
+
+    result = runner.invoke(migrate_command)
+
+    assert result.exit_code == 0
+    assert call_order == ['make_migrations', 'migrate']
+    assert 'Migrations generated and applied successfully.' in result.output


### PR DESCRIPTION
### Motivation
- Provide coverage for SDK CLI commands by adding one test file per command (`init`, `build`, `migrate`) and remove tests for `login`/`logout`/`publish` which are not required.
- Ensure CLI behavior validated in isolation so downstream changes to CLI internals surface fast regressions.
- Keep tests aligned with SDK structure under `sdk/tests/cli` for discoverability with existing test tooling.

### Description
- Added `sdk/tests/cli/test_init.py` which tests `setup()` behavior and that `init_command` delegates to `setup()` via `longlink.cli.init.setup`.
- Added `sdk/tests/cli/test_build.py` which tests `build_app()` writes `Dockerfile` and `manifest.json`, enforces version format, and verifies `build_command` output.
- Added `sdk/tests/cli/test_migrate.py` which tests `migrate_command` calls `make_migrations()` before `migrate()` and prints success message.

### Testing
- Ran Python syntax check with `python -m py_compile sdk/tests/cli/test_init.py sdk/tests/cli/test_build.py sdk/tests/cli/test_migrate.py` which succeeded.
- Ran `PYTHONPATH=. pytest tests/cli -q` which failed during collection due to runtime environment using Python 3.10 while SDK imports `datetime.UTC` (Python >=3.12 required), causing `ImportError`.
- Ran `make format` which failed dependency resolution for same Python version mismatch (project targets Python >=3.12).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13d317df88323a8d7741bc4e9672c)