### PR TITLE
web: split routes for sdk/api/dev bundle modes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,11 @@ import SdkLayout from './sdk/Layout';
 import SdkLonglink from './sdk/Longlink';
 import { RequireAuth } from '@/components/Auth';
 
+const buildMode = import.meta.env.MODE;
+
+const isSdkBuild = buildMode === 'sdk';
+const isDevelopment = buildMode === 'development';
+
 function GlobalLoader() {
     const isFetching = useIsFetching();
     const isMutating = useIsMutating();
@@ -27,14 +32,20 @@ function GlobalLoader() {
     );
 }
 
+/**
+ * Wraps route element with auth guard.
+ */
 const withAuth = (element: ReactElement) => <RequireAuth>{element}</RequireAuth>;
 
-const router = createBrowserRouter([
+const sdkRoutes = [
     {
-        path: '/sdk',
+        path: '/',
         element: <SdkLayout />,
         children: [{ path: '*', element: <SdkLonglink /> }],
     },
+];
+
+const apiRoutes = [
     {
         path: '/',
         element: withAuth(<Layout />),
@@ -59,8 +70,37 @@ const router = createBrowserRouter([
         children: [{ index: true, element: <OrganizationPage page="profile" /> }],
     },
     { path: '*', element: withAuth(<NotFound />) },
-]);
+];
 
+/**
+ * Builds route tree based on bundle mode.
+ */
+function getRoutes() {
+    // SDK bundle serves app from root without control-plane auth routes.
+    if (isSdkBuild) {
+        return sdkRoutes;
+    }
+
+    // Dev bundle exposes both trees so SDK path and API path work together.
+    if (isDevelopment) {
+        return [
+            {
+                path: '/sdk',
+                element: <SdkLayout />,
+                children: [{ path: '*', element: <SdkLonglink /> }],
+            },
+            ...apiRoutes,
+        ];
+    }
+
+    return apiRoutes;
+}
+
+const router = createBrowserRouter(getRoutes());
+
+/**
+ * Renders app shell, router, global toaster.
+ */
 export default function App() {
     return (
         <>


### PR DESCRIPTION
### Motivation
- Support two different browser routes depending on bundle mode so SDK builds serve app directly without control-plane auth while API builds keep control-plane routes with auth. 
- Enable local development to exercise both SDK and API flows simultaneously by exposing both route trees in dev mode. 
- Keep routing decision deterministic and driven by Vite build `MODE` to avoid runtime config plumbing.

### Description
- Replace single static route tree with `sdkRoutes` and `apiRoutes` and add `getRoutes()` to choose routes based on `import.meta.env.MODE`. 
- SDK build (`--mode sdk`) now mounts SDK shell at `/` and omits API/auth routes, API build (`--mode api`) returns control-plane `apiRoutes`, and development mode mounts SDK at `/sdk` while preserving API routes at `/`. 
- Added small inline docs/comments and a route-builder helper and updated `App` to create router via `createBrowserRouter(getRoutes())`. 
- Edited file: `web/src/App.tsx`.

### Testing
- Ran code formatter with `cd web && bun run format`, which completed successfully. 
- Ran `cd web && bun run build:api`, which failed due to an existing TypeScript error in `src/Layout.tsx` unrelated to this change. 
- Ran `cd web && bun run build:sdk`, which failed with same existing TypeScript error in `src/Layout.tsx`. 
- Ran `cd .. && make format`, which failed due to local Python version mismatch when installing API dev env (`requires Python>=3.12`, local is `3.10.19`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1553906f48323bb7efb6f75480bd6)