### PR TITLE
SDK: eager env initialization and add environments docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -91,6 +91,13 @@ export default defineConfig({
             ]
           },
           {
+            text: 'Environments',
+            collapsed: true,
+            items: [
+              { text: 'Introduction', link: '/sdk/environments/' }
+            ]
+          },
+          {
             text: 'Database',
             collapsed: true,
             items: [

--- a/docs/src/sdk/environments/index.md
+++ b/docs/src/sdk/environments/index.md
@@ -1,0 +1,48 @@
+# Environments
+
+LongLink SDK uses environment variables to configure runtime behavior.
+The SDK reads values from process environment and from `.env`.
+
+## Load behavior
+
+The SDK now loads environments when `longlink.envs` is imported.
+This means invalid or missing required values fail fast during startup.
+
+The module exposes:
+
+- `envs`: loaded settings object
+- `get_envs()`: cached loader function
+- `Envs`: base settings model
+- `EnvsDev`: development defaults used when `DEV=true`
+
+## Variables
+
+The SDK environment model includes:
+
+- `DEV`: enable local development mode
+- `KEY`: application key
+- `DBURL`: application database URL
+- `storage_key`: object storage access key
+- `storage_secret`: object storage secret
+- `storage_endpoint`: object storage endpoint URL
+
+## Development mode
+
+Set `DEV=true` to use development defaults from `EnvsDev`.
+In development mode, the SDK uses:
+
+- `DBURL=sqlite:///./dev.db`
+- `storage_key=dev`
+- `storage_secret=dev`
+- `storage_endpoint=http://localhost:9000`
+
+## Example
+
+```python
+from longlink.envs import envs
+
+print(envs.DBURL)
+print(envs.storage_endpoint)
+```
+
+Use environment variables or `.env` to override defaults.

--- a/docs/src/sdk/index.md
+++ b/docs/src/sdk/index.md
@@ -47,3 +47,9 @@ Run the development server:
 ```bash
 longlink dev
 ```
+
+## Configuration
+
+To configure runtime variables for database and storage, see the environments guide:
+
+- [Environments](/sdk/environments/)

--- a/sdk/longlink/envs.py
+++ b/sdk/longlink/envs.py
@@ -1,10 +1,12 @@
 import os
 from functools import lru_cache
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Envs(BaseSettings):
-    """App specific secrets"""
+    """App specific secrets."""
+
     DEV: bool = False
     KEY: str  # Example: 'samplekey'
 
@@ -21,6 +23,8 @@ class Envs(BaseSettings):
 
 
 class EnvsDev(Envs):
+    """Development defaults for local execution."""
+
     DEV: bool = True
     KEY: str = 'longlink'
 
@@ -32,15 +36,12 @@ class EnvsDev(Envs):
 
 @lru_cache(maxsize=1)
 def get_envs() -> Envs:
+    """Load and cache environment settings for current process."""
+
     if os.getenv('DEV', '').lower() in {'1', 'true', 'yes', 'on'}:
-        return EnvsDev()  # type: ignore
+        return EnvsDev()  # type: ignore[return-value]
 
-    return Envs()  # type: ignore
-
-
-class _LazyEnvs:
-    def __getattr__(self, item):
-        return getattr(get_envs(), item)
+    return Envs()  # type: ignore[return-value]
 
 
-envs = _LazyEnvs()
+envs: Envs = get_envs()


### PR DESCRIPTION
### Motivation
- Make SDK env loading fail-fast and explicit by removing lazy proxy so misconfiguration surfaces at startup.
- Provide clear documentation for env vars and development defaults so developers can configure DB/storage correctly.

### Description
- Replace `_LazyEnvs` proxy with eager `envs: Envs = get_envs()` and add docstrings to `sdk/longlink/envs.py`, while keeping cached `get_envs()` API.
- Add documentation page `docs/src/sdk/environments/index.md` describing load behavior, variables, dev defaults, and usage example.
- Expose new Environments page in VitePress sidebar (`docs/.vitepress/config.ts`) and link it from SDK overview (`docs/src/sdk/index.md`).

### Testing
- Ran `python -m compileall sdk/longlink/envs.py`, which succeeded.
- Ran `make format`, which failed in this environment due to Python version mismatch (`api[dev]` requires Python >= 3.12; current interpreter is 3.10.19).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1579b37688323a5d56fb63722bf13)