### PR TITLE
Add application management modal to Settings page

### DIFF
--- a/api/src/pages/settings.xml
+++ b/api/src/pages/settings.xml
@@ -108,7 +108,41 @@
             title="Application Settings"
             subtitle="Control app defaults, permissions, and lifecycle settings"
             icon="settings"
-          />
+            action="Manage applications"
+          >
+            <DialogContent className="sm:max-w-xl">
+              <DialogHeader>
+                <DialogTitle>Manage applications</DialogTitle>
+                <DialogDescription>
+                  Choose how you want to register an application in this workspace.
+                </DialogDescription>
+              </DialogHeader>
+              <Stack gap="12">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Connect application</CardTitle>
+                    <CardDescription>
+                      Link an existing deployed app and keep current runtime configuration.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Button variant="outline">Connect application</Button>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Add application</CardTitle>
+                    <CardDescription>
+                      Create a new application record and configure it for this organization.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Button>Add application</Button>
+                  </CardContent>
+                </Card>
+              </Stack>
+            </DialogContent>
+          </Hero>
           <Table endpoint="/apps">
             <Column key="name" label="Name" content="{name}" />
             <Column key="url" label="URL" content="{url}" />


### PR DESCRIPTION
### Motivation
- Provide UI control on Settings page to let user connect existing app or add new app without leaving page.
- Use existing dialog primitives to keep behavior consistent with platform UI patterns.

### Description
- Updated `Hero` in `api/src/pages/settings.xml` to set `action="Manage applications"` and render a dialog body under the hero.
- Added `DialogContent` with header/description and two `Card` options: `Connect application` (outline button) and `Add application` (primary button).
- Kept existing applications `Table` unchanged so list view and downstream flow remain intact.

### Testing
- Ran `bun run format` inside `web/` and it completed successfully.
- Ran `make format` at repo root which failed due to environment Python version mismatch (project requires Python >=3.12), so full repo formatting aborted.
- No automated test cases added per repository instruction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1584906e483239c2722dca4347e53)