### PR TITLE
docs: add pages introduction and structure guidance

### DIFF
--- a/docs/src/sdk/pages/index.md
+++ b/docs/src/sdk/pages/index.md
@@ -1,3 +1,50 @@
 # Pages
 
-T[TODO] How a page is defined
+A page is the UI contract for one application view.
+Each page is defined in one XML file.
+LongLink renders this file in the web client.
+
+## How a page is structured
+
+A page usually has three layers:
+
+1. **Page root**
+   The XML root contains layout and content elements.
+2. **Layout blocks**
+   Layout elements such as `<Hero>`, `<Card>`, `<Columns>`, `<Tabs>`, and `<Table>` organize screen structure.
+3. **Content and interaction blocks**
+   HTML elements (`<h1>`, `<p>`, `<ul>`) and UI components (`<Button>`, `<Input>`, `<Select>`) provide text and user actions.
+
+This separation keeps each page explicit, composable, and easy to maintain.
+
+## Minimal example
+
+```xml
+<Hero title="Orders" subtitle="Track order status and actions">
+  <Card>
+    <CardHeader>
+      <CardTitle>Recent orders</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p>Select an order to view details.</p>
+      <Button>Open order</Button>
+    </CardContent>
+  </Card>
+</Hero>
+```
+
+## Recommended page flow
+
+Use this sequence when building a page:
+
+1. Define the main goal of the view.
+2. Pick layout components that match this goal.
+3. Add text using HTML elements for clear structure.
+4. Add interactive components for user input and actions.
+5. Split complex content into tabs or sections when needed.
+
+## Related references
+
+- [Layout components](./layout/hero)
+- [Form and interaction components](./components/button)
+- [HTML elements](./html-elements)


### PR DESCRIPTION
### Motivation

- Define what a page is in SDK docs and how LongLink renders pages from XML files.
- Help authors build maintainable pages by explaining structural layers and recommended flow.

### Description

- Replaced placeholder content in `docs/src/sdk/pages/index.md` with an introduction that defines a page and how it is rendered.
- Added `How a page is structured` section describing XML root, layout blocks, and content/interaction blocks.
- Added `Minimal example` XML snippet and `Recommended page flow` to guide page authors from goal to layout to interactions.
- Added related links to layout, component, and HTML element reference pages for navigation.

### Testing

- Ran `make format` from repository root which failed due to project requiring Python `>=3.12` while environment uses Python `3.10.19`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e159448ecc83238564b16f20fdf29b)