### PR TITLE
Refactor SDK app initialization around validated ENV objects

### DIFF
--- a/docs/src/sdk/environments/index.md
+++ b/docs/src/sdk/environments/index.md
@@ -1,23 +1,22 @@
 # Environments
 
-LongLink SDK uses environment variables to configure runtime behavior.
+LongLink SDK uses environment objects to configure runtime behavior.
 The SDK reads values from process environment and from `.env`.
 
-## Load behavior
+## Base classes and helpers
 
-The SDK now loads environments when `longlink.envs` is imported.
-This means invalid or missing required values fail fast during startup.
+The SDK exposes:
 
-The module exposes:
+- `ENV`: base settings model for application variables
+- `ENVDev`: development defaults used when `DEV=true`
+- `envs`: default loaded environment object
+- `get_envs()`: cached loader for default environment object
 
-- `envs`: loaded settings object
-- `get_envs()`: cached loader function
-- `Envs`: base settings model
-- `EnvsDev`: development defaults used when `DEV=true`
+The SDK also keeps aliases `Envs` and `EnvsDev` for compatibility.
 
 ## Variables
 
-The SDK environment model includes:
+The default environment model includes:
 
 - `DEV`: enable local development mode
 - `KEY`: application key
@@ -28,7 +27,7 @@ The SDK environment model includes:
 
 ## Development mode
 
-Set `DEV=true` to use development defaults from `EnvsDev`.
+Set `DEV=true` to use development defaults from `ENVDev`.
 In development mode, the SDK uses:
 
 - `DBURL=sqlite:///./dev.db`
@@ -36,13 +35,56 @@ In development mode, the SDK uses:
 - `storage_secret=dev`
 - `storage_endpoint=http://localhost:9000`
 
-## Example
+## Application wrapper integration
+
+LongLink SDK application is now an `App` wrapper around FastAPI.
+The wrapper takes an `ENV` object during initialization.
+
+This means environment validation happens when `ENV` object is created.
+If any required variable is missing or invalid, application creation fails early.
+
+The wrapper stores validated object at `app.state.env`.
+Routes and services can read typed values from this location.
+
+## Showcase: define custom environment and create application
 
 ```python
-from longlink.envs import envs
+from longlink import App, ENV
 
-print(envs.DBURL)
-print(envs.storage_endpoint)
+
+class ProjectENV(ENV):
+    """Project-specific environment model."""
+
+    FEATURE_FLAG: bool
+    EXTERNAL_API_BASE_URL: str
+
+
+project_env = ProjectENV()
+application = App(env=project_env)
+app = application.fastapi
 ```
 
-Use environment variables or `.env` to override defaults.
+In this flow:
+
+1. `ProjectENV()` validates standard and custom variables.
+2. `App(env=project_env)` binds validated object to FastAPI state.
+3. `app` is ready for uvicorn with full typed environment context.
+
+## Showcase: extend current environment for new requirements
+
+```python
+from longlink import App, ENVDev
+
+
+class ExtendedDevENV(ENVDev):
+    """Development environment with extra project variables."""
+
+    DEMO_BUCKET_PREFIX: str = "demo"
+
+
+extended_env = ExtendedDevENV()
+application = App(env=extended_env)
+app = application.fastapi
+```
+
+Use this pattern when application needs extra environment variables without losing SDK defaults.

--- a/docs/src/sdk/index.md
+++ b/docs/src/sdk/index.md
@@ -48,6 +48,15 @@ Run the development server:
 longlink dev
 ```
 
+## Application Construction
+
+The SDK creates applications through an `App` wrapper that contains a FastAPI instance and a validated environment object.
+You can extend `ENV` with project-specific variables and pass the resulting object to `App`.
+
+See complete examples in:
+
+- [Environments](/sdk/environments/)
+
 ## Configuration
 
 To configure runtime variables for database and storage, see the environments guide:

--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,11 +1,13 @@
 # Import internal routes for side-effect registration on the global router.
 import longlink.routes  # noqa: E402,F401
-from longlink.app import create_app
-from longlink.xml import load_page_schema_from_xml
-from longlink.router import (get, put, page, post, pages, patch, route, delete,
-                             xml_page)
-from longlink.predefined import issues_page, sample_page
+from longlink.app import App, create_app, create_longlink_app
+from longlink.envs import ENV, ENVDev, Envs, EnvsDev, envs, get_envs
 from longlink.organization import org
+from longlink.predefined import issues_page, sample_page
+from longlink.router import (delete, get, page, pages, patch, post, put, route,
+                             xml_page)
+from longlink.xml import load_page_schema_from_xml
 
-# Official Starlette application instance.
-app = create_app()
+# Official Starlette application wrapper and instance.
+application = create_longlink_app()
+app = application.fastapi

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,13 +1,20 @@
-from fastapi import FastAPI
 from pathlib import Path
-from longlink.router import api_router
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from fastapi.middleware.cors import CORSMiddleware
+
+from longlink.envs import ENV, get_envs
+from longlink.router import api_router
 
 
 class SPAStaticFiles(StaticFiles):
+    """Serve SPA assets and fallback to `index.html` for unknown routes."""
+
     async def get_response(self, path: str, scope):
+        """Return static file response, falling back to SPA entrypoint on 404."""
+
         try:
             return await super().get_response(path, scope)
         except StarletteHTTPException as exc:
@@ -17,23 +24,52 @@ class SPAStaticFiles(StaticFiles):
         return await super().get_response("index.html", scope)
 
 
-def create_app() -> FastAPI:
-    app = FastAPI()
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=[
-            "http://localhost:3000",
-            "http://localhost:5173",
-            "http://localhost:8000",
-        ],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-    app.include_router(api_router)
+class App:
+    """LongLink SDK application wrapper around FastAPI and validated env."""
 
-    static_dir = Path(__file__).resolve().parent / "static"
-    if static_dir.exists():
-        app.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
+    def __init__(self, env: ENV, fastapi_app: FastAPI | None = None):
+        """Create application wrapper and bind validated env to FastAPI state."""
 
-    return app
+        self.env = env
+        self.fastapi = fastapi_app or FastAPI()
+        self._configure()
+
+    def _configure(self) -> None:
+        """Configure middleware, routes, static assets, and application state."""
+
+        # Keep validated env accessible to route handlers and extensions.
+        self.fastapi.state.env = self.env
+        self.fastapi.state.longlink_app = self
+
+        self.fastapi.add_middleware(
+            CORSMiddleware,
+            allow_origins=[
+                "http://localhost:3000",
+                "http://localhost:5173",
+                "http://localhost:8000",
+            ],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        self.fastapi.include_router(api_router)
+
+        static_dir = Path(__file__).resolve().parent / "static"
+        if static_dir.exists():
+            self.fastapi.mount(
+                "/",
+                SPAStaticFiles(directory=static_dir, html=True),
+                name="static",
+            )
+
+
+def create_longlink_app(env: ENV | None = None) -> App:
+    """Create LongLink app wrapper with explicit or default environment."""
+
+    return App(env=env or get_envs())
+
+
+def create_app(env: ENV | None = None) -> FastAPI:
+    """Create and return FastAPI application for backwards compatibility."""
+
+    return create_longlink_app(env=env).fastapi

--- a/sdk/longlink/cli/dev.py
+++ b/sdk/longlink/cli/dev.py
@@ -1,20 +1,34 @@
+import importlib
 import os
 import sys
+
 import click
 import uvicorn
-import importlib
 
 
 def load_app():
-    importlib.import_module("main")
-    from longlink.app import create_app
+    """Load user module and return FastAPI app instance for uvicorn factory."""
 
-    return create_app()
+    main_module = importlib.import_module("main")
+
+    # Prefer explicit app exports from user module before SDK fallback.
+    if hasattr(main_module, "app"):
+        return getattr(main_module, "app")
+
+    if hasattr(main_module, "application"):
+        application = getattr(main_module, "application")
+        if hasattr(application, "fastapi"):
+            return application.fastapi
+
+    from longlink import app
+
+    return app
 
 
 @click.command(name="dev")
 def dev_command():
-    """Run the LongLink app locally with auto-reload."""
+    """Run LongLink application locally with auto-reload enabled."""
+
     sys.path.insert(0, os.getcwd())
     os.environ["DEV"] = "True"
 

--- a/sdk/longlink/envs.py
+++ b/sdk/longlink/envs.py
@@ -1,10 +1,11 @@
 import os
 from functools import lru_cache
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Envs(BaseSettings):
-    """App specific secrets."""
+class ENV(BaseSettings):
+    """Base SDK environment model loaded from process variables or `.env`."""
 
     DEV: bool = False
     KEY: str  # Example: 'samplekey'
@@ -21,7 +22,7 @@ class Envs(BaseSettings):
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 
 
-class EnvsDev(Envs):
+class ENVDev(ENV):
     """Development defaults for local execution."""
 
     DEV: bool = True
@@ -33,14 +34,25 @@ class EnvsDev(Envs):
     storage_endpoint: str = 'http://localhost:9000'
 
 
+def _is_dev_enabled() -> bool:
+    """Return whether current process should load development defaults."""
+
+    return os.getenv('DEV', '').lower() in {'1', 'true', 'yes', 'on'}
+
+
 @lru_cache(maxsize=1)
-def get_envs() -> Envs:
-    """Load and cache environment settings for current process."""
+def get_envs() -> ENV:
+    """Load and cache default SDK environment for current process."""
 
-    if os.getenv('DEV', '').lower() in {'1', 'true', 'yes', 'on'}:
-        return EnvsDev()  # type: ignore[return-value]
+    if _is_dev_enabled():
+        return ENVDev()  # type: ignore[return-value]
 
-    return Envs()  # type: ignore[return-value]
+    return ENV()  # type: ignore[return-value]
 
 
-envs: Envs = get_envs()
+# Backwards-compatible aliases while SDK moves to `ENV` naming.
+Envs = ENV
+EnvsDev = ENVDev
+
+# Default process-level SDK environment.
+envs: ENV = get_envs()


### PR DESCRIPTION
### Motivation
- Make environment validation explicit and early so app creation fails fast when required vars missing or invalid. 
- Let projects extend SDK environment model and pass validated instance into application, enabling typed access to custom variables.
- Keep backwards compatibility while moving SDK toward an explicit App wrapper that composes FastAPI with validated env.

### Description
- Replace `Envs`/`EnvsDev` with `ENV`/`ENVDev` while keeping `Envs`/`EnvsDev` aliases and provide `get_envs()` and process-level `envs` default; add helper `_is_dev_enabled()` to centralize dev detection (`sdk/longlink/envs.py`).
- Add `App` wrapper that accepts a validated `ENV` instance, binds it to `app.state.env`, configures middleware, routes, and static mounting, and expose `create_longlink_app()` and compatibility `create_app()` helpers (`sdk/longlink/app.py`).
- Update package exports to expose `App`, environment models/helpers, and create a default `application` wrapper with `app = application.fastapi` for legacy consumers (`sdk/longlink/__init__.py`).
- Improve dev loader to prefer user-defined `app` or `application.fastapi` from `main.py` before falling back to SDK default, enabling user entrypoints to use custom `ENV` and `App` (`sdk/longlink/cli/dev.py`).
- Update documentation to describe new ENV model, show how to extend `ENV`/`ENVDev`, and demonstrate constructing `App` with custom/extended envs (`docs/src/sdk/environments/index.md`, `docs/src/sdk/index.md`).

### Testing
- `python -m compileall sdk/longlink` executed and succeeded for SDK module compilation.
- `make format` attempted but failed in this environment because formatter dependencies require Python >= 3.12 while current runtime is Python 3.10.19, so formatting step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2041274f48323818061f864d6be6c)