### PR TITLE
test(api): add unit tests for utils (apps, compute, database, storage, url)

### DIFF
--- a/api/tests/utils/test_apps.py
+++ b/api/tests/utils/test_apps.py
@@ -1,0 +1,21 @@
+import pytest
+from src.utils import apps
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_request_raises_when_app_missing(monkeypatch):
+    """Request helper should fail when target app is not registered in database."""
+
+    class _AppsService:
+        async def get_by_uuid(self, _uuid: str):
+            """Return missing app for every lookup."""
+            return None
+
+    apps._clients.clear()
+    monkeypatch.setattr(apps.db, "apps", _AppsService())
+
+    with pytest.raises(ValueError, match="App not found"):
+        await apps.request("missing-app", "GET", "/health")
+
+    apps._clients.clear()

--- a/api/tests/utils/test_compute.py
+++ b/api/tests/utils/test_compute.py
@@ -1,0 +1,19 @@
+import pytest
+from src.utils import compute
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_namespace():
+    """Compute create helper should reject non-kubernetes-compliant namespace names."""
+
+    with pytest.raises(ValueError, match="Namespace must contain only lowercase letters"):
+        await compute.create(
+            namespace="Invalid Namespace",
+            pod_name="valid-pod",
+            image="busybox:latest",
+            command=["sleep"],
+            args=["5"],
+            env_vars={},
+            container_port=None,
+        )

--- a/api/tests/utils/test_database.py
+++ b/api/tests/utils/test_database.py
@@ -1,0 +1,36 @@
+import pytest
+from src.utils import database
+from unittest.mock import Mock
+
+
+@pytest.mark.unit
+def test_create_sync_raises_when_database_already_exists(monkeypatch):
+    """Database helper should prevent creating duplicate databases."""
+    fake_cursor = Mock()
+    fake_cursor.fetchone.return_value = (1,)
+
+    class _CursorContext:
+        def __enter__(self):
+            """Return fake cursor when context starts."""
+            return fake_cursor
+
+        def __exit__(self, exc_type, exc, tb):
+            """Do not suppress errors raised in context."""
+            return False
+
+    fake_connection = Mock()
+    fake_connection.cursor.return_value = _CursorContext()
+
+    def _connect_stub(**kwargs):
+        """Return fake admin connection for database helper call."""
+        return fake_connection
+
+    monkeypatch.setattr(database.psycopg2, "connect", _connect_stub)
+
+    with pytest.raises(ValueError, match="already exists"):
+        database._create_sync("existing_db")
+
+    fake_connection.close.assert_called_once()
+    fake_cursor.execute.assert_called_once_with(
+        "SELECT 1 FROM pg_database WHERE datname = %s", ("existing_db",)
+    )

--- a/api/tests/utils/test_storage.py
+++ b/api/tests/utils/test_storage.py
@@ -1,0 +1,21 @@
+import pytest
+from src.utils import storage
+from unittest.mock import Mock
+
+
+@pytest.mark.unit
+def test_create_raises_when_bucket_exists(monkeypatch):
+    """Storage helper should raise when bucket already exists in provider."""
+    fake_client = Mock()
+    fake_client.head_bucket.return_value = None
+
+    def _client_stub(*args, **kwargs):
+        """Return fake S3 client for storage helper call."""
+        return fake_client
+
+    monkeypatch.setattr(storage.boto3, "client", _client_stub)
+
+    with pytest.raises(ValueError, match="already exists"):
+        storage.create("existing-bucket")
+
+    fake_client.create_bucket.assert_not_called()

--- a/api/tests/utils/test_url.py
+++ b/api/tests/utils/test_url.py
@@ -1,0 +1,6 @@
+from src.utils import url
+
+
+def test_normalize_adds_https_for_non_localhost():
+    """URL helper should add https scheme for non-local addresses."""
+    assert url.normalize("example.com/api") == "https://example.com/api"


### PR DESCRIPTION
### Motivation
- Add focused unit coverage for core utility modules to catch regressions in validation and error paths. 
- Ensure helpers enforce input constraints and surface clear errors for provisioning workflows.

### Description
- Added `api/tests/utils/test_apps.py` with a test that `apps.request()` raises `ValueError` when target app UUID is missing and database lookup returns `None` using `monkeypatch` to stub DB service. 
- Added `api/tests/utils/test_compute.py` with a test that `compute.create()` rejects invalid Kubernetes namespace names. 
- Added `api/tests/utils/test_database.py` with a test that `database._create_sync()` raises when database already exists by mocking `psycopg2.connect()` and cursor behavior. 
- Added `api/tests/utils/test_storage.py` with a test that `storage.create()` raises for existing buckets and avoids calling `create_bucket()` by stubbing `boto3.client()`. 
- Added `api/tests/utils/test_url.py` with a test that `url.normalize()` adds appropriate `https` scheme for non-local hosts. 

### Testing
- Ran `python -m isort tests/utils/*.py` in `api/` to fix imports and formatting (passed). 
- Ran `pytest tests/utils/test_url.py -q` in `api/` (passed: 1 test). 
- Ran `pytest tests/utils -q` in `api/` which failed during collection due to missing optional environment packages (`kubernetes`, `psycopg2`, `boto3`) causing import errors; individual unit tests rely on mocking but modules import these dependencies at top-level. 
- Ran `make format` from repo root which failed in this environment due to Python version mismatch (local env Python 3.10 vs project requirement >=3.12).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e204e1c7cc832385dfcc879e92bdea)