### PR TITLE
useUser: fetch current user from /user endpoint

### DIFF
--- a/web/src/hooks/use-user.tsx
+++ b/web/src/hooks/use-user.tsx
@@ -15,7 +15,7 @@ export type User = {
 export function useUser() {
     return useQuery({
         queryKey: ['user'],
-        queryFn: () => apiFetch<User>('/me'),
+        queryFn: () => apiFetch<User>('/user'),
         staleTime: Infinity,
     });
 }


### PR DESCRIPTION
### Motivation
- The backend returns the authenticated user at `/user` rather than `/me`, so the hook must use the correct endpoint to retrieve the current user.

### Description
- Updated `useUser` in `web/src/hooks/use-user.tsx` to call `apiFetch<User>('/user')` instead of `apiFetch<User>('/me')`.

### Testing
- Ran `yarn test` and TypeScript typecheck via `yarn tsc`, and the test suite and typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2054eb1a083238c6eac1ea4c7bd52)