### PR TITLE
Use SDK backend for /sdk dev pages via /sdk-api proxy

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,8 +1,34 @@
-const apiBaseUrl = '/api';
+const controlPlaneApiBaseUrl = '/api';
+const sdkDevApiBaseUrl = '/sdk-api';
 
 const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/, '');
 
-export const getApiBaseUrl = () => normalizeBaseUrl(apiBaseUrl);
+/**
+ * Detects SDK runtime context in development and SDK build modes.
+ */
+const isSdkRuntime = () => {
+    if (import.meta.env.MODE === 'sdk') {
+        return true;
+    }
+
+    if (!import.meta.env.DEV) {
+        return false;
+    }
+
+    // SDK dev route lives under /sdk when running the unified development server.
+    return window.location.pathname.startsWith('/sdk');
+};
+
+/**
+ * Resolves API base URL for current runtime mode.
+ */
+export const getApiBaseUrl = () => {
+    if (isSdkRuntime()) {
+        return normalizeBaseUrl(import.meta.env.DEV ? sdkDevApiBaseUrl : '');
+    }
+
+    return normalizeBaseUrl(controlPlaneApiBaseUrl);
+};
 
 type QueryValue = string | number | boolean | null | undefined;
 export type ApiQueryParams = Record<string, QueryValue>;
@@ -67,9 +93,9 @@ const buildUrl = (path: string, query?: ApiQueryParams) => {
 };
 
 /**
- * Makes an API request to the backend with automatic JSON handling.
- * Supports query parameters, custom body types, and app-scoped paths.
- * Throws an Error with the response message on failure.
+ * Makes an API request to backend with automatic JSON handling.
+ * Supports query parameters, custom body types, app-scoped paths.
+ * Throws Error with response message on failure.
  */
 export async function apiFetch<TResponse>(path: string, options: ApiRequestOptions = {}): Promise<TResponse> {
     const { method, query, body, credentials } = options;

--- a/web/src/sdk/Longlink.tsx
+++ b/web/src/sdk/Longlink.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import { fromXml, renderNode, createContext, registry } from '@/xml';
 import { useApiData } from '@/hooks/use-data';
 import { type AppNavigationPage } from '@/lib/navigation';
+import { getApiBaseUrl } from '@/lib/api';
 import { getPagesFromResponse } from './pages';
 
 type AppMetadata = {
@@ -51,6 +52,6 @@ export default function SdkLonglink() {
     }
 
     const ast = fromXml(data);
-    const ctx = createContext({ baseUrl: '/api' });
+    const ctx = createContext({ baseUrl: getApiBaseUrl() });
     return renderNode(ast, registry, ctx);
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -40,6 +40,11 @@ export default defineConfig(({ mode }) => {
                     changeOrigin: true,
                     rewrite: (requestPath) => requestPath.replace(/^\/api/, ''),
                 },
+                '/sdk-api': {
+                    target: 'http://localhost:1707',
+                    changeOrigin: true,
+                    rewrite: (requestPath) => requestPath.replace(/^\/sdk-api/, ''),
+                },
             },
         },
     };


### PR DESCRIPTION
### Motivation
- In development `/sdk` must load SDK app pages directly from local SDK backend (localhost:1707) instead of going through control-plane API so preview behaves like direct app runtime.

### Description
- Add Vite dev proxy `/sdk-api` → `http://localhost:1707` with prefix rewrite so dev server forwards SDK page requests to local SDK backend (`web/vite.config.ts`).
- Implement `getApiBaseUrl()` in `src/lib/api.ts` to detect SDK runtime (bundle mode `sdk` or dev path starting with `/sdk`) and resolve API base to `/sdk-api` in dev while preserving `/api` for control-plane usage.
- Update SDK XML render context to call `getApiBaseUrl()` instead of hardcoded `/api` so XML `Query`/fetch operations hit resolved SDK backend (`src/sdk/Longlink.tsx`).

### Testing
- Ran `cd web && bun run format` which completed successfully.
- Ran `make format` at repo root which failed due to environment Python version mismatch (requires Python >= 3.12), unrelated to these changes.
- Ran `cd web && bun run build` which failed due to an existing TypeScript type error in `src/Layout.tsx` not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e208e988b48323bd9b0f55850b8fcc)