### PR TITLE
Add Self-Hosted deployment guide and environment variable reference

### DIFF
--- a/docs/src/api/self-hosted/index.md
+++ b/docs/src/api/self-hosted/index.md
@@ -1,3 +1,67 @@
 # Self Hosted
 
-[TODO] How to setup with the database, storage, ecc
+Use this mode when you run LongLink control plane in your infrastructure.
+
+## Required infrastructure
+
+You must provide these external systems:
+
+- **Kubernetes cluster** for compute and application runtime
+- **PostgreSQL server** for database provisioning
+- **S3-compatible object storage** for files and artifacts
+
+## Required environment variables
+
+Configure the API container with these provisioning variables.
+
+### Compute (Kubernetes)
+
+- `ENV_PROVISION_COMPUTE_API_SERVER_URL`
+- `ENV_PROVISION_COMPUTE_ADMIN_USERNAME`
+- `ENV_PROVISION_COMPUTE_ADMIN_PASSWORD`
+- `ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE`
+- `ENV_PROVISION_COMPUTE_VERIFY_SSL`
+
+### Database (PostgreSQL)
+
+- `ENV_PROVISION_DATABASE_HOST`
+- `ENV_PROVISION_DATABASE_PORT`
+- `ENV_PROVISION_DATABASE_USERNAME`
+- `ENV_PROVISION_DATABASE_PASSWORD`
+- `ENV_PROVISION_DATABASE_MAINTENANCE_DATABASE`
+- `ENV_PROVISION_DATABASE_SSLMODE` (optional)
+
+Use **database administrator credentials** for `ENV_PROVISION_DATABASE_USERNAME` and `ENV_PROVISION_DATABASE_PASSWORD`.
+The account must have permission to create databases on the maintenance database.
+
+### Storage (S3-compatible)
+
+- `ENV_PROVISION_STORAGE_ENDPOINT_URL`
+- `ENV_PROVISION_STORAGE_ACCESS_KEY_ID`
+- `ENV_PROVISION_STORAGE_SECRET_ACCESS_KEY`
+- `ENV_PROVISION_STORAGE_REGION_NAME` (optional)
+
+This model matches Docker Compose development setup, but uses production infrastructure.
+
+## Control plane deployment model
+
+LongLink API is distributed as container image.
+
+Deploy API container into your Kubernetes cluster.
+
+Deploy application containers into same Kubernetes cluster.
+
+With this topology:
+
+- control plane reaches applications through internal cluster networking
+- control plane proxies traffic without public internet path
+- service discovery and network policy stay inside cluster boundary
+
+## Why same-cluster deployment
+
+Keeping control plane and applications in one cluster simplifies routing and security:
+
+1. Control plane schedules and tracks application workloads in cluster.
+2. Internal services communicate with private DNS and cluster IPs.
+3. Control-plane-to-application traffic avoids external ingress and egress.
+4. Governance stays centralized while runtime stays in your infrastructure.


### PR DESCRIPTION
### Motivation

- Provide guidance for running the LongLink control plane in customer-managed infrastructure and replace the previous TODO placeholder.
- Document the external services and configuration surface required to provision compute, database, and object storage for self-hosted deployments.
- Clarify the recommended deployment topology and reasons to co-locate control plane and application workloads in the same Kubernetes cluster.

### Description

- Replaced the placeholder TODO in `docs/src/api/self-hosted/index.md` with a comprehensive self-hosted deployment guide. 
- Added a `Required infrastructure` section listing `Kubernetes cluster`, `PostgreSQL server`, and `S3-compatible object storage` as prerequisites. 
- Added a `Required environment variables` section enumerating provisioning variables for compute (`ENV_PROVISION_COMPUTE_*`), database (`ENV_PROVISION_DATABASE_*`), and storage (`ENV_PROVISION_STORAGE_*`) including notes about using database administrator credentials. 
- Added sections describing the control plane deployment model for containerized API deployment and a short rationale for same-cluster deployment.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2098fb2ac832390eeac687d4e8052)