### PR TITLE
Add database overview endpoint and wire to settings UI table

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -59,6 +59,7 @@ import src.routes.users
 import src.routes.compute
 import src.routes.storage
 import src.routes.settings
+import src.routes.databases
 import src.routes.organization
 
 app.include_router(router)

--- a/api/src/db/__init__.py
+++ b/api/src/db/__init__.py
@@ -1,6 +1,7 @@
 from .models import App, Env, User, Setting, Permission  # noqa: F401
 from .services import (AppsService, EnvsService, UsersService, ComputesService,
-                       SettingsService, StoragesService, PermissionsService)
+                       SettingsService, StoragesService, DatabasesService,
+                       PermissionsService)
 
 apps = AppsService()
 envs = EnvsService()
@@ -11,3 +12,4 @@ permissions = PermissionsService()
 storages = StoragesService()
 
 computes = ComputesService()
+databases = DatabasesService()

--- a/api/src/db/services/__init__.py
+++ b/api/src/db/services/__init__.py
@@ -4,4 +4,5 @@ from .users import UsersService  # noqa: F401
 from .computes import ComputesService  # noqa: F401
 from .settings import SettingsService  # noqa: F401
 from .storages import StoragesService  # noqa: F401
+from .databases import DatabasesService  # noqa: F401
 from .permissions import PermissionsService  # noqa: F401

--- a/api/src/db/services/databases.py
+++ b/api/src/db/services/databases.py
@@ -1,0 +1,10 @@
+from src.utils import database as database_utils
+from src.models.databases import DatabaseOverviewMetric
+
+
+class DatabasesService:
+    """Service for database cluster metadata and overview metrics."""
+
+    async def list_overview_metrics(self) -> list[DatabaseOverviewMetric]:
+        """Return high-level database cluster metrics for settings UI."""
+        return await database_utils.list_overview_metrics()

--- a/api/src/models/databases.py
+++ b/api/src/models/databases.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class DatabaseOverviewMetric(BaseModel):
+    key: str
+    label: str
+    value: str
+    unit: str | None = None
+    description: str | None = None

--- a/api/src/pages/settings.xml
+++ b/api/src/pages/settings.xml
@@ -170,24 +170,28 @@
     <MenuSection title="Database" icon="database">
       <MenuSubSection title="" root="true">
         <Stack gap="24">
-          <Hero title="Database Settings" subtitle="Connect a database instance." icon="settings" action="Connect" />
-          <Query id="databases" path="/databases">
+          <Hero
+            title="Database Overview"
+            subtitle="Cluster capacity and usage stats for quick resource visibility."
+            icon="settings"
+          />
+          <Query id="databaseOverview" path="/databases/overview">
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Server</TableHead>
-                  <TableHead>Host</TableHead>
-                  <TableHead>Port</TableHead>
-                  <TableHead>Username</TableHead>
+                  <TableHead>Metric</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead>Unit</TableHead>
+                  <TableHead>Description</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                <For each="databases ?? []" as="database">
+                <For each="databaseOverview ?? []" as="metric">
                   <TableRow>
-                    <TableCell>{database.name}</TableCell>
-                    <TableCell>{database.host}</TableCell>
-                    <TableCell>{database.port}</TableCell>
-                    <TableCell>{database.username}</TableCell>
+                    <TableCell>{metric.label}</TableCell>
+                    <TableCell>{metric.value}</TableCell>
+                    <TableCell>{metric.unit ?? '-'}</TableCell>
+                    <TableCell>{metric.description ?? '-'}</TableCell>
                   </TableRow>
                 </For>
               </TableBody>

--- a/api/src/routes/databases.py
+++ b/api/src/routes/databases.py
@@ -1,0 +1,18 @@
+import src.db as db
+from fastapi import HTTPException
+from src.router import router
+from src.models.databases import DatabaseOverviewMetric
+
+
+@router.get("/databases/overview")
+async def list_database_overview_metrics() -> list[DatabaseOverviewMetric]:
+    """Return database overview metrics displayed in settings UI."""
+    try:
+        return await db.databases.list_overview_metrics()
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    except Exception as error:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unable to collect database overview metrics: {error}",
+        ) from error

--- a/api/src/utils/database.py
+++ b/api/src/utils/database.py
@@ -3,6 +3,7 @@ import asyncio
 import psycopg2
 from src.env import env
 from psycopg2 import sql
+from src.models.databases import DatabaseOverviewMetric
 
 _DATABASE_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -15,6 +16,11 @@ async def create(database_name: str) -> None:
         )
 
     await asyncio.to_thread(_create_sync, database_name)
+
+
+async def list_overview_metrics() -> list[DatabaseOverviewMetric]:
+    """Return user-facing metrics about provisioned PostgreSQL cluster."""
+    return await asyncio.to_thread(_list_overview_metrics_sync)
 
 
 def _create_sync(database_name: str) -> None:
@@ -34,7 +40,9 @@ def _create_sync(database_name: str) -> None:
         admin_connection.autocommit = True
         with admin_connection.cursor() as cursor:
             # Guard against duplicate DB names before CREATE DATABASE.
-            cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", (database_name,))
+            cursor.execute(
+                "SELECT 1 FROM pg_database WHERE datname = %s", (database_name,)
+            )
             if cursor.fetchone() is not None:
                 raise ValueError(f"Database '{database_name}' already exists")
 
@@ -42,5 +50,83 @@ def _create_sync(database_name: str) -> None:
             cursor.execute(
                 sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name))
             )
+    finally:
+        admin_connection.close()
+
+
+def _list_overview_metrics_sync() -> list[DatabaseOverviewMetric]:
+    """Collect cluster metrics from PostgreSQL system catalogs."""
+    connection_kwargs: dict[str, str | int] = {
+        "host": env.ENV_PROVISION_DATABASE_HOST,
+        "port": env.ENV_PROVISION_DATABASE_PORT,
+        "user": env.ENV_PROVISION_DATABASE_USERNAME,
+        "password": env.ENV_PROVISION_DATABASE_PASSWORD,
+        "dbname": env.ENV_PROVISION_DATABASE_MAINTENANCE_DATABASE,
+    }
+    if env.ENV_PROVISION_DATABASE_SSLMODE:
+        connection_kwargs["sslmode"] = env.ENV_PROVISION_DATABASE_SSLMODE
+
+    admin_connection = psycopg2.connect(**connection_kwargs)
+    try:
+        with admin_connection.cursor() as cursor:
+            # Gather counts and storage usage from system catalogs.
+            cursor.execute(
+                """
+                SELECT
+                    COUNT(*) FILTER (WHERE datistemplate = false) AS total_databases,
+                    COUNT(*) FILTER (
+                        WHERE datistemplate = false
+                        AND datname NOT IN ('postgres')
+                    ) AS created_databases,
+                    COALESCE(SUM(pg_database_size(datname)) FILTER (WHERE datistemplate = false), 0) AS used_storage_bytes,
+                    MAX(pg_database_size(datname)) FILTER (WHERE datistemplate = false) AS largest_database_bytes
+                FROM pg_database
+                """
+            )
+            (
+                total_databases,
+                created_databases,
+                used_storage_bytes,
+                largest_database_bytes,
+            ) = cursor.fetchone()
+
+            # Free storage cannot be queried reliably without infra-level quotas.
+            free_storage_bytes: int | None = None
+
+        return [
+            DatabaseOverviewMetric(
+                key="total_databases",
+                label="Total Databases",
+                value=str(total_databases or 0),
+                description="Non-template databases visible in cluster.",
+            ),
+            DatabaseOverviewMetric(
+                key="created_databases",
+                label="Created Databases",
+                value=str(created_databases or 0),
+                description="Databases created for workloads (excluding postgres default DB).",
+            ),
+            DatabaseOverviewMetric(
+                key="used_storage_bytes",
+                label="Used Storage",
+                value=str(used_storage_bytes or 0),
+                unit="bytes",
+                description="Total size sum for all non-template databases.",
+            ),
+            DatabaseOverviewMetric(
+                key="largest_database_bytes",
+                label="Largest Database",
+                value=str(largest_database_bytes or 0),
+                unit="bytes",
+                description="Largest single non-template database size.",
+            ),
+            DatabaseOverviewMetric(
+                key="free_storage_bytes",
+                label="Free Storage",
+                value="N/A" if free_storage_bytes is None else str(free_storage_bytes),
+                unit=None if free_storage_bytes is None else "bytes",
+                description="Infra quota metric not exposed by PostgreSQL catalogs.",
+            ),
+        ]
     finally:
         admin_connection.close()


### PR DESCRIPTION
### Motivation
- Provide high-level database cluster visibility in settings UI instead of manual "Connect" action. 
- Surface metrics (counts, storage usage, largest DB) to help admins monitor DB resource usage at a glance.

### Description
- Add `GET /databases/overview` route returning list of `DatabaseOverviewMetric` models to expose cluster metrics via API (`api/src/routes/databases.py`, `api/src/models/databases.py`).
- Implement `DatabasesService` and register it on `db` service exports for route usage (`api/src/db/services/databases.py`, `api/src/db/services/__init__.py`, `api/src/db/__init__.py`).
- Extend DB utilities to query PostgreSQL catalogs and compute metrics: total non-template DBs, created workload DBs (excluding `postgres`), total used storage bytes, largest DB bytes, and a placeholder `free_storage` value when infra quota data unavailable (`api/src/utils/database.py`).
- Register new route in API bootstrap and update settings page XML to remove connect button and render a metrics table bound to `/databases/overview` (`api/main.py`, `api/src/pages/settings.xml`).

### Testing
- Ran `python -m isort api/src api/main.py` successfully to fix imports.
- Ran `python -m compileall api/src api/main.py` successfully; modules compile cleanly.
- Ran `make format` which failed due to environment Python version mismatch (local environment is Python 3.10 while project requires Python >=3.12).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20b030ba48323a51d858526f3696a)