### PR TITLE
sdk: seed local env defaults in dev command

### DIFF
--- a/sdk/longlink/cli/dev.py
+++ b/sdk/longlink/cli/dev.py
@@ -6,6 +6,20 @@ import click
 import uvicorn
 
 
+def _set_dev_env_defaults() -> None:
+    """Seed local development environment with SDK-safe default secrets."""
+
+    # Ensure dev mode stays enabled for parent process and uvicorn reload workers.
+    os.environ["DEV"] = "True"
+
+    # Provide local-first defaults so sample apps boot without external secrets.
+    os.environ.setdefault("KEY", "longlink")
+    os.environ.setdefault("DBURL", "sqlite:///./dev.db")
+    os.environ.setdefault("storage_key", "dev")
+    os.environ.setdefault("storage_secret", "dev")
+    os.environ.setdefault("storage_endpoint", "http://localhost:9000")
+
+
 def load_app():
     """Load user module and return FastAPI app instance for uvicorn factory."""
 
@@ -30,7 +44,7 @@ def dev_command():
     """Run LongLink application locally with auto-reload enabled."""
 
     sys.path.insert(0, os.getcwd())
-    os.environ["DEV"] = "True"
+    _set_dev_env_defaults()
 
     uvicorn.run(
         "longlink.cli.dev:load_app",


### PR DESCRIPTION
### Motivation
- Fix `longlink dev` crash caused by missing required ENV settings so sample apps boot in local dev using SQLite and local storage defaults.

### Description
- Add `_set_dev_env_defaults()` in `sdk/longlink/cli/dev.py` to set `DEV=True` and provide safe defaults for `KEY`, `DBURL`, `storage_key`, `storage_secret`, and `storage_endpoint`, and call it from `dev_command()`.

### Testing
- Attempted `make format` from repo root which failed due to host Python being 3.10 while project requires Python `>=3.12`, so install/format steps could not run; no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20c6c8e6c8323be5fa7d385c46490)