### PR TITLE
Introduce `LongLink` FastAPI subclass; remove implicit app creation and require explicit `app` export

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,13 +1,9 @@
 # Import internal routes for side-effect registration on the global router.
 import longlink.routes  # noqa: E402,F401
-from longlink.app import App, create_app, create_longlink_app
+from longlink.app import App, LongLink
 from longlink.envs import ENV, ENVDev, Envs, EnvsDev, envs, get_envs
 from longlink.organization import org
 from longlink.predefined import issues_page, sample_page
 from longlink.router import (delete, get, page, pages, patch, post, put, route,
                              xml_page)
 from longlink.xml import load_page_schema_from_xml
-
-# Official Starlette application wrapper and instance.
-application = create_longlink_app()
-app = application.fastapi

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -24,24 +24,24 @@ class SPAStaticFiles(StaticFiles):
         return await super().get_response("index.html", scope)
 
 
-class App:
-    """LongLink SDK application wrapper around FastAPI and validated env."""
+class LongLink(FastAPI):
+    """LongLink SDK FastAPI application with platform defaults attached."""
 
-    def __init__(self, env: ENV, fastapi_app: FastAPI | None = None):
-        """Create application wrapper and bind validated env to FastAPI state."""
+    def __init__(self, env: ENV | None = None, **kwargs):
+        """Create FastAPI app and apply LongLink middleware, routes, and state."""
 
-        self.env = env
-        self.fastapi = fastapi_app or FastAPI()
+        super().__init__(**kwargs)
+        self.env = env or get_envs()
         self._configure()
 
     def _configure(self) -> None:
-        """Configure middleware, routes, static assets, and application state."""
+        """Configure middleware, routes, static assets, and LongLink state."""
 
         # Keep validated env accessible to route handlers and extensions.
-        self.fastapi.state.env = self.env
-        self.fastapi.state.longlink_app = self
+        self.state.env = self.env
+        self.state.longlink_app = self
 
-        self.fastapi.add_middleware(
+        self.add_middleware(
             CORSMiddleware,
             allow_origins=[
                 "http://localhost:3000",
@@ -52,24 +52,16 @@ class App:
             allow_methods=["*"],
             allow_headers=["*"],
         )
-        self.fastapi.include_router(api_router)
+        self.include_router(api_router)
 
         static_dir = Path(__file__).resolve().parent / "static"
         if static_dir.exists():
-            self.fastapi.mount(
+            self.mount(
                 "/",
                 SPAStaticFiles(directory=static_dir, html=True),
                 name="static",
             )
 
 
-def create_longlink_app(env: ENV | None = None) -> App:
-    """Create LongLink app wrapper with explicit or default environment."""
-
-    return App(env=env or get_envs())
-
-
-def create_app(env: ENV | None = None) -> FastAPI:
-    """Create and return FastAPI application for backwards compatibility."""
-
-    return create_longlink_app(env=env).fastapi
+# Backwards-compatible alias while SDK migrates naming to LongLink.
+App = LongLink

--- a/sdk/longlink/cli/dev.py
+++ b/sdk/longlink/cli/dev.py
@@ -34,9 +34,9 @@ def load_app():
         if hasattr(application, "fastapi"):
             return application.fastapi
 
-    from longlink import app
-
-    return app
+    raise RuntimeError(
+        "main.py must export `app` as FastAPI instance. Example: `from longlink import LongLink; app = LongLink()`."
+    )
 
 
 @click.command(name="dev")

--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -1,5 +1,7 @@
 import src.routes.sample
-from longlink import issues_page, sample_page
+from longlink import LongLink, issues_page, sample_page
+
+app = LongLink()
 
 # xml_page("/cart", name="Cart", icon="shopping-cart", schema_path=PAGES_DIR / "cart.xml")
 # xml_page("/dashboard", name="Dashboard", icon="layout-dashboard", schema_path=PAGES_DIR / "dashboard.xml")


### PR DESCRIPTION
### Motivation
- Rename and expose a clear SDK application type and remove implicit side-effectful application creation to encourage explicit FastAPI app exports from user projects.
- Consolidate environment and platform defaults directly onto the FastAPI app instance for simpler integration and clearer state handling.

### Description
- Replaced the wrapper `App` with `LongLink`, which now subclasses `FastAPI` and stores validated env on `self.state` while installing middleware, routers, and static SPA handling directly on the instance.
- Removed `create_longlink_app` and `create_app` factory functions and the module-level `application` instance from `__init__.py`, and added a backwards-compatible alias `App = LongLink`.
- Updated the dev CLI `load_app` to require that `main.py` export an `app` FastAPI instance and to raise a `RuntimeError` with an example import message if not present, removing the previous fallback to the SDK-provided app.
- Updated the sample app to instantiate `LongLink` as `app` and adjusted imports accordingly.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20f8ec2988323a70c6b025395d2b3)