### PR TITLE
refactor(api): split shared router into per-module routers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
 from fastapi import FastAPI
 from pathlib import Path
 from src.env import env
-from src.router import router
+from src.routes import routers
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -51,18 +51,8 @@ app.add_middleware(
 
 
 # Register routers
-import src.routes.apps
-import src.routes.auth
-import src.routes.user
-import src.routes.pages
-import src.routes.users
-import src.routes.compute
-import src.routes.storage
-import src.routes.settings
-import src.routes.databases
-import src.routes.organization
-
-app.include_router(router)
+for router in routers:
+    app.include_router(router)
 
 static_dir = Path(__file__).resolve().parent / "static"
 if static_dir.exists():

--- a/api/src/router.py
+++ b/api/src/router.py
@@ -1,3 +1,0 @@
-from fastapi import APIRouter
-
-router = APIRouter()

--- a/api/src/routes/__init__.py
+++ b/api/src/routes/__init__.py
@@ -1,0 +1,25 @@
+from src.routes.apps import router as apps_router
+from src.routes.auth import router as auth_router
+from src.routes.user import router as user_router
+from src.routes.pages import router as pages_router
+from src.routes.users import router as users_router
+from src.routes.compute import router as compute_router
+from src.routes.proxies import router as proxies_router
+from src.routes.storage import router as storage_router
+from src.routes.settings import router as settings_router
+from src.routes.databases import router as databases_router
+from src.routes.organization import router as organization_router
+
+routers = [
+    apps_router,
+    auth_router,
+    compute_router,
+    databases_router,
+    organization_router,
+    pages_router,
+    proxies_router,
+    settings_router,
+    storage_router,
+    user_router,
+    users_router,
+]

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -1,8 +1,9 @@
 import src.db as db
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from src.utils import apps
-from src.router import router
 from src.models.apps import AppType, AppCreate, AppMetadata, AppResponse
+
+router = APIRouter()
 
 
 @router.get("/apps")

--- a/api/src/routes/auth.py
+++ b/api/src/routes/auth.py
@@ -1,12 +1,13 @@
 import httpx
 import src.db as db
 from typing import cast
-from fastapi import Request, HTTPException
+from fastapi import Request, APIRouter, HTTPException
 from src.env import env
 from src.auth import oauth
-from src.router import router
 from fastapi.responses import RedirectResponse
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
+
+router = APIRouter()
 
 
 @router.get("/login/oidc")

--- a/api/src/routes/compute.py
+++ b/api/src/routes/compute.py
@@ -1,10 +1,11 @@
 import src.db as db
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from src.env import env
-from src.router import router
 from src.models.computes import (ComputeEnvironment, ComputeContainerCreate,
                                  ComputeContainerCreateResponse)
 from kubernetes.client.exceptions import ApiException
+
+router = APIRouter()
 
 
 def _pod_name_from_app_key(app_key: str, container_name: str) -> str:

--- a/api/src/routes/databases.py
+++ b/api/src/routes/databases.py
@@ -1,7 +1,8 @@
 import src.db as db
-from fastapi import HTTPException
-from src.router import router
+from fastapi import APIRouter, HTTPException
 from src.models.databases import DatabaseOverviewMetric
+
+router = APIRouter()
 
 
 @router.get("/databases/overview")

--- a/api/src/routes/organization.py
+++ b/api/src/routes/organization.py
@@ -1,7 +1,9 @@
 import src.db as db
 import src.utils.apps
+from fastapi import APIRouter
 from src.config import OrganizationSettings
-from src.router import router
+
+router = APIRouter()
 
 
 @router.get("/organization")

--- a/api/src/routes/pages.py
+++ b/api/src/routes/pages.py
@@ -1,11 +1,12 @@
 import xmltodict
 from typing import List
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from pathlib import Path
 from pydantic import BaseModel
-from src.router import router
 from fastapi.responses import Response
 from xml.parsers.expat import ExpatError
+
+router = APIRouter()
 
 PAGES_DIR = Path(__file__).resolve().parents[1] / "pages"
 PAGE_NAME_PATTERN = "abcdefghijklmnopqrstuvwxyz0123456789-"

--- a/api/src/routes/proxies.py
+++ b/api/src/routes/proxies.py
@@ -1,11 +1,12 @@
 import httpx
 import src.db as db
-from fastapi import Request, Response, HTTPException
+from fastapi import Request, Response, APIRouter, HTTPException
 from src.utils import apps
-from src.router import router
 from fastapi.responses import JSONResponse
 
 ALLOWED_METHODS = ["GET", "POST"]
+
+router = APIRouter()
 
 
 @router.api_route("/apps/{app_name}", methods=ALLOWED_METHODS)

--- a/api/src/routes/settings.py
+++ b/api/src/routes/settings.py
@@ -1,9 +1,10 @@
 import src.db as db
 from typing import List
-from fastapi import Query, HTTPException
+from fastapi import Query, APIRouter, HTTPException
 from src.utils import apps
-from src.router import router
 from src.models.settings import SettingSet, SettingSetItem, SettingResponse
+
+router = APIRouter()
 
 
 @router.get("/settings")

--- a/api/src/routes/storage.py
+++ b/api/src/routes/storage.py
@@ -1,6 +1,8 @@
 import src.db as db
-from src.router import router
+from fastapi import APIRouter
 from src.models.storages import StorageConnection
+
+router = APIRouter()
 
 
 @router.get("/storage")

--- a/api/src/routes/user.py
+++ b/api/src/routes/user.py
@@ -1,8 +1,9 @@
 import src.db as db
-from fastapi import Depends
+from fastapi import Depends, APIRouter
 from src.auth import authuser
 from src.models import UserUpdate
-from src.router import router
+
+router = APIRouter()
 
 
 @router.get("/user")

--- a/api/src/routes/users.py
+++ b/api/src/routes/users.py
@@ -1,8 +1,9 @@
 import src.db as db
-from fastapi import Depends
+from fastapi import Depends, APIRouter
 from src.auth import authuser
-from src.router import router
 from src.models.users import UserResponse
+
+router = APIRouter()
 
 
 @router.get("/users")


### PR DESCRIPTION
### Motivation
- Move route declarations to their modules to keep endpoints colocated and remove side-effect imports. 
- Prepare routing for clearer module isolation and future per-module middleware or mounts.

### Description
- Each route module under `api/src/routes` now declares its own `router = APIRouter()` instead of importing shared `src.router`.
- Added centralized registry `routers` in `api/src/routes/__init__.py` that imports each module router and exposes a list of routers.
- Updated `api/main.py` to `include_router` for each router from `src.routes.routers` instead of relying on a single shared router import. 
- Removed obsolete `api/src/router.py` and applied import/style fixes (`isort`).

### Testing
- Ran `python -m isort api/main.py api/src/routes` which completed successfully. 
- Ran `python -m compileall api/main.py api/src/routes` which completed successfully. 
- Ran `make format` which failed due to environment Python (3.10.19) not meeting package requirement `Python>=3.12`, so repo-level format step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21e30788483239aec36c159a30107)