### PR TITLE
sdk: migrate SDK models and DB foundation to SQLModel

### DIFF
--- a/sdk/longlink/database/__init__.py
+++ b/sdk/longlink/database/__init__.py
@@ -1,5 +1,10 @@
-from .base import Base
+from .base import Base, get_session
 
 
 class Database:
+    """Placeholder DB facade for SDK public API."""
+
     pass
+
+
+__all__ = ["Base", "Database", "get_session"]

--- a/sdk/longlink/database/base.py
+++ b/sdk/longlink/database/base.py
@@ -1,15 +1,14 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlmodel import Session, SQLModel, create_engine
 
 DATABASE_URL = "sqlite:///./test.db"
 
-engine = create_engine(DATABASE_URL, echo=False, future=True)
+engine = create_engine(DATABASE_URL, echo=False)
 
-SessionLocal = sessionmaker(
-    bind=engine,
-    autoflush=False,
-    autocommit=False,
-    future=True,
-)
 
-Base = declarative_base()
+# Keep backward-compatible alias for code still importing `Base`.
+Base = SQLModel
+
+
+def get_session() -> Session:
+    """Create DB session bound to SDK engine."""
+    return Session(engine)

--- a/sdk/longlink/database/env.py
+++ b/sdk/longlink/database/env.py
@@ -4,7 +4,8 @@ from longlink.database.base import Base, engine
 target_metadata = Base.metadata
 
 
-def run_migrations_offline():
+def run_migrations_offline() -> None:
+    """Run Alembic migrations in offline mode."""
     context.configure(
         url=str(engine.url),
         target_metadata=target_metadata,
@@ -17,7 +18,8 @@ def run_migrations_offline():
         context.run_migrations()
 
 
-def run_migrations_online():
+def run_migrations_online() -> None:
+    """Run Alembic migrations in online mode."""
     with engine.connect() as connection:
         context.configure(
             connection=connection,

--- a/sdk/longlink/database/migrations.py
+++ b/sdk/longlink/database/migrations.py
@@ -1,46 +1,45 @@
-from alembic import command
+import importlib.util
+import sys
 from pathlib import Path
+
+from alembic import command
 from alembic.config import Config
 
+from longlink.database.base import Base, engine
+
 CURRENT_FILE = Path(__file__).resolve()
-
-import sys
-import importlib.util
-from pathlib import Path
-
 MODELS_PATH = Path.cwd() / "src" / "models"
 
+
+# Load application model modules so metadata includes table definitions.
 for py_file in MODELS_PATH.glob("*.py"):
     if py_file.name.startswith("__"):
         continue
 
     module_name = f"src.models.{py_file.stem}"
-
     spec = importlib.util.spec_from_file_location(module_name, py_file)
     if spec is None or spec.loader is None:
         continue
+
     module = importlib.util.module_from_spec(spec)
-    print(f"Importing module: {module_name} from {py_file}")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
 
-from longlink.database.base import Base, engine
 
-
-def make_migrations():
+def make_migrations() -> None:
+    """Generate new Alembic revision from metadata diff."""
     cfg = Config()
     cfg.set_main_option("script_location", str(CURRENT_FILE.parent))
     cfg.set_main_option("version_locations", "migrations")
-
     command.revision(cfg)
 
 
-def migrate():
+def migrate() -> None:
+    """Apply all pending Alembic migrations."""
     cfg = Config()
     cfg.set_main_option("script_location", str(CURRENT_FILE.parent))
     cfg.set_main_option("version_locations", "migrations")
     command.upgrade(cfg, "head")
-
 
 
 if __name__ == "__main__":

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx",
     "fsspec",
     "fastapi",
+    "sqlmodel",
     "xmltodict",
 ]
 requires-python = ">=3.12"

--- a/sdk/sample/src/models/contract.py
+++ b/sdk/sample/src/models/contract.py
@@ -1,5 +1,7 @@
 from enum import Enum
-from pydantic import EmailStr, BaseModel
+
+from pydantic import EmailStr
+from sqlmodel import SQLModel
 
 """
 Features
@@ -15,10 +17,8 @@ class StatusEnum(str, Enum):
     ARCHIVED = "Archived"
 
 
-class Contract(BaseModel):
+class Contract(SQLModel):
     name: str
     company: str
     email: EmailStr
     status: StatusEnum
-
-

--- a/sdk/sample/src/models/projects.py
+++ b/sdk/sample/src/models/projects.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 from enum import Enum
 from typing import Optional
-from datetime import datetime
-from pydantic import Field, BaseModel
+
+from sqlmodel import Field, SQLModel
 
 """
 Features:
@@ -10,24 +11,25 @@ File attachments
 Task list (embedded)
 """
 
+
 class ProjectStatus(str, Enum):
     PLANNED = "Planned"
     ACTIVE = "Active"
     COMPLETED = "Completed"
 
 
-class LinkedContact(BaseModel):
+class LinkedContact(SQLModel):
     id: str
     name: str
     email: Optional[str] = None
 
 
-class Project(BaseModel):
-    id: str = Field(..., description="Unique project identifier")
-    name: str = Field(..., description="Project name")
-    linked_contact: LinkedContact = Field(..., description="Associated contact")
+class Project(SQLModel):
+    id: str = Field(description="Unique project identifier")
+    name: str = Field(description="Project name")
+    linked_contact: LinkedContact = Field(description="Associated contact")
     status: ProjectStatus = Field(default=ProjectStatus.PLANNED, description="Project status")
-    budget: float = Field(..., ge=0, description="Project budget in currency units")
-    owner: str = Field(..., description="Project owner name or ID")
+    budget: float = Field(ge=0, description="Project budget in currency units")
+    owner: str = Field(description="Project owner name or ID")
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/sdk/sample/src/types/sample.py
+++ b/sdk/sample/src/types/sample.py
@@ -1,9 +1,10 @@
-from typing import Optional
 from datetime import datetime
-from pydantic import Field, BaseModel
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
 
 
-class UserModel(BaseModel):
+class UserModel(SQLModel):
     id: int
     username: str = Field(min_length=3, max_length=30)
     email: str


### PR DESCRIPTION
### Motivation
- Move SDK to `sqlmodel` for better FastAPI integration and first-class SQL model support.
- Ensure generated apps use consistent DB/session API that is compatible with FastAPI and SQLModel tooling.

### Description
- Replaced SQLAlchemy declarative/session setup with `sqlmodel` engine and `get_session()` in `sdk/longlink/database/base.py` and kept `Base = SQLModel` alias for compatibility.
- Exported `get_session()` and `Base` from `sdk/longlink/database/__init__.py` and added brief `Database` docstring.
- Updated Alembic helpers in `sdk/longlink/database/env.py` and `sdk/longlink/database/migrations.py` to use `SQLModel` metadata and to load application model modules before generating/applying migrations.
- Migrated sample SDK schemas/models in `sdk/sample/src/` from `pydantic.BaseModel` to `sqlmodel.SQLModel` and added `sqlmodel` to `sdk/pyproject.toml` dependencies.

### Testing
- Ran `python -m compileall sdk/longlink sdk/sample/src` which completed successfully.
- Ran `make format` which failed because formatter bootstraps `api[dev]` requiring `Python >=3.12` while environment is `Python 3.10.19`.
- No unit tests were added or modified in this change per SDK guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21e5aa1908323af9ddde631a7e85b)