### PR TITLE
SDK: add LongLinkRouter and switch sample app to APIRouter-style

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -4,6 +4,6 @@ from longlink.app import App, LongLink
 from longlink.envs import ENV, ENVDev, Envs, EnvsDev, envs, get_envs
 from longlink.organization import org
 from longlink.predefined import issues_page, sample_page
-from longlink.router import (delete, get, page, pages, patch, post, put, route,
-                             xml_page)
+from longlink.router import (LongLinkRouter, delete, get, page, pages, patch,
+                             post, put, route, xml_page)
 from longlink.xml import load_page_schema_from_xml

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -1,13 +1,13 @@
-import json
 import inspect
-from typing import Any, Callable, Awaitable
+import json
+from typing import Any, Callable
 from fastapi import APIRouter
 from pathlib import Path
 from pydantic import BaseModel
 from functools import wraps
 from fastapi.responses import Response, JSONResponse, PlainTextResponse
 
-Handler = Callable[..., Awaitable[Any]]
+Handler = Callable[..., Any]
 
 api_router = APIRouter()
 _pages: list[dict[str, str]] = []
@@ -17,7 +17,8 @@ _pages: list[dict[str, str]] = []
 def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
     @wraps(handler)
     async def endpoint(*args, **kwargs):
-        body = await handler(*args, **kwargs)
+        result = handler(*args, **kwargs)
+        body = await result if inspect.isawaitable(result) else result
 
         if is_page:
             if isinstance(body, str):
@@ -72,6 +73,31 @@ def _format_response(handler: Handler, body: Any) -> Response | JSONResponse | P
     return PlainTextResponse(str(body))
 
 
+class LongLinkRouter(APIRouter):
+    """APIRouter that applies LongLink response formatting to route handlers."""
+
+    def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
+        """Register route after wrapping endpoint with LongLink response handling."""
+
+        super().add_api_route(path, _build_endpoint(endpoint), **kwargs)
+
+    def page(self, path: str, name: str, icon: str) -> Callable[[Handler], Handler]:
+        """Register page endpoint and track metadata for page listing."""
+
+        def decorator(func: Handler) -> Handler:
+            _pages.append({"path": path, "name": name, "icon": icon})
+            endpoint_path = f"/pages/{path.lstrip('/')}"
+            super().add_api_route(
+                endpoint_path,
+                _build_endpoint(func, is_page=True),
+                methods=["GET"],
+                response_model=None,
+            )
+            return func
+
+        return decorator
+
+
 def route(path: str, methods: list[str] | None = None):
     normalized_methods = [method.upper() for method in (methods or ["GET"])]
 
@@ -88,18 +114,7 @@ def route(path: str, methods: list[str] | None = None):
 
 
 def page(path: str, name: str, icon: str):
-    def decorator(func: Handler) -> Handler:
-        _pages.append({"path": path, "name": name, "icon": icon})
-        endpoint_path = f"/pages/{path.lstrip('/')}"
-        api_router.add_api_route(
-            endpoint_path,
-            _build_endpoint(func, is_page=True),
-            methods=["GET"],
-            response_model=None,
-        )
-        return func
-
-    return decorator
+    return LongLinkRouter.page(api_router, path, name, icon)
 
 
 def xml_page(path: str, name: str | None = None, icon: str | None = None, schema_path: str | Path | None = None) -> None:

--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -1,7 +1,8 @@
-import src.routes.sample
 from longlink import LongLink, issues_page, sample_page
+from src.routes.sample import router
 
 app = LongLink()
+app.include_router(router)
 
 # xml_page("/cart", name="Cart", icon="shopping-cart", schema_path=PAGES_DIR / "cart.xml")
 # xml_page("/dashboard", name="Dashboard", icon="layout-dashboard", schema_path=PAGES_DIR / "dashboard.xml")

--- a/sdk/sample/src/routes/sample.py
+++ b/sdk/sample/src/routes/sample.py
@@ -1,49 +1,66 @@
-from longlink import get, put, post, patch, delete
+from longlink import LongLinkRouter
 from src.types import UserModel
 
+router = LongLinkRouter()
 
-@get("/sample")
+
+@router.get("/sample")
 async def sample_get_endpoint():
+    """Handle sample GET request."""
+
     return "Sample GET endpoint received data"
 
 
-@post("/sample")
+@router.post("/sample")
 async def sample_post_endpoint():
+    """Handle sample POST request."""
+
     return "Sample POST endpoint response"
 
 
-@put("/sample")
+@router.put("/sample")
 async def sample_put_endpoint():
+    """Handle sample PUT request."""
+
     return f"Sample PUT endpoint updated item"
 
 
-@delete("/sample")
+@router.delete("/sample")
 async def sample_delete_endpoint():
+    """Handle sample DELETE request."""
+
     return f"Sample DELETE endpoint deleted item"
 
 
-
-@patch("/sample")
+@router.patch("/sample")
 async def sample_patch_endpoint():
+    """Handle sample PATCH request."""
+
     return f"Sample PATCH endpoint patched item"
 
 
 # Example with dynamic URL parameter
-@post("/dynamic/{object}")
+@router.post("/dynamic/{object}")
 async def sample_post_endpoint_with_object(object: int):
+    """Handle sample POST request with dynamic path parameter."""
+
     return "Sample POST endpoint response"
 
 
 # Example with params
 # Params must have a default value
-@post("/params/{object}")
+@router.post("/params/{object}")
 async def sample_post_endpoint_with_params(object: int, start: int = 0, end: int = 10):
+    """Handle sample POST request with path and query parameters."""
+
     return "Sample POST endpoint response"
 
 
 # Example that return a Pydantic model
-@post("/sample/user")
+@router.post("/sample/user")
 async def sample_post_user_endpoint() -> UserModel:
+    """Handle sample POST request that returns a typed user model."""
+
     return UserModel(
         id=1,
         username="testuser",
@@ -55,6 +72,8 @@ async def sample_post_user_endpoint() -> UserModel:
 
 # Example with params
 # Params must have a default value
-@get("/params/{object}")
+@router.get("/params/{object}")
 async def sample_get_endpoint_with_params(object: int, start: int = 0, end: int = 10):
+    """Handle sample GET request with path and query parameters."""
+
     return "Sample GET endpoint response"


### PR DESCRIPTION
### Motivation
- Replace global generic route decorators with router-based registration to match FastAPI patterns and simplify app composition.
- Preserve existing LongLink response formatting and page metadata behavior while enabling `include_router` usage.

### Description
- Added `LongLinkRouter` in `sdk/longlink/router/__init__.py` which wraps `add_api_route` and `page` to apply LongLink response formatting and page metadata tracking.
- Exported `LongLinkRouter` from top-level `longlink` package by updating `sdk/longlink/__init__.py` so apps can import `LongLinkRouter` directly.
- Converted sample app to router-style by creating `router = LongLinkRouter()` and replacing `@get/post/...` with `@router.get/post/...` in `sdk/sample/src/routes/sample.py` and registering router with `app.include_router(router)` in `sdk/sample/main.py`.
- Made `_build_endpoint` awaitable-safe so both sync and async handlers are supported and preserved existing response formatting logic.

### Testing
- Ran `python -m compileall` for modified modules which succeeded for `sdk/longlink/router/__init__.py`, `sdk/sample/main.py`, and `sdk/sample/src/routes/sample.py`.
- Ran `make format` which failed in this environment due to inability to fetch PyPI dependency `starlette` (network/tunnel error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21ff420988323bdb2a62c56aab409)