### PR TITLE
docs: add SDK endpoints guide and FastAPI references

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         items: [
           { text: 'Overview', link: '/sdk/' },
           { text: 'Environments', link: '/sdk/environments/' },
+          { text: 'Endpoints', link: '/sdk/endpoints/' },
           {
             text: 'Pages',
             collapsed: true,

--- a/docs/src/sdk/endpoints/index.md
+++ b/docs/src/sdk/endpoints/index.md
@@ -1,0 +1,77 @@
+# Endpoints
+
+LongLink SDK wraps FastAPI.
+You define endpoint handlers on the wrapped FastAPI app.
+
+## How endpoint setup works
+
+1. Create environment object.
+2. Create `App(env=...)` wrapper.
+3. Access FastAPI instance with `application.fastapi`.
+4. Register endpoints with FastAPI decorators.
+
+## Basic endpoint example
+
+```python
+from longlink import App, ENV
+
+
+env = ENV()
+application = App(env=env)
+app = application.fastapi
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Return basic service health status."""
+
+    return {"status": "ok"}
+```
+
+## Endpoint with request and response models
+
+```python
+from pydantic import BaseModel
+from longlink import App, ENV
+
+
+class ItemCreate(BaseModel):
+    """Request model for item creation."""
+
+    name: str
+
+
+class ItemResponse(BaseModel):
+    """Response model for item payload."""
+
+    id: int
+    name: str
+
+
+env = ENV()
+application = App(env=env)
+app = application.fastapi
+
+
+@app.post("/items", response_model=ItemResponse)
+def create_item(payload: ItemCreate) -> ItemResponse:
+    """Create item and return normalized response."""
+
+    return ItemResponse(id=1, name=payload.name)
+```
+
+## FastAPI references
+
+LongLink endpoint layer follows FastAPI behavior.
+Use FastAPI docs for decorator options, validation, dependency injection, and OpenAPI metadata.
+
+- [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/)
+- [Path operation decorators](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/)
+- [Request body with Pydantic](https://fastapi.tiangolo.com/tutorial/body/)
+- [Dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/)
+- [Response models](https://fastapi.tiangolo.com/tutorial/response-model/)
+
+::: tip
+Use standard FastAPI patterns for routers and dependencies.
+LongLink wrapper does not replace FastAPI routing model.
+:::

--- a/docs/src/sdk/index.md
+++ b/docs/src/sdk/index.md
@@ -56,9 +56,16 @@ You can extend `ENV` with project-specific variables and pass the resulting obje
 See complete examples in:
 
 - [Environments](/sdk/environments/)
+- [Endpoints](/sdk/endpoints/)
 
 ## Configuration
 
 To configure runtime variables for database and storage, see the environments guide:
 
 - [Environments](/sdk/environments/)
+
+## API Endpoints
+
+To define endpoint handlers on top of the wrapped FastAPI app, see:
+
+- [Endpoints](/sdk/endpoints/)


### PR DESCRIPTION
### Motivation

- Provide clear guidance for defining HTTP endpoints using SDK `App` wrapper since SDK exposes a FastAPI instance for handlers.

### Description

- Add new documentation page `docs/src/sdk/endpoints/index.md` with endpoint setup steps, basic `GET` example, Pydantic request/response example, and links to core FastAPI docs.
- Update SDK overview `docs/src/sdk/index.md` to reference the new Endpoints page and add a short `API Endpoints` section for discoverability.
- Update VitePress sidebar config `docs/.vitepress/config.ts` to include `Endpoints` entry under Applications SDK navigation.

### Testing

- Ran `make format`; automated run failed due to dependency fetch error from PyPI (`https://pypi.org/simple/isort/`) caused by network/tunnel connectivity, so formatting step did not complete.
- No other automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e220af106483238134ad812f3b161e)