### PR TITLE
docs(sdk): position SDK as thin wrapper around FastAPI ecosystem

### DIFF
--- a/docs/src/sdk/index.md
+++ b/docs/src/sdk/index.md
@@ -1,19 +1,30 @@
 # Application SDK
 
-Applications in LongLink are **logic-centric components** designed to implement business rules, validation, and process control.
+LongLink SDK is wrapper around proven Python ecosystem tools.
+Goal is to keep development flow as close as possible to native FastAPI stack, while adding platform integration and normalized interfaces.
 
-They do not manage infrastructure, persistence, or rendering directly. Instead, each application defines **how data is validated, processed, and enforced**, while the platform handles execution, storage, and delivery.
+SDK centers around these building blocks:
 
-An application is therefore a **pure Python logic layer** responsible for:
+- FastAPI for REST API design and runtime behavior
+- SQLModel for relational data models built on SQLAlchemy
+- Alembic for schema migration lifecycle
+- Pydantic for request and response models, plus Pydantic Settings for configuration
+- S3-compatible object storage exposed through a normalization layer aligned with the S3 specification
 
-- enforcing business constraints
-- validating and transforming data
-- orchestrating workflows and decisions
+This design means you can use standard FastAPI ecosystem patterns first, then rely on SDK wrappers to reduce boilerplate for platform concerns.
 
-Each application operates in isolation with:
+## What SDK Adds
 
-- a dedicated database for structured data
-- a dedicated object storage for unstructured data and files
+SDK does not replace ecosystem tools.
+SDK wraps and connects tools so you can focus on business logic.
+
+SDK provides:
+
+- app bootstrap wrapper around FastAPI
+- environment and settings wiring with typed validation
+- normalized database and migration conventions
+- normalized object storage access for S3-compatible providers
+- integration points with LongLink control plane lifecycle
 
 ## Application Types
 
@@ -50,22 +61,24 @@ longlink dev
 
 ## Application Construction
 
-The SDK creates applications through an `App` wrapper that contains a FastAPI instance and a validated environment object.
-You can extend `ENV` with project-specific variables and pass the resulting object to `App`.
+The SDK creates applications through an `App` wrapper that contains a FastAPI instance and validated settings.
+You can extend settings with project-specific values and pass the resulting object to `App`.
 
 See complete examples in:
 
 - [Environments](/sdk/environments/)
 - [Endpoints](/sdk/endpoints/)
+- [Database](/sdk/database/)
+- [Storage](/sdk/storage/)
 
 ## Configuration
 
-To configure runtime variables for database and storage, see the environments guide:
+To configure runtime variables for database and storage, see:
 
 - [Environments](/sdk/environments/)
 
 ## API Endpoints
 
-To define endpoint handlers on top of the wrapped FastAPI app, see:
+To define endpoint handlers on top of wrapped FastAPI app, see:
 
 - [Endpoints](/sdk/endpoints/)

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -6,18 +6,34 @@ This folder contains the LongLink Python SDK.
 
 ```
 sdk/
-├── longlink/           # Core SDK code
+├── longlink/         # Core SDK code
 ├── sample/           # Sample applications
-└── tests/           # Unit tests
+└── tests/            # Unit tests
 ```
 
-This folder contains:
+## SDK Direction
 
-- `tests` - Unit tests for the SDK
-- `longlink` - Core SDK code
-- `sample` - Sample projects using the SDK
+The SDK must stay close to the FastAPI ecosystem.
+Treat SDK as thin wrapper that simplifies integration, not custom framework that replaces ecosystem defaults.
 
-You can install the SDK locally in development mode with the following command:
+Core stack expectations:
+
+- FastAPI for API behavior and routing
+- SQLModel (SQLAlchemy-based) for DB models
+- Alembic for DB migrations
+- Pydantic and Pydantic Settings for data validation and app configuration
+- S3-compatible storage with normalized behavior aligned to S3 specification
+
+When implementing SDK features:
+
+- prefer native FastAPI, SQLModel, Alembic, and Pydantic patterns
+- add wrappers only to remove repetitive boilerplate or enforce platform conventions
+- keep abstractions explicit and easy to map back to underlying ecosystem tools
+- keep storage interfaces provider-agnostic by normalizing to S3-compatible semantics
+
+## Local Development
+
+Install SDK in development mode:
 
 ```bash
 pip install -e './sdk'
@@ -25,20 +41,16 @@ pip install -e './sdk'
 
 ## Tests
 
-To run the unit tests, use the following command:
+Run unit tests:
 
 ```bash
 pytest tests
 ```
 
-## SDK
-
-The sdk folder contains the code to create a LongLink application. Each repository shall create a single application, therefore there is no need for
-
 ## Pre-Commit
 
-Fix imports with `isort`:
+Fix imports:
 
-```
+```bash
 python -m isort .
 ```


### PR DESCRIPTION
### Motivation
- Clarify SDK role as thin wrapper around proven FastAPI ecosystem tools to reduce boilerplate and keep developer flow familiar. 
- Align SDK guidance with platform needs: typed settings, SQLModel/SQLAlchemy for models, Alembic for migrations, and S3-spec-aligned normalized storage interface.

### Description
- Rewrote `docs/src/sdk/index.md` to position SDK around `FastAPI`, `SQLModel`, `Alembic`, `Pydantic` (including Pydantic Settings), and S3-compatible storage normalization, and to document what SDK adds (bootstrap, settings wiring, DB/migrations conventions, storage normalization, control plane integration). 
- Updated `sdk/AGENTS.md` to codify SDK direction and implementation rules (prefer native ecosystem patterns, add wrappers only for boilerplate, keep storage provider-agnostic via S3 semantics), and preserved local dev/test/pre-commit instructions. 
- Added internal doc links to `Database` and `Storage` sections and adjusted wording to use `settings` terminology for the `App` wrapper.

### Testing
- Attempted to run `make format` from repo root as required, but command failed due to network/PyPI fetch error when installing dependencies (`psycopg2-binary`), so automated formatting was not completed. 
- Committed changes successfully; no unit tests were executed as part of this rollout (`pytest tests` not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e221e545948323a9a8137641ac04e0)