### PR TITLE
test(api): add pytest route test suite under tests/routes

### DIFF
--- a/api/tests/routes/conftest.py
+++ b/api/tests/routes/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from main import app
+from collections.abc import Generator
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Provide FastAPI test client with clean dependency overrides per test."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()

--- a/api/tests/routes/test_apps_routes.py
+++ b/api/tests/routes/test_apps_routes.py
@@ -1,0 +1,87 @@
+import pytest
+from types import SimpleNamespace
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        """Store fake upstream response payload and status code."""
+        self._payload = payload
+        self.status_code = status_code
+        self.is_success = 200 <= status_code < 300
+
+    def json(self) -> dict:
+        """Return stored JSON payload."""
+        return self._payload
+
+
+@pytest.mark.unit
+def test_list_apps_returns_app_responses(client, monkeypatch):
+    """List apps route returns mapped app payloads from database service."""
+    from src.routes import apps as apps_routes
+
+    async def fake_list():
+        """Return two fake apps for list endpoint."""
+        return [
+            SimpleNamespace(id="1", name="One", url="https://one", type="tool"),
+            SimpleNamespace(id="2", name="Two", url="https://two", type="space"),
+        ]
+
+    monkeypatch.setattr(apps_routes.db.apps, "list", fake_list)
+
+    response = client.get("/apps")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {"id": "1", "name": "One", "url": "https://one", "type": "tool"},
+        {"id": "2", "name": "Two", "url": "https://two", "type": "space"},
+    ]
+
+
+@pytest.mark.unit
+def test_create_app_registers_metadata_and_returns_app(client, monkeypatch):
+    """Create app route fetches metadata, persists app, triggers org sync."""
+    from src.routes import apps as apps_routes
+
+    created = {}
+
+    async def fake_raw(url: str, method: str):
+        """Return valid metadata payload for app registration."""
+        created["metadata_url"] = url
+        created["method"] = method
+        return _FakeHttpResponse({"name": "Calendar", "type": "tool"})
+
+    async def fake_create(name: str, url: str, key: str, app_type: str, app_id: str | None):
+        """Persist fake app and return created object."""
+        created["create_args"] = {
+            "name": name,
+            "url": url,
+            "key": key,
+            "app_type": app_type,
+            "app_id": app_id,
+        }
+        return SimpleNamespace(id="app-1", name=name, url=url, type=app_type)
+
+    async def fake_org(app_id: str):
+        """Capture organization sync app id."""
+        created["org_app_id"] = app_id
+
+    monkeypatch.setattr(apps_routes.apps, "raw", fake_raw)
+    monkeypatch.setattr(apps_routes.db.apps, "create", fake_create)
+    monkeypatch.setattr(apps_routes.apps, "org", fake_org)
+
+    response = client.post(
+        "/apps",
+        json={"id": " external-id ", "url": "example.com/", "key": "k-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "app-1",
+        "name": "Calendar",
+        "url": "https://example.com",
+        "type": "tool",
+    }
+    assert created["metadata_url"] == "https://example.com/metadata.json"
+    assert created["method"] == "GET"
+    assert created["create_args"]["app_id"] == "external-id"
+    assert created["org_app_id"] == "app-1"

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -1,0 +1,63 @@
+import httpx
+import pytest
+from types import SimpleNamespace
+
+
+@pytest.mark.unit
+def test_logout_returns_ok_response(client):
+    """Logout route returns success payload."""
+    response = client.get("/logout")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.unit
+def test_login_oidc_handles_provider_metadata_failure(client, monkeypatch):
+    """OIDC login route returns 502 when provider metadata fetch fails."""
+    from src.routes import auth as auth_routes
+
+    class _FailingOidcClient:
+        async def authorize_redirect(self, request, redirect_uri: str):
+            """Raise HTTP status error to emulate OIDC metadata outage."""
+            request_info = httpx.Request(method="GET", url="https://issuer.example/.well-known")
+            response = httpx.Response(status_code=503, request=request_info)
+            raise httpx.HTTPStatusError("unavailable", request=request_info, response=response)
+
+    monkeypatch.setattr(auth_routes.oauth, "create_client", lambda _: _FailingOidcClient())
+
+    response = client.get("/login/oidc")
+
+    assert response.status_code == 502
+    assert "OIDC provider metadata is unavailable" in response.json()["detail"]
+
+
+@pytest.mark.unit
+def test_auth_oidc_sets_user_session_and_redirects(client, monkeypatch):
+    """OIDC callback stores user in session and redirects to control plane URL."""
+    from src.routes import auth as auth_routes
+
+    async def fake_create_or_update_oidc_user(**kwargs):
+        """Return fake user record persisted from userinfo claims."""
+        return SimpleNamespace(id=77, **kwargs)
+
+    class _OidcClient:
+        async def authorize_access_token(self, request):
+            """Return token containing userinfo payload."""
+            return {
+                "userinfo": {
+                    "sub": "oidc-1",
+                    "email": "user@example.com",
+                    "name": "Test User",
+                    "picture": "https://avatar",
+                }
+            }
+
+    monkeypatch.setattr(auth_routes.oauth, "create_client", lambda _: _OidcClient())
+    monkeypatch.setattr(auth_routes.db.users, "create_or_update_oidc_user", fake_create_or_update_oidc_user)
+
+    response = client.get("/auth/oidc", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "http://localhost:5173"
+    assert "set-cookie" in {key.lower() for key in response.headers.keys()}

--- a/api/tests/routes/test_compute_routes.py
+++ b/api/tests/routes/test_compute_routes.py
@@ -1,0 +1,78 @@
+import pytest
+from types import SimpleNamespace
+
+
+@pytest.mark.unit
+def test_list_compute_environments_uses_env_defaults(client):
+    """Compute list route returns default environment from configuration."""
+    response = client.get("/compute")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "key": "default",
+            "api_server_url": "http://localhost:8001",
+            "default_namespace": "default",
+            "verify_ssl": False,
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_create_compute_container_for_app_returns_not_found(client, monkeypatch):
+    """Container creation route returns 404 when app id does not exist."""
+    from src.routes import compute as compute_routes
+
+    async def fake_get_by_uuid(app_id: str):
+        """Return no app for requested id."""
+        return None
+
+    monkeypatch.setattr(compute_routes.db.apps, "get_by_uuid", fake_get_by_uuid)
+
+    response = client.post(
+        "/compute/apps/missing/containers",
+        json={"image": "python:3.12", "container_name": "worker"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "App 'missing' not found"
+
+
+@pytest.mark.unit
+def test_create_compute_container_for_app_success(client, monkeypatch):
+    """Container creation route calls compute service and returns created payload."""
+    from src.routes import compute as compute_routes
+
+    calls = {}
+
+    async def fake_get_by_uuid(app_id: str):
+        """Return fake app matching route parameter."""
+        return SimpleNamespace(id=app_id, key="sales")
+
+    async def fake_create_container(**kwargs):
+        """Capture create container request arguments."""
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setattr(compute_routes.db.apps, "get_by_uuid", fake_get_by_uuid)
+    monkeypatch.setattr(compute_routes.db.computes, "create_container", fake_create_container)
+
+    response = client.post(
+        "/compute/apps/app-9/containers",
+        json={
+            "image": "python:3.12",
+            "container_name": "worker",
+            "env": [{"name": "MODE", "value": "prod"}],
+            "container_port": 8080,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "app_id": "app-9",
+        "app_key": "sales",
+        "namespace": "default",
+        "pod_name": "sales-worker",
+        "image": "python:3.12",
+        "status": "created",
+    }
+    assert calls["kwargs"]["env_vars"] == {"MODE": "prod"}

--- a/api/tests/routes/test_databases_routes.py
+++ b/api/tests/routes/test_databases_routes.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.unit
+def test_list_database_overview_metrics_returns_metrics(client, monkeypatch):
+    """Database overview route returns metrics from database service."""
+    from src.routes import databases as databases_routes
+
+    async def fake_list_overview_metrics():
+        """Return fake overview metrics list."""
+        return [
+            {
+                "key": "connections",
+                "label": "Connections",
+                "value": "7",
+                "unit": None,
+                "description": "active",
+            }
+        ]
+
+    monkeypatch.setattr(databases_routes.db.databases, "list_overview_metrics", fake_list_overview_metrics)
+
+    response = client.get("/databases/overview")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "key": "connections",
+            "label": "Connections",
+            "value": "7",
+            "unit": None,
+            "description": "active",
+        }
+    ]

--- a/api/tests/routes/test_organization_routes.py
+++ b/api/tests/routes/test_organization_routes.py
@@ -1,0 +1,63 @@
+import pytest
+
+
+@pytest.mark.unit
+def test_get_organization_returns_current_settings(client, monkeypatch):
+    """Organization get route returns organization settings model payload."""
+    from src.routes import organization as organization_routes
+
+    async def fake_get_organization():
+        """Return organization settings payload from settings service."""
+        return {
+            "ORG_NAME": "LongLink",
+            "ORG_NAME_LEGAL": "LongLink Inc",
+            "ORG_TAX_ID": "123",
+            "ORG_PHONE": "",
+            "ORG_MAIL_CONTACT": "",
+            "ORG_MAIL_SUPPORT": "",
+            "ORG_WEBSITE": "",
+            "ORG_ADDRESS": "",
+        }
+
+    monkeypatch.setattr(organization_routes.db.settings, "get_organization", fake_get_organization)
+
+    response = client.get("/organization")
+
+    assert response.status_code == 200
+    assert response.json()["ORG_NAME"] == "LongLink"
+
+
+@pytest.mark.unit
+def test_update_organization_persists_and_notifies_apps(client, monkeypatch):
+    """Organization put route saves settings then triggers app sync."""
+    from src.routes import organization as organization_routes
+
+    state = {"saved": None, "notified": False}
+
+    async def fake_save_organization(payload):
+        """Capture payload written to organization settings service."""
+        state["saved"] = payload.model_dump()
+
+    async def fake_org():
+        """Capture organization notification call to apps."""
+        state["notified"] = True
+
+    monkeypatch.setattr(organization_routes.db.settings, "save_organization", fake_save_organization)
+    monkeypatch.setattr(organization_routes.src.utils.apps, "org", fake_org)
+
+    payload = {
+        "ORG_NAME": "LongLink",
+        "ORG_NAME_LEGAL": "LongLink LLC",
+        "ORG_TAX_ID": "ABC",
+        "ORG_PHONE": "123",
+        "ORG_MAIL_CONTACT": "contact@longlink.dev",
+        "ORG_MAIL_SUPPORT": "support@longlink.dev",
+        "ORG_WEBSITE": "https://longlink.dev",
+        "ORG_ADDRESS": "Earth",
+    }
+    response = client.put("/organization", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == payload
+    assert state["saved"] == payload
+    assert state["notified"] is True

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+@pytest.mark.unit
+def test_list_pages_returns_parsed_page_attributes(client, monkeypatch, tmp_path):
+    """Pages list route reads xml files and returns normalized metadata."""
+    from src.routes import pages as pages_routes
+
+    monkeypatch.setattr(pages_routes, "PAGES_DIR", tmp_path)
+    (tmp_path / "overview.xml").write_text('<Page name="Overview" icon="home"/>', encoding="utf-8")
+    (tmp_path / "custom-page.xml").write_text('<Page name="Custom"/>', encoding="utf-8")
+
+    response = client.get("/pages")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {"name": "Overview", "path": "overview", "icon": "home"},
+        {"name": "Custom", "path": "custom-page", "icon": "file-text"},
+    ]
+
+
+@pytest.mark.unit
+def test_get_page_rejects_invalid_name(client):
+    """Pages get route rejects invalid page names with 404."""
+    response = client.get("/pages/../secrets")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Page not found"

--- a/api/tests/routes/test_proxies_routes.py
+++ b/api/tests/routes/test_proxies_routes.py
@@ -1,0 +1,73 @@
+import pytest
+from types import SimpleNamespace
+
+
+class _FakeUpstreamResponse:
+    def __init__(self, json_payload=None, content: bytes = b"", status_code: int = 200, headers=None):
+        """Build fake upstream response with JSON, bytes, status, and headers."""
+        self._json_payload = json_payload
+        self.content = content
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.is_success = 200 <= status_code < 300
+
+    def json(self):
+        """Return JSON payload or raise ValueError when payload missing."""
+        if self._json_payload is None:
+            raise ValueError("invalid json")
+        return self._json_payload
+
+
+@pytest.mark.unit
+def test_proxy_root_wraps_pages_response(client, monkeypatch):
+    """Proxy root route wraps upstream pages payload under pages key."""
+    from src.routes import proxies as proxies_routes
+
+    async def fake_get_by_uuid(app_name: str):
+        """Return no app to force fallback lookup by name."""
+        return None
+
+    async def fake_get_by_name(app_name: str):
+        """Return fake app resolved from name."""
+        return SimpleNamespace(id="app-1", key="k-1")
+
+    async def fake_request(app_id: str, method: str, path: str, **kwargs):
+        """Return pages payload from fake upstream app."""
+        return _FakeUpstreamResponse(json_payload=[{"path": "overview"}], status_code=200)
+
+    monkeypatch.setattr(proxies_routes.db.apps, "get_by_uuid", fake_get_by_uuid)
+    monkeypatch.setattr(proxies_routes.db.apps, "get_by_name", fake_get_by_name)
+    monkeypatch.setattr(proxies_routes.apps, "request", fake_request)
+
+    response = client.get("/apps/calendar")
+
+    assert response.status_code == 200
+    assert response.json() == {"pages": [{"path": "overview"}]}
+
+
+@pytest.mark.unit
+def test_proxy_path_forwards_json_payload(client, monkeypatch):
+    """Proxy path route forwards JSON body and returns upstream content."""
+    from src.routes import proxies as proxies_routes
+
+    captured = {}
+
+    async def fake_get_by_uuid(app_name: str):
+        """Return fake app for proxying by id."""
+        return SimpleNamespace(id="app-1", key="k-1")
+
+    async def fake_request(app_id: str, method: str, path: str, **kwargs):
+        """Capture forwarded request and return plain text response."""
+        captured.update({"app_id": app_id, "method": method, "path": path, **kwargs})
+        return _FakeUpstreamResponse(content=b"ok", status_code=201, headers={"content-type": "text/plain"})
+
+    monkeypatch.setattr(proxies_routes.db.apps, "get_by_uuid", fake_get_by_uuid)
+    monkeypatch.setattr(proxies_routes.apps, "request", fake_request)
+
+    response = client.post("/apps/app-1/run", params={"x": "1"}, json={"hello": "world"})
+
+    assert response.status_code == 201
+    assert response.text == "ok"
+    assert captured["path"] == "run"
+    assert captured["json"] == {"hello": "world"}
+    assert captured["params"]["key"] == "k-1"

--- a/api/tests/routes/test_settings_routes.py
+++ b/api/tests/routes/test_settings_routes.py
@@ -1,0 +1,52 @@
+import pytest
+from types import SimpleNamespace
+
+
+@pytest.mark.unit
+def test_get_setting_returns_value(client, monkeypatch):
+    """Single setting route returns stored setting response payload."""
+    from src.routes import settings as settings_routes
+
+    async def fake_get(key: str, app_id=None):
+        """Return fake setting object for requested key."""
+        return SimpleNamespace(key=key, value="on", appid=app_id)
+
+    monkeypatch.setattr(settings_routes.db.settings, "get", fake_get)
+
+    response = client.get("/settings/feature")
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "feature", "value": "on", "app_id": None}
+
+
+@pytest.mark.unit
+def test_put_settings_saves_all_and_notifies_org(client, monkeypatch):
+    """Bulk settings route writes every item and triggers org sync."""
+    from src.routes import settings as settings_routes
+
+    calls = {"set": [], "org": False}
+
+    async def fake_set(key: str, value: str, app_id=None):
+        """Store each set call and return saved setting object."""
+        calls["set"].append({"key": key, "value": value, "app_id": app_id})
+        return SimpleNamespace(key=key, value=value, appid=app_id)
+
+    async def fake_org():
+        """Mark org sync trigger call."""
+        calls["org"] = True
+
+    monkeypatch.setattr(settings_routes.db.settings, "set", fake_set)
+    monkeypatch.setattr(settings_routes.apps, "org", fake_org)
+
+    response = client.put(
+        "/settings",
+        json=[{"key": "a", "value": "1"}, {"key": "b", "value": "2"}],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {"key": "a", "value": "1", "app_id": None},
+        {"key": "b", "value": "2", "app_id": None},
+    ]
+    assert len(calls["set"]) == 2
+    assert calls["org"] is True

--- a/api/tests/routes/test_storage_routes.py
+++ b/api/tests/routes/test_storage_routes.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+@pytest.mark.unit
+def test_list_storages_returns_connections(client, monkeypatch):
+    """Storage route returns storage connections from service layer."""
+    from src.routes import storage as storage_routes
+
+    async def fake_list():
+        """Return fake storage connections list."""
+        return [
+            {
+                "name": "default",
+                "endpoint_url": "http://localhost:9000",
+                "region_name": None,
+            }
+        ]
+
+    monkeypatch.setattr(storage_routes.db.storages, "list", fake_list)
+
+    response = client.get("/storage")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "name": "default",
+            "endpoint_url": "http://localhost:9000",
+            "region_name": None,
+        }
+    ]

--- a/api/tests/routes/test_user_routes.py
+++ b/api/tests/routes/test_user_routes.py
@@ -1,0 +1,45 @@
+import pytest
+from types import SimpleNamespace
+
+
+@pytest.mark.unit
+def test_get_user_details_returns_authenticated_user(client):
+    """User details route returns dependency-injected authenticated user."""
+    from main import app
+    from src.auth import authuser
+
+    async def fake_authuser():
+        """Return fake authenticated user object."""
+        return SimpleNamespace(id=1, name="Ada", email="ada@example.com", avatar=None)
+
+    app.dependency_overrides[authuser] = fake_authuser
+
+    response = client.get("/user")
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Ada"
+
+
+@pytest.mark.unit
+def test_patch_user_details_updates_with_payload(client, monkeypatch):
+    """Patch user route updates user when payload has mutable fields."""
+    from main import app
+    from src.auth import authuser
+    from src.routes import user as user_routes
+
+    async def fake_authuser():
+        """Return fake authenticated user object."""
+        return SimpleNamespace(id=2, name="Before", email="before@example.com", avatar=None)
+
+    async def fake_update(user_id: int, **params):
+        """Return fake updated user object with merged fields."""
+        return SimpleNamespace(id=user_id, name=params["name"], email="before@example.com", avatar=None)
+
+    app.dependency_overrides[authuser] = fake_authuser
+    monkeypatch.setattr(user_routes.db.users, "update", fake_update)
+
+    response = client.patch("/user", json={"name": "After"})
+
+    assert response.status_code == 200
+    assert response.json()["id"] == 2
+    assert response.json()["name"] == "After"

--- a/api/tests/routes/test_users_routes.py
+++ b/api/tests/routes/test_users_routes.py
@@ -1,0 +1,42 @@
+import pytest
+from types import SimpleNamespace
+
+
+@pytest.mark.unit
+def test_list_users_returns_mapped_user_responses(client, monkeypatch):
+    """Users route returns user records mapped to response schema."""
+    from main import app
+    from src.auth import authuser
+    from src.routes import users as users_routes
+
+    async def fake_authuser():
+        """Return fake authenticated user required by route guard."""
+        return SimpleNamespace(id=99)
+
+    async def fake_list():
+        """Return fake users from users service."""
+        return [
+            SimpleNamespace(
+                id=1,
+                name="Ada",
+                email="ada@example.com",
+                avatar="https://avatar",
+                oidc_subject="oidc-ada",
+            )
+        ]
+
+    app.dependency_overrides[authuser] = fake_authuser
+    monkeypatch.setattr(users_routes.db.users, "list", fake_list)
+
+    response = client.get("/users")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": 1,
+            "name": "Ada",
+            "email": "ada@example.com",
+            "avatar": "https://avatar",
+            "oidc_subject": "oidc-ada",
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Increase unit coverage for API route handlers to catch regressions in request handling and response shaping.
- Provide isolated, Pythonic tests that exercise success and selected error paths without requiring full infra (DB/K8s).

### Description
- Add new test package `api/tests/routes` with shared FastAPI `TestClient` fixture in `conftest.py` to provide clean dependency overrides per test via `app.dependency_overrides.clear()`.
- Implement pytest unit tests for all route modules: `apps`, `auth`, `compute`, `databases`, `organization`, `pages`, `proxies`, `settings`, `storage`, `user`, and `users` using `monkeypatch` to stub async service calls and upstream HTTP behavior.
- Tests use lightweight helpers (e.g., `_FakeHttpResponse`, `_FakeUpstreamResponse`) and `types.SimpleNamespace` for fake records, and assert both normal responses and selected error conditions.
- Format/import fixes applied to new test files (`isort` run) and tests compiled to verify syntax (`python -m compileall tests/routes`).

### Testing
- `python -m compileall tests/routes` succeeded and verified files are syntactically valid. ✅
- `pytest tests/routes -q` attempted but failed at import time due to missing runtime dependency raising `ModuleNotFoundError: No module named 'kubernetes'`. ⚠️
- `make format` attempted but failed due to environment network restrictions preventing installation of dev dependency (`pytest-asyncio`) from PyPI. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2203f29e483238486468f23a9c7a4)