### PR TITLE
refactor(sdk): move xml and metadata helpers into utils package

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,9 +1,9 @@
 # Import internal routes for side-effect registration on the global router.
 import longlink.routes  # noqa: E402,F401
 from longlink.app import App, LongLink
-from longlink.envs import ENV, ENVDev, Envs, EnvsDev, envs, get_envs
-from longlink.organization import org
+from longlink.envs import ENV, Envs, ENVDev, EnvsDev, envs, get_envs
+from longlink.router import (LongLinkRouter, get, put, page, post, pages,
+                             patch, route, delete, xml_page)
+from longlink.utils.xml import load_page_schema_from_xml
 from longlink.predefined import issues_page, sample_page
-from longlink.router import (LongLinkRouter, delete, get, page, pages, patch,
-                             post, put, route, xml_page)
-from longlink.xml import load_page_schema_from_xml
+from longlink.organization import org

--- a/sdk/longlink/cli/build.py
+++ b/sdk/longlink/cli/build.py
@@ -2,7 +2,7 @@ import json
 import click
 from pathlib import Path
 from datetime import UTC, datetime
-from longlink.metadata import load_metadata
+from longlink.utils.metadata import load_metadata
 
 DOCKERFILE_TEMPLATE = """FROM python:3.12-slim
 

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -1,5 +1,5 @@
-import inspect
 import json
+import inspect
 from typing import Any, Callable
 from fastapi import APIRouter
 from pathlib import Path
@@ -126,7 +126,7 @@ def xml_page(path: str, name: str | None = None, icon: str | None = None, schema
     resolved_icon = icon
 
     if resolved_name is None or resolved_icon is None:
-        from longlink.xml import load_page_metadata_from_xml
+        from longlink.utils.xml import load_page_metadata_from_xml
 
         metadata = load_page_metadata_from_xml(xml_path)
         resolved_name = resolved_name or metadata.get("name")
@@ -137,7 +137,7 @@ def xml_page(path: str, name: str | None = None, icon: str | None = None, schema
 
     @page(path, name=resolved_name, icon=resolved_icon)
     async def _xml_page() -> dict[str, Any]:
-        from longlink.xml import load_page_schema_from_xml
+        from longlink.utils.xml import load_page_schema_from_xml
 
         return load_page_schema_from_xml(xml_path)
 

--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,7 +1,7 @@
 """Metadata route."""
 
 from longlink.router import get
-from longlink.metadata import metadata
+from longlink.utils.metadata import metadata
 
 
 @get('/metadata.json')

--- a/sdk/longlink/utils/__init__.py
+++ b/sdk/longlink/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for LongLink SDK internals."""

--- a/sdk/longlink/utils/metadata.py
+++ b/sdk/longlink/utils/metadata.py
@@ -5,12 +5,16 @@ from pydantic import BaseModel
 
 
 class Metadata(BaseModel):
+    """LongLink app metadata model loaded from metadata.json."""
+
     name: str = 'Sample LongLink app'
     description: str = ''
     type: Literal['tool', 'space', 'process'] = 'tool'
 
 
 def load_metadata() -> Metadata:
+    """Load app metadata from cwd metadata.json with safe defaults."""
+
     metadata_file = Path.cwd() / 'metadata.json'
 
     if not metadata_file.exists():
@@ -18,6 +22,7 @@ def load_metadata() -> Metadata:
         return Metadata()
 
     try:
+        # Parse metadata file if present; fallback to defaults on parse/read issues.
         payload = json.loads(metadata_file.read_text())
     except (json.JSONDecodeError, OSError):
         return Metadata()

--- a/sdk/longlink/utils/xml.py
+++ b/sdk/longlink/utils/xml.py
@@ -1,9 +1,13 @@
+"""XML helper utilities for LongLink page definitions."""
+
 import xmltodict
 from typing import Any
 from pathlib import Path
 
 
 def load_page_schema_from_xml(path: str | Path) -> str:
+    """Load XML page schema text and validate root element."""
+
     content = Path(path).read_text(encoding="utf-8")
     document = xmltodict.parse(content)
     _get_page_root(document)
@@ -11,10 +15,13 @@ def load_page_schema_from_xml(path: str | Path) -> str:
 
 
 def load_page_metadata_from_xml(path: str | Path) -> dict[str, str]:
+    """Extract root metadata fields from XML page schema."""
+
     document = xmltodict.parse(Path(path).read_text(encoding="utf-8"))
     root = _get_page_root(document)
 
     metadata: dict[str, str] = {}
+    # Pull supported metadata attrs from root element and normalize whitespace.
     for key in ("name", "icon"):
         value = root.get(f"@{key}") or root.get(key)
         if isinstance(value, str) and value.strip():
@@ -24,6 +31,8 @@ def load_page_metadata_from_xml(path: str | Path) -> dict[str, str]:
 
 
 def _get_page_root(document: dict[str, Any]) -> dict[str, Any]:
+    """Return XML root object for Page documents."""
+
     root = document.get("Page")
     if not isinstance(root, dict):
         raise ValueError("XML page document must contain a <Page> root element.")


### PR DESCRIPTION
### Motivation
- Organize SDK helper utilities to improve discoverability and encapsulation by grouping XML and metadata helpers under a `utils` package.
- Avoid top-level module clutter and make import paths explicit for SDK internals.

### Description
- Added `sdk/longlink/utils` package and moved `xml.py` and `metadata.py` into `sdk/longlink/utils/` while adding `__init__.py`.
- Updated SDK imports to reference `longlink.utils.xml` and `longlink.utils.metadata` from affected modules including `sdk/longlink/__init__.py`, `sdk/longlink/router/__init__.py`, `sdk/longlink/routes/metadata.py`, and `sdk/longlink/cli/build.py`.
- Added concise docstrings and small inline comments to the moved helper modules to clarify behavior.
- Removed old top-level `sdk/longlink/xml.py` and `sdk/longlink/metadata.py` in favor of the relocated modules.

### Testing
- Ran `make format` from repo root which executed `isort` and `bun prettier` and completed successfully.
- `isort` applied import fixes and formatter ran over web and SDK files with no errors.
- No unit tests were added or modified as per SDK workflow instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e224903a1c8323855befe1a06edf9f)