### PR TITLE
Refactor router and internal SDK routes; expose api_router and bundle SDK routes into LongLink app

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,9 +1,8 @@
-# Import internal routes for side-effect registration on the global router.
+# Import internal routes so LongLink app can include SDK-managed routers.
 import longlink.routes  # noqa: E402,F401
 from longlink.app import App, LongLink
-from longlink.envs import ENV, ENVDev, Envs, EnvsDev, envs, get_envs
-from longlink.organization import org
-from longlink.predefined import issues_page, sample_page
-from longlink.router import (LongLinkRouter, delete, get, page, pages, patch,
-                             post, put, route, xml_page)
 from longlink.xml import load_page_schema_from_xml
+from longlink.envs import ENV, Envs, ENVDev, EnvsDev, envs, get_envs
+from longlink.router import LongLinkRouter, api_router
+from longlink.predefined import issues_page, sample_page
+from longlink.organization import org

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,12 +1,11 @@
-from pathlib import Path
-
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from starlette.exceptions import HTTPException as StarletteHTTPException
-
+from pathlib import Path
 from longlink.envs import ENV, get_envs
 from longlink.router import api_router
+from longlink.routes import sdk_router
+from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from fastapi.middleware.cors import CORSMiddleware
 
 
 class SPAStaticFiles(StaticFiles):
@@ -53,6 +52,7 @@ class LongLink(FastAPI):
             allow_headers=["*"],
         )
         self.include_router(api_router)
+        self.include_router(sdk_router)
 
         static_dir = Path(__file__).resolve().parent / "static"
         if static_dir.exists():

--- a/sdk/longlink/predefined.py
+++ b/sdk/longlink/predefined.py
@@ -1,10 +1,14 @@
-from longlink.router import xml_page
+from longlink.router import api_router
 from longlink.constants import PATH
 
 
 def issues_page(path: str = "/issues", name: str | None = None, icon: str | None = None) -> None:
-    xml_page(path, name=name, icon=icon, schema_path=PATH / "pages" / "issues.xml")
+    """Register predefined issues XML page route."""
+
+    api_router.xml_page(path, name=name, icon=icon, schema_path=PATH / "pages" / "issues.xml")
 
 
 def sample_page(path: str = "/sample-xml", name: str | None = None, icon: str | None = None) -> None:
-    xml_page(path, name=name, icon=icon, schema_path=PATH / "pages" / "sample.xml")
+    """Register predefined sample XML page route."""
+
+    api_router.xml_page(path, name=name, icon=icon, schema_path=PATH / "pages" / "sample.xml")

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -9,8 +9,6 @@ from fastapi.responses import Response, JSONResponse, PlainTextResponse
 
 Handler = Callable[..., Any]
 
-_pages: list[dict[str, str]] = []
-
 
 def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
     @wraps(handler)
@@ -73,6 +71,12 @@ def _format_response(handler: Handler, body: Any) -> Response | JSONResponse | P
 class LongLinkRouter(APIRouter):
     """APIRouter that applies LongLink response formatting to route handlers."""
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Create router and initialize in-memory page metadata store."""
+
+        super().__init__(*args, **kwargs)
+        self._pages: list[dict[str, str]] = []
+
     def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
         """Register route after wrapping endpoint with LongLink response handling."""
 
@@ -82,7 +86,7 @@ class LongLinkRouter(APIRouter):
         """Register page endpoint and track metadata for page listing."""
 
         def decorator(func: Handler) -> Handler:
-            _pages.append({"path": path, "name": name, "icon": icon})
+            self._pages.append({"path": path, "name": name, "icon": icon})
             endpoint_path = f"/pages/{path.lstrip('/')}"
             super().add_api_route(
                 endpoint_path,
@@ -133,7 +137,7 @@ class LongLinkRouter(APIRouter):
     def pages(self) -> list[dict[str, str]]:
         """Return registered page metadata."""
 
-        return list(_pages)
+        return list(self._pages)
 
 
 api_router = LongLinkRouter()

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -1,5 +1,5 @@
-import inspect
 import json
+import inspect
 from typing import Any, Callable
 from fastapi import APIRouter
 from pathlib import Path
@@ -9,9 +9,7 @@ from fastapi.responses import Response, JSONResponse, PlainTextResponse
 
 Handler = Callable[..., Any]
 
-api_router = APIRouter()
 _pages: list[dict[str, str]] = []
-
 
 
 def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
@@ -26,16 +24,15 @@ def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
                     content=body,
                     media_type="text/xml",
                 )
-            elif isinstance(body, (dict, list)):
+            if isinstance(body, (dict, list)):
                 return Response(
                     content=json.dumps(body),
                     media_type="application/json",
                 )
-            else:
-                return PlainTextResponse(
-                    "Invalid response type. Page routes must return an XML string, dict, or list.",
-                    status_code=500,
-                )
+            return PlainTextResponse(
+                "Invalid response type. Page routes must return an XML string, dict, or list.",
+                status_code=500,
+            )
 
         return _format_response(handler, body)
 
@@ -97,70 +94,46 @@ class LongLinkRouter(APIRouter):
 
         return decorator
 
+    def xml_page(
+        self,
+        path: str,
+        name: str | None = None,
+        icon: str | None = None,
+        schema_path: str | Path | None = None,
+    ) -> None:
+        """Register XML-backed page endpoint using explicit data or XML metadata."""
 
-def route(path: str, methods: list[str] | None = None):
-    normalized_methods = [method.upper() for method in (methods or ["GET"])]
+        if schema_path is None:
+            raise ValueError("schema_path is required for xml_page().")
+        xml_path = Path(schema_path)
 
-    def decorator(func: Handler) -> Handler:
-        api_router.add_api_route(
-            path,
-            _build_endpoint(func),
-            methods=normalized_methods,
-            response_model=None,
-        )
-        return func
+        resolved_name = name
+        resolved_icon = icon
 
-    return decorator
+        if resolved_name is None or resolved_icon is None:
+            from longlink.xml import load_page_metadata_from_xml
 
+            metadata = load_page_metadata_from_xml(xml_path)
+            resolved_name = resolved_name or metadata.get("name")
+            resolved_icon = resolved_icon or metadata.get("icon")
 
-def page(path: str, name: str, icon: str):
-    return LongLinkRouter.page(api_router, path, name, icon)
+        if not resolved_name or not resolved_icon:
+            raise ValueError("XML pages must define both name and icon, either in xml_page() or in the XML root.")
 
+        async def xml_endpoint() -> dict[str, Any]:
+            """Load XML schema for runtime renderer."""
 
-def xml_page(path: str, name: str | None = None, icon: str | None = None, schema_path: str | Path | None = None) -> None:
-    if schema_path is None:
-        raise ValueError("schema_path is required for xml_page().")
-    xml_path = Path(schema_path)
+            from longlink.xml import load_page_schema_from_xml
 
-    resolved_name = name
-    resolved_icon = icon
+            return load_page_schema_from_xml(xml_path)
 
-    if resolved_name is None or resolved_icon is None:
-        from longlink.xml import load_page_metadata_from_xml
+        # Keep endpoint registration and metadata registration coupled.
+        self.page(path, name=resolved_name, icon=resolved_icon)(xml_endpoint)
 
-        metadata = load_page_metadata_from_xml(xml_path)
-        resolved_name = resolved_name or metadata.get("name")
-        resolved_icon = resolved_icon or metadata.get("icon")
+    def pages(self) -> list[dict[str, str]]:
+        """Return registered page metadata."""
 
-    if not resolved_name or not resolved_icon:
-        raise ValueError("XML pages must define both name and icon, either in xml_page() or in the XML root.")
-
-    @page(path, name=resolved_name, icon=resolved_icon)
-    async def _xml_page() -> dict[str, Any]:
-        from longlink.xml import load_page_schema_from_xml
-
-        return load_page_schema_from_xml(xml_path)
+        return list(_pages)
 
 
-def pages() -> list[dict[str, str]]:
-    return list(_pages)
-
-
-def get(path: str):
-    return route(path, ["GET"])
-
-
-def post(path: str):
-    return route(path, ["POST"])
-
-
-def put(path: str):
-    return route(path, ["PUT"])
-
-
-def patch(path: str):
-    return route(path, ["PATCH"])
-
-
-def delete(path: str):
-    return route(path, ["DELETE"])
+api_router = LongLinkRouter()

--- a/sdk/longlink/routes/__init__.py
+++ b/sdk/longlink/routes/__init__.py
@@ -1,5 +1,13 @@
 """Register SDK internal routes."""
 
-from . import pages, metadata, organization
+from .pages import pages_router
+from fastapi import APIRouter
+from .metadata import metadata_router
+from .organization import organization_router
 
-__all__ = ['metadata', 'organization', 'pages']
+sdk_router = APIRouter()
+sdk_router.include_router(metadata_router)
+sdk_router.include_router(organization_router)
+sdk_router.include_router(pages_router)
+
+__all__ = ['metadata_router', 'organization_router', 'pages_router', 'sdk_router']

--- a/sdk/longlink/routes/__init__.py
+++ b/sdk/longlink/routes/__init__.py
@@ -10,4 +10,4 @@ sdk_router.include_router(metadata_router)
 sdk_router.include_router(organization_router)
 sdk_router.include_router(pages_router)
 
-__all__ = ['metadata_router', 'organization_router', 'pages_router', 'sdk_router']
+__all__ = ["metadata_router", "organization_router", "pages_router", "sdk_router"]

--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,9 +1,12 @@
 """Metadata route."""
 
-from longlink.router import get
+from fastapi import APIRouter
 from longlink.metadata import metadata
 
+metadata_router = APIRouter()
 
-@get('/metadata.json')
+@metadata_router.get('/metadata.json')
 async def get_metadata_information() -> dict:
+    """Return current application metadata as JSON."""
+
     return metadata.model_dump()

--- a/sdk/longlink/routes/organization.py
+++ b/sdk/longlink/routes/organization.py
@@ -1,13 +1,17 @@
-from longlink.router import put, post
+from fastapi import APIRouter
 from longlink.organization import OrganizationSettings, org
 
+organization_router = APIRouter()
 
-@post('/organization')
-@put('/organization')
+
+@organization_router.post('/organization')
+@organization_router.put('/organization')
 async def update_organization_settings(payload: OrganizationSettings) -> OrganizationSettings:
-    """Organization synchronization routes."""
+    """Synchronize organization settings with in-memory organization state."""
+
     updated_settings = payload.model_dump()
 
+    # Mirror payload fields into shared organization settings singleton.
     for key, value in updated_settings.items():
         setattr(org, key, value)
 

--- a/sdk/longlink/routes/pages.py
+++ b/sdk/longlink/routes/pages.py
@@ -1,8 +1,11 @@
-from longlink.router import get, pages
+from fastapi import APIRouter
+from longlink.router import api_router
+
+pages_router = APIRouter()
 
 
-@get('/pages')
+@pages_router.get('/pages')
 async def get_available_pages() -> list[dict[str, str]]:
-    """Pages route."""
+    """Return metadata for all registered pages."""
 
-    return pages()
+    return api_router.pages()


### PR DESCRIPTION
### Motivation
- Centralize LongLink routing by exposing a reusable `api_router` instance and making XML page registration a router method to keep metadata and endpoint registration coupled.
- Make SDK internal routes (metadata, organization, pages) an includable `sdk_router` so the LongLink app can mount SDK-managed routes cleanly.
- Simplify and modernize route registration by removing top-level decorator functions and using `APIRouter` instances for internal routes.

### Description
- Introduced `api_router = LongLinkRouter()` in `longlink.router` and moved `xml_page` implementation into the `LongLinkRouter` class so XML-backed pages are registered via `api_router.xml_page()` and page metadata is tracked by the router.
- Removed the previous top-level `route/get/post/put/patch/delete` decorators and replaced usages to call into `api_router` directly.
- Added `routes/sdk_router` in `longlink.routes` which aggregates `metadata_router`, `organization_router`, and `pages_router`, and updated `LongLink` app to `include_router(sdk_router)` alongside `api_router` in `longlink.app`.
- Converted internal route modules to use `APIRouter` (`metadata_router`, `organization_router`, `pages_router`) and updated endpoints to register on those routers and interact with the new `api_router` (e.g. pages endpoint returns `api_router.pages()`).
- Updated imports and refactored predefined page helpers (`issues_page`, `sample_page`) to register via `api_router.xml_page()` and added docstrings.
- Minor reordering and cleanup of imports and response formatting adjustments in `router` module.

### Testing
- Ran the automated test suite with `pytest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22522784483239f4ae62842299f5c)