### PR TITLE
Use testcontainers for Keycloak OIDC integration test

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     'pytest==8.4.2',
     'pytest-asyncio==1.2.0',
     'isort==8.0.1',
+    'testcontainers==4.13.2',
 ]
 
 [tool.setuptools]

--- a/api/tests/test_oidc_bridge_keycloak.py
+++ b/api/tests/test_oidc_bridge_keycloak.py
@@ -3,24 +3,58 @@ import sys
 import uuid
 import httpx
 import pytest
+import socket
+import asyncio
 import importlib
 from httpx import ASGITransport
 from pathlib import Path
+from docker.errors import DockerException
+from testcontainers.core.container import DockerContainer
 
-KEYCLOAK_BASE_URL = 'http://127.0.0.1:18080'
+KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.2"
+KEYCLOAK_INTERNAL_PORT = 8080
+
+
+def _pick_free_port() -> int:
+    """Return an available host TCP port for temporary container binding."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return int(sock.getsockname()[1])
+
+
+async def _wait_for_keycloak_ready(base_url: str) -> None:
+    """Poll Keycloak until master realm endpoint responds successfully."""
+    timeout_s = 90.0
+
+    # Poll master realm endpoint until Keycloak fully boots.
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        for _ in range(int(timeout_s)):
+            try:
+                response = await client.get(f"{base_url}/realms/master")
+                if response.status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+
+            await asyncio.sleep(1)
+
+    raise RuntimeError("Keycloak container did not become ready in time")
+
 
 async def _admin_token(client: httpx.AsyncClient, base_url: str) -> str:
+    """Fetch admin access token from Keycloak master realm."""
     response = await client.post(
-        f'{base_url}/realms/master/protocol/openid-connect/token',
+        f"{base_url}/realms/master/protocol/openid-connect/token",
         data={
-            'grant_type': 'password',
-            'client_id': 'admin-cli',
-            'username': 'admin',
-            'password': 'admin',
+            "grant_type": "password",
+            "client_id": "admin-cli",
+            "username": "admin",
+            "password": "admin",
         },
     )
     response.raise_for_status()
-    return response.json()['access_token']
+    return response.json()["access_token"]
 
 
 async def _setup_realm(
@@ -30,33 +64,34 @@ async def _setup_realm(
     client_id: str,
     client_secret: str,
 ) -> None:
+    """Create realm and OIDC client used by API integration flow."""
     token = await _admin_token(client, base_url)
-    headers = {'Authorization': f'Bearer {token}'}
+    headers = {"Authorization": f"Bearer {token}"}
 
     realm_response = await client.post(
-        f'{base_url}/admin/realms',
+        f"{base_url}/admin/realms",
         headers=headers,
-        json={'realm': realm, 'enabled': True},
+        json={"realm": realm, "enabled": True},
     )
     if realm_response.status_code not in (201, 409):
         realm_response.raise_for_status()
 
     client_payload = {
-        'clientId': client_id,
-        'enabled': True,
-        'protocol': 'openid-connect',
-        'publicClient': False,
-        'secret': client_secret,
-        'standardFlowEnabled': True,
-        'directAccessGrantsEnabled': True,
-        'redirectUris': [
-            'http://localhost:8000/auth/oidc',
-            'http://testserver/auth/oidc',
+        "clientId": client_id,
+        "enabled": True,
+        "protocol": "openid-connect",
+        "publicClient": False,
+        "secret": client_secret,
+        "standardFlowEnabled": True,
+        "directAccessGrantsEnabled": True,
+        "redirectUris": [
+            "http://localhost:8000/auth/oidc",
+            "http://testserver/auth/oidc",
         ],
-        'webOrigins': ['*'],
+        "webOrigins": ["*"],
     }
     client_response = await client.post(
-        f'{base_url}/admin/realms/{realm}/clients',
+        f"{base_url}/admin/realms/{realm}/clients",
         headers=headers,
         json=client_payload,
     )
@@ -65,46 +100,75 @@ async def _setup_realm(
 
 
 def _load_app_with_oidc(db_path: Path, issuer: str, client_id: str, client_secret: str):
-    os.environ['DEV'] = 'true'
-    os.environ['ENV_DATABASE_URL'] = f'sqlite+aiosqlite:///{db_path}'
-    os.environ['ENV_OIDC_ISSUER'] = issuer
-    os.environ['ENV_OIDC_CLIENT_ID'] = client_id
-    os.environ['ENV_OIDC_CLIENT_SECRET'] = client_secret
-    os.environ['ENV_OIDC_REDIRECT_URI'] = 'http://testserver/auth/oidc'
+    """Reload FastAPI app module with OIDC config values for integration test."""
+    os.environ["DEV"] = "true"
+    os.environ["ENV_DATABASE_URL"] = f"sqlite+aiosqlite:///{db_path}"
+    os.environ["ENV_OIDC_ISSUER"] = issuer
+    os.environ["ENV_OIDC_CLIENT_ID"] = client_id
+    os.environ["ENV_OIDC_CLIENT_SECRET"] = client_secret
+    os.environ["ENV_OIDC_REDIRECT_URI"] = "http://testserver/auth/oidc"
 
-    for module_name in ('main', 'src.auth', 'src.env', 'src.routes.auth'):
+    # Reset cached modules so env reads happen with test-specific values.
+    for module_name in ("main", "src.auth", "src.env", "src.routes.auth"):
         if module_name in sys.modules:
             del sys.modules[module_name]
 
-    module = importlib.import_module('main')
+    module = importlib.import_module("main")
     return module.app
 
 
-@pytest.mark.integration
-async def test_pure_oidc_bridge_with_dedicated_control_plane_realm(tmp_path: Path) -> None:
-    realm = f'longlink-control-plane-{uuid.uuid4().hex[:8]}'
-    client_id = 'longlink-api'
-    client_secret = 'longlink-secret'
+@pytest.fixture()
+async def keycloak_base_url() -> str:
+    """Start disposable Keycloak with testcontainers and return reachable base URL."""
+    host_port = _pick_free_port()
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as keycloak_client:
-            await _setup_realm(keycloak_client, KEYCLOAK_BASE_URL, realm, client_id, client_secret)
+        with (
+            DockerContainer(KEYCLOAK_IMAGE)
+            .with_exposed_ports(KEYCLOAK_INTERNAL_PORT)
+            .with_env("KEYCLOAK_ADMIN", "admin")
+            .with_env("KEYCLOAK_ADMIN_PASSWORD", "admin")
+            .with_command("start-dev --http-port=8080")
+            .with_bind_ports(KEYCLOAK_INTERNAL_PORT, host_port)
+        ) as _container:
+            base_url = f"http://127.0.0.1:{host_port}"
+            await _wait_for_keycloak_ready(base_url)
+            yield base_url
+    except DockerException as exc:  # pragma: no cover - depends on host docker availability
+        pytest.skip(f"Docker unavailable for testcontainers Keycloak: {exc}")
 
-        issuer = f'{KEYCLOAK_BASE_URL}/realms/{realm}'
-        app = _load_app_with_oidc(tmp_path / 'oidc.db', issuer, client_id, client_secret)
 
-        async with httpx.AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url='http://testserver',
-        ) as client:
-            methods = await client.get('/login')
-            assert methods.status_code == 200
-            assert methods.json() == ['oidc']
+@pytest.mark.integration
+async def test_pure_oidc_bridge_with_dedicated_control_plane_realm(
+    tmp_path: Path, keycloak_base_url: str
+) -> None:
+    """Validate OIDC login bridge flow against disposable Keycloak realm."""
+    realm = f"longlink-control-plane-{uuid.uuid4().hex[:8]}"
+    client_id = "longlink-api"
+    client_secret = "longlink-secret"
 
-            login_redirect = await client.get('/login/oidc', follow_redirects=False)
-            assert login_redirect.status_code in (302, 307)
-            redirect_location = login_redirect.headers['location']
-            assert f'/realms/{realm}/protocol/openid-connect/auth' in redirect_location
-            assert f'client_id={client_id}' in redirect_location
-    except httpx.HTTPError as exc:  # pragma: no cover - integration env dependent
-        pytest.skip(f'Local Keycloak integration is unavailable: {exc}')
+    async with httpx.AsyncClient(timeout=10.0) as keycloak_client:
+        await _setup_realm(
+            keycloak_client,
+            keycloak_base_url,
+            realm,
+            client_id,
+            client_secret,
+        )
+
+    issuer = f"{keycloak_base_url}/realms/{realm}"
+    app = _load_app_with_oidc(tmp_path / "oidc.db", issuer, client_id, client_secret)
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        methods = await client.get("/login")
+        assert methods.status_code == 200
+        assert methods.json() == ["oidc"]
+
+        login_redirect = await client.get("/login/oidc", follow_redirects=False)
+        assert login_redirect.status_code in (302, 307)
+        redirect_location = login_redirect.headers["location"]
+        assert f"/realms/{realm}/protocol/openid-connect/auth" in redirect_location
+        assert f"client_id={client_id}" in redirect_location


### PR DESCRIPTION
### Motivation
- Allow Keycloak OIDC integration test to run in CI/locally by launching disposable Keycloak via testcontainers instead of relying on fixed local instance. 
- Make test robust to environments without Docker by skipping with clear message when Docker daemon unavailable.

### Description
- Add `testcontainers==4.13.2` to API dev dependencies in `api/pyproject.toml`.
- Replace hardcoded `KEYCLOAK_BASE_URL` test flow with a `keycloak_base_url` fixture that starts Keycloak using `testcontainers.core.container.DockerContainer` and returns a reachable base URL.
- Add helpers: `_pick_free_port` to allocate host port and `_wait_for_keycloak_ready` to poll Keycloak readiness, and update `_admin_token`, `_setup_realm`, `_load_app_with_oidc` to use dynamic issuer and environment setup; add docstrings and small comments per repo rules.
- Add `DockerException` handling in fixture to `pytest.skip` when Docker unavailable so test suite remains usable in non-Docker envs.
- Run `isort`/formatting on the modified test file.

### Testing
- Ran `make format`, formatting completed successfully.
- Ran `cd api && ../.venv/bin/python -m pytest tests/test_oidc_bridge_keycloak.py -m integration`; initial run exposed Docker-unavailable error which led to adding `DockerException` skip handling, final run shows the test is skipped in this environment (`1 skipped, 1 warning`).
- Behavior: when Docker is available the fixture will start Keycloak and the test exercises the OIDC bridge flow; when Docker not available the test is skipped with explanatory message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2811919ec8323a99682551a1ac63a)