### PR TITLE
SDK: support sample router/page registration with LongLink app

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,10 +1,15 @@
-# Import internal routes so LongLink app can include SDK-managed routers.
-import longlink.routes  # noqa: E402,F401
-from longlink.app import App, LongLink
-from longlink.xml import load_page_schema_from_xml
-from longlink.envs import ENV, Envs, ENVDev, EnvsDev, envs, get_envs
-from longlink.router import (LongLinkRouter, get, put, page, post, pages,
-                             patch, route, delete, xml_page, api_router)
-from longlink.utils.xml import load_page_schema_from_xml
-from longlink.predefined import issues_page, sample_page
+"""Public SDK exports for LongLink applications."""
+
+from longlink.app import LongLink
+from longlink.envs import Settings, Enviroments, Environments
+from longlink.router import Router
 from longlink.organization import org
+
+__all__ = [
+    "Environments",
+    "Enviroments",
+    "LongLink",
+    "Router",
+    "Settings",
+    "org",
+]

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 from pathlib import Path
-from longlink.envs import ENV
-from longlink.router import api_router
 from longlink.routes import sdk_router
+from fastapi.responses import Response
+from pydantic_settings import BaseSettings
 from fastapi.staticfiles import StaticFiles
+from longlink.utils.page import Page
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -28,14 +29,14 @@ class LongLink(FastAPI):
 
     def __init__(
         self,
-        title: str,
+        title: str = "LongLink App",
         summary: str | None = None,
         description: str | None = None,
         version: str = "0.1.0",
         terms_of_service: str | None = None,
         contact: dict | None = None,
         license_info: dict | None = None,
-        env: ENV | None = None,
+        env: BaseSettings | None = None,
         **kwargs,
     ):
         """Create FastAPI app and apply LongLink middleware, routes, and state."""
@@ -50,13 +51,9 @@ class LongLink(FastAPI):
             **kwargs,
         )
 
-        # TODO: dependencies=[Depends(verify_token), Depends(verify_key)] ensure that all the routes are protected
-
-        ## Configure middleware, routes, static assets, and LongLink state.
-
-        # Keep validated env accessible to route handlers and extensions.
-        # self.state.env = self.env
-        # self.state.longlink_app = self
+        # Keep shared runtime state for SDK routes.
+        self.state.env = env
+        self.state.pages: list[dict[str, str]] = []
 
         self.add_middleware(
             CORSMiddleware,
@@ -69,11 +66,39 @@ class LongLink(FastAPI):
             allow_methods=["*"],
             allow_headers=["*"],
         )
-        self.include_router(api_router)
         self.include_router(sdk_router)
 
         static_dir = Path(__file__).resolve().parent / "static"
         if static_dir.exists():
-            self.mount(
-                "/", SPAStaticFiles(directory=static_dir, html=True), name="static"
-            )
+            self.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
+
+    def include_page(self, page: str | Path) -> None:
+        """Register XML page file and expose it through a generated `/pages/*` route."""
+
+        page_file = Page(page)
+        page_content = page_file.load_page_schema()
+        metadata = page_file.load_page_metadata()
+
+        page_path = page_file.path.stem
+
+        # Persist page metadata for discovery endpoint.
+        self.state.pages.append(
+            {
+                "path": f"/pages/{page_path}",
+                "name": metadata.get("name", page_path.replace("_", " ").title()),
+                "icon": metadata.get("icon", "FileText"),
+            }
+        )
+
+        async def _page_endpoint(content: str = page_content) -> Response:
+            """Return static XML content for registered page file."""
+
+            return Response(content=content, media_type="text/xml")
+
+        self.add_api_route(
+            f"/pages/{page_path}",
+            _page_endpoint,
+            methods=["GET"],
+            response_model=None,
+            name=f"page_{page_path}",
+        )

--- a/sdk/longlink/envs.py
+++ b/sdk/longlink/envs.py
@@ -6,23 +6,26 @@ class Settings(BaseSettings):
     """SDK environment model loaded from process variables or `.env`."""
 
     DEV: bool = False
-    KEY: str = 'longlink'
+    KEY: str = "longlink"
 
     # Database
     DBURL: str | None = None
 
     # Storage
-    storage_key: str = 'dev'
-    storage_secret: str = 'dev'
-    storage_endpoint: str = 'http://localhost:9000'
+    storage_key: str = "dev"
+    storage_secret: str = "dev"
+    storage_endpoint: str = "http://localhost:9000"
 
-    model_config = SettingsConfigDict(
-        env_file='.env',
-        env_file_encoding='utf-8'
-    )
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     @model_validator(mode="after")
     def apply_dev_defaults(self):
+        """Set local development defaults when DEV mode is enabled."""
+
         if self.DEV:
-            self.DBURL = 'sqlite:///./dev.db'
+            self.DBURL = "sqlite:///./dev.db"
         return self
+
+
+Enviroments = Settings
+Environments = Settings

--- a/sdk/longlink/router/__init__.py
+++ b/sdk/longlink/router/__init__.py
@@ -2,7 +2,6 @@ import json
 import inspect
 from typing import Any, Callable
 from fastapi import APIRouter
-from pathlib import Path
 from pydantic import BaseModel
 from functools import wraps
 from fastapi.responses import Response, JSONResponse, PlainTextResponse
@@ -11,22 +10,20 @@ Handler = Callable[..., Any]
 
 
 def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
+    """Wrap route handler to normalize SDK response serialization behavior."""
+
     @wraps(handler)
     async def endpoint(*args, **kwargs):
+        """Execute handler and convert result to FastAPI response."""
+
         result = handler(*args, **kwargs)
         body = await result if inspect.isawaitable(result) else result
 
         if is_page:
             if isinstance(body, str):
-                return Response(
-                    content=body,
-                    media_type="text/xml",
-                )
+                return Response(content=body, media_type="text/xml")
             if isinstance(body, (dict, list)):
-                return Response(
-                    content=json.dumps(body),
-                    media_type="application/json",
-                )
+                return Response(content=json.dumps(body), media_type="application/json")
             return PlainTextResponse(
                 "Invalid response type. Page routes must return an XML string, dict, or list.",
                 status_code=500,
@@ -39,6 +36,8 @@ def _build_endpoint(handler: Handler, *, is_page: bool = False) -> Handler:
 
 
 def _format_response(handler: Handler, body: Any) -> Response | JSONResponse | PlainTextResponse:
+    """Serialize handler return value using annotation-aware defaults."""
+
     return_type = inspect.signature(handler).return_annotation
 
     if (
@@ -73,7 +72,9 @@ class Router(APIRouter):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create router and initialize in-memory page metadata store."""
+
         super().__init__(*args, **kwargs)
+        self._pages: list[dict[str, str]] = []
 
     def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
         """Register route after wrapping endpoint with LongLink response handling."""
@@ -84,6 +85,8 @@ class Router(APIRouter):
         """Register page endpoint and track metadata for page listing."""
 
         def decorator(func: Handler) -> Handler:
+            """Attach page route and register page metadata for router instance."""
+
             self._pages.append({"path": path, "name": name, "icon": icon})
             endpoint_path = f"/pages/{path.lstrip('/')}"
             super().add_api_route(
@@ -95,3 +98,8 @@ class Router(APIRouter):
             return func
 
         return decorator
+
+    def pages(self) -> list[dict[str, str]]:
+        """Return page metadata registered through `@router.page`."""
+
+        return self._pages

--- a/sdk/longlink/routes/metadata.py
+++ b/sdk/longlink/routes/metadata.py
@@ -1,11 +1,10 @@
-from fastapi import APIRouter
-from longlink.router import get
+from fastapi import Request, APIRouter
 
 metadata_router = APIRouter()
 
 
 @metadata_router.get("/openapi.json")
-async def get_openapi():
+async def get_openapi(request: Request):
     """Return current application OpenAPI schema."""
 
-    return get.openapi()
+    return request.app.openapi()

--- a/sdk/longlink/routes/pages.py
+++ b/sdk/longlink/routes/pages.py
@@ -1,11 +1,10 @@
-from fastapi import APIRouter
-from longlink.router import api_router
+from fastapi import Request, APIRouter
 
 pages_router = APIRouter()
 
 
-@pages_router.get('/pages')
-async def get_available_pages() -> list[dict[str, str]]:
+@pages_router.get("/pages")
+async def get_available_pages(request: Request) -> list[dict[str, str]]:
     """Return metadata for all registered pages."""
 
-    return api_router.pages()
+    return request.app.state.pages

--- a/sdk/sample/main.py
+++ b/sdk/sample/main.py
@@ -1,8 +1,7 @@
 from app.envs import env
+from longlink import LongLink
 from app.pages import pages
 from app.routes import routers
-from longlink import LongLink
-
 
 app = LongLink(env=env)
 


### PR DESCRIPTION
### Motivation
- Sample app now registers routers and pages via `LongLink(env=env)` and requires SDK support to include XML pages and surface app state for metadata and OpenAPI.
- Align SDK public surface with current usage (`LongLink`, `Router`, env aliases) so sample imports work without breaking fast iteration.

### Description
- Export surface adjusted in `longlink.__init__` to provide `LongLink`, `Router`, `Settings`, and aliases `Enviroments`/`Environments` for compatibility.
- `LongLink` app updated in `longlink.app` to accept optional `env`, set `self.state.env`, maintain `self.state.pages`, mount SDK routes, and provide `include_page()` to register XML page files as `/pages/<file_stem>` endpoints using `longlink.utils.page.Page`.
- Router enhancements: `Router` now initializes internal `_pages` list and exposes `pages()` to return registered page metadata while keeping response-wrapping behavior.
- Internal routes fixed to use request-bound app state: `/pages` now returns `request.app.state.pages` and `/openapi.json` returns `request.app.openapi()`.
- Minor cleanup: env defaults and aliases added in `longlink.envs` and import ordering in sample `main.py` adjusted so `LongLink(env=env)` works as intended.

### Testing
- Ran `make format` from repo root; succeeded.
- Compiled code via `python -m compileall sdk/longlink sdk/sample/main.py`; succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a26135908323b85a566d684f5a6f)