### PR TITLE
feat(sdk): add Table base model with timestamps and update sample models

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -5,6 +5,7 @@ from longlink.xml import load_page_schema_from_xml
 from longlink.envs import ENV, Envs, ENVDev, EnvsDev, envs, get_envs
 from longlink.router import (LongLinkRouter, get, put, page, post, pages,
                              patch, route, delete, xml_page, api_router)
+from longlink.database import Table
 from longlink.utils.xml import load_page_schema_from_xml
 from longlink.predefined import issues_page, sample_page
 from longlink.organization import org

--- a/sdk/longlink/database/__init__.py
+++ b/sdk/longlink/database/__init__.py
@@ -1,4 +1,4 @@
-from .base import Base, get_session
+from .base import Base, Table, get_session
 
 
 class Database:
@@ -7,4 +7,4 @@ class Database:
     pass
 
 
-__all__ = ["Base", "Database", "get_session"]
+__all__ = ["Base", "Database", "Table", "get_session"]

--- a/sdk/longlink/database/base.py
+++ b/sdk/longlink/database/base.py
@@ -1,12 +1,21 @@
-from sqlmodel import Session, SQLModel, create_engine
+from typing import Optional
+from datetime import datetime
+from sqlmodel import Field, Session, SQLModel, create_engine
 
 DATABASE_URL = "sqlite:///./test.db"
 
 engine = create_engine(DATABASE_URL, echo=False)
 
 
+class Table(SQLModel):
+    """Base SQLModel for DB tables with common timestamp fields."""
+
+    created_at: Optional[datetime] = Field(default=None, nullable=True)
+    updated_at: Optional[datetime] = Field(default=None, nullable=True)
+
+
 # Keep backward-compatible alias for code still importing `Base`.
-Base = SQLModel
+Base = Table
 
 
 def get_session() -> Session:

--- a/sdk/sample/app/models/contract.py
+++ b/sdk/sample/app/models/contract.py
@@ -1,7 +1,6 @@
 from enum import Enum
+from longlink import Table
 from pydantic import EmailStr
-from sqlmodel import SQLModel
-
 
 
 class StatusEnum(str, Enum):
@@ -10,7 +9,7 @@ class StatusEnum(str, Enum):
     ARCHIVED = "Archived"
 
 
-class Contract(SQLModel):
+class Contract(Table):
     name: str
     company: str
     email: EmailStr

--- a/sdk/sample/app/models/projects.py
+++ b/sdk/sample/app/models/projects.py
@@ -1,8 +1,7 @@
 from enum import Enum
 from typing import Optional
-from datetime import datetime
+from longlink import Table
 from sqlmodel import Field, SQLModel
-
 
 
 class ProjectStatus(str, Enum):
@@ -17,12 +16,10 @@ class LinkedContact(SQLModel):
     email: Optional[str] = None
 
 
-class Project(SQLModel):
+class Project(Table):
     id: str = Field(description="Unique project identifier")
     name: str = Field(description="Project name")
     linked_contact: LinkedContact = Field(description="Associated contact")
     status: ProjectStatus = Field(default=ProjectStatus.PLANNED, description="Project status")
     budget: float = Field(ge=0, description="Project budget in currency units")
     owner: str = Field(description="Project owner name or ID")
-    created_at: Optional[datetime] = None
-    updated_at: Optional[datetime] = None


### PR DESCRIPTION
### Motivation

- Ensure DB models inherit common timestamp fields (`created_at`, `updated_at`) from single SDK-provided base so examples follow recommended pattern and avoid duplication.

### Description

- Added `Table` base class in `sdk/longlink/database/base.py` with `created_at` and `updated_at` fields and aliased `Base = Table` for compatibility. 
- Exported `Table` from `longlink.database` (`sdk/longlink/database/__init__.py`) and re-exported at top-level import surface (`sdk/longlink/__init__.py`).
- Updated sample app models to inherit from `Table`: `Contract` and `Project` now extend `Table`, and duplicated timestamp fields were removed from `Project`.

### Testing

- Ran `make format` from repository root (runs `isort`, JS `prettier` formatting, etc.), and it completed successfully. 
- No unit tests were added or modified per SDK guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a35c913083239e0281bd37e9bb4b)