### PR TITLE
api: standardize audit columns across DB models

### DIFF
--- a/api/src/db/models/__base__.py
+++ b/api/src/db/models/__base__.py
@@ -1,3 +1,21 @@
+from datetime import datetime
+from sqlalchemy import String, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
+
+
+class AuditMixin:
+    """Provide shared audit metadata columns for persisted entities."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -1,11 +1,10 @@
 import uuid
-from datetime import datetime
-from sqlalchemy import String, DateTime, func
+from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base
+from src.db.models.__base__ import Base, AuditMixin
 
 
-class App(Base):
+class App(Base, AuditMixin):
     '''Represent an application installed in the platform.'''
     __tablename__ = 'apps'
 
@@ -14,7 +13,3 @@ class App(Base):
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
     type: Mapped[str] = mapped_column(String(16), nullable=False, default='tool')
-
-    # Timestamp informations
-    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
-    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/models/envs.py
+++ b/api/src/db/models/envs.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-from sqlalchemy import Text, String, Integer, DateTime, ForeignKey, func
+from sqlalchemy import Text, String, Integer, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base
+from src.db.models.__base__ import Base, AuditMixin
 
 
-class Env(Base):
+class Env(Base, AuditMixin):
     '''Represent an application secret environment variable.
     Envs are stored as secrets and injected in the app container as environment variables.
     '''
@@ -16,7 +15,3 @@ class Env(Base):
     key: Mapped[str] = mapped_column(String(128), nullable=False)
     value: Mapped[str] = mapped_column(Text, nullable=False)
     appid: Mapped[str] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=False)
-
-    # Timestamp informations
-    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
-    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/models/permissions.py
+++ b/api/src/db/models/permissions.py
@@ -1,11 +1,10 @@
 import uuid
-from datetime import datetime
-from sqlalchemy import String, Integer, DateTime, UniqueConstraint, func
+from sqlalchemy import String, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base
+from src.db.models.__base__ import Base, AuditMixin
 
 
-class Permission(Base):
+class Permission(Base, AuditMixin):
     '''Represent the access level granted to one user for one app.'''
     __tablename__ = 'permissions'
     __table_args__ = (
@@ -16,7 +15,3 @@ class Permission(Base):
     user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     app_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
     level: Mapped[str] = mapped_column(String(16), nullable=False)
-
-    # Timestamp informations
-    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
-    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/models/settings.py
+++ b/api/src/db/models/settings.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-from sqlalchemy import Text, String, Integer, DateTime, ForeignKey, func
+from sqlalchemy import Text, String, Integer, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base
+from src.db.models.__base__ import Base, AuditMixin
 
 
-class Setting(Base):
+class Setting(Base, AuditMixin):
     '''Represent a platform setting at org or app scope.'''
     __tablename__ = 'settings'
 
@@ -14,7 +13,3 @@ class Setting(Base):
     key: Mapped[str] = mapped_column(String(128), nullable=False)
     value: Mapped[str] = mapped_column(Text, nullable=False)
     appid: Mapped[str | None] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=True)
-
-    # Timestamp informations
-    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
-    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())

--- a/api/src/db/models/users.py
+++ b/api/src/db/models/users.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-from sqlalchemy import String, Integer, DateTime, func
+from sqlalchemy import String, Integer
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base
+from src.db.models.__base__ import Base, AuditMixin
 
 
-class User(Base):
+class User(Base, AuditMixin):
     '''Represent a user account authenticated via OIDC.'''
 
     __tablename__ = 'users'
@@ -14,7 +13,3 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     avatar: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     oidc_subject: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
-
-    # Timestamp informations
-    date_update: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
-    date_creation: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())


### PR DESCRIPTION
### Motivation
- Normalize audit metadata across API persistence layer to use `created_at`, `updated_at`, `deleted_at`, `created_by`, `updated_by`, `deleted_by` instead of ad-hoc `date_creation`/`date_update` fields.
- Ensure single source of truth for audit columns to avoid schema drift and simplify future migrations and access patterns.

### Description
- Added shared `AuditMixin` to `api/src/db/models/__base__.py` exposing `created_at`, `updated_at`, `deleted_at`, `created_by`, `updated_by`, `deleted_by` with appropriate types and defaults.
- Updated core DB models `App`, `User`, `Setting`, `Env`, and `Permission` to inherit from `AuditMixin` and removed legacy `date_creation`/`date_update` fields from those models.
- Kept `created_by`/`updated_by`/`deleted_by` as nullable string identifiers to support multiple identity sources.
- Ran project formatting tools to apply import/order fixes and code style adjustments (`isort`/prettier via `make format`).

### Testing
- Ran `make format` at repo root, which executed `isort` and frontend formatting, and completed successfully. 
- No new unit tests were added per repository guidance; only formatting/linters were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a3e07c388323b1f74798c86fef7f)