### PR TITLE
feat(sdk): add request-scoped storage dependency for FastAPI

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -3,6 +3,7 @@
 from longlink.app import LongLink
 from longlink.envs import Settings, Enviroments, Environments
 from longlink.router import Router
+from longlink.storage import Storage, get_storage
 from longlink.organization import org
 
 __all__ = [
@@ -11,5 +12,7 @@ __all__ = [
     "LongLink",
     "Router",
     "Settings",
+    "Storage",
+    "get_storage",
     "org",
 ]

--- a/sdk/longlink/storage.py
+++ b/sdk/longlink/storage.py
@@ -1,14 +1,43 @@
 import fsspec
+from fastapi import Request
+from longlink.envs import Settings
 
-if envs.DEV:
-    # local
-    fs = fsspec.filesystem("file")
 
-else:
-    # S3
-    fs = fsspec.filesystem(
-        "s3",
-        key=envs.storage_key,
-        secret=envs.storage_secret,
-        client_kwargs={"endpoint_url": envs.storage_endpoint},
-    )
+class Storage:
+    """Thin wrapper around fsspec filesystem read/write operations."""
+
+    def __init__(self, fs: fsspec.AbstractFileSystem):
+        """Store filesystem client used for IO operations."""
+
+        self.fs = fs
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        """Write raw bytes to path using configured filesystem backend."""
+
+        with self.fs.open(path, "wb") as file_handle:
+            file_handle.write(data)
+
+    def read_bytes(self, path: str) -> bytes:
+        """Read raw bytes from path using configured filesystem backend."""
+
+        with self.fs.open(path, "rb") as file_handle:
+            return file_handle.read()
+
+
+def get_storage(request: Request) -> Storage:
+    """Create request-scoped storage client from app environment settings."""
+
+    envs = request.app.state.env or Settings()
+
+    # Select local filesystem for development, S3-compatible filesystem otherwise.
+    if envs.DEV:
+        fs = fsspec.filesystem("file")
+    else:
+        fs = fsspec.filesystem(
+            "s3",
+            key=envs.storage_key,
+            secret=envs.storage_secret,
+            client_kwargs={"endpoint_url": envs.storage_endpoint},
+        )
+
+    return Storage(fs)


### PR DESCRIPTION
### Motivation
- Provide SDK-native storage helper backed by `fsspec` so endpoints can read/write bytes via a FastAPI dependency. 
- Choose local filesystem in `DEV` and S3-compatible backend in non-`DEV` using SDK env settings for consistent platform behavior.
- Export storage utilities from SDK package root for straightforward imports in application endpoints.

### Description
- Replace module-level `fsspec` setup with `Storage` class implementing `write_bytes` and `read_bytes` for filesystem IO (`sdk/longlink/storage.py`).
- Add `get_storage(request: Request)` FastAPI dependency that reads `request.app.state.env` (falls back to `Settings()`), uses `file` fs when `DEV` true, else configures S3-compatible fs via `storage_key`, `storage_secret`, `storage_endpoint` (`sdk/longlink/storage.py`).
- Export `Storage` and `get_storage` from SDK package root so callers can `from longlink import Storage, get_storage` (`sdk/longlink/__init__.py`).

### Testing
- Ran `make format` which executed `isort`/`prettier` and completed successfully.
- Byte-compiled modified modules with `/workspace/longlink/.venv/bin/python -m compileall sdk/longlink/storage.py sdk/longlink/__init__.py` and compilation succeeded.
- Package build/format hooks ran as part of `make format` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a5db56b08323ac2e1f9b85942f61)