### PR TITLE
Add sampleapp pyproject and FastAPI TestClient route tests

### DIFF
--- a/sdk/sample/pyproject.toml
+++ b/sdk/sample/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sampleapp"
+version = "0.1.0"
+description = "Sample LongLink application package."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi",
+  "longlink",
+  "uvicorn",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/sdk/sample/tests/routes/test_sample_routes.py
+++ b/sdk/sample/tests/routes/test_sample_routes.py
@@ -1,0 +1,30 @@
+"""Route tests for sample LongLink app."""
+
+import os
+from fastapi.testclient import TestClient
+
+# Provide required settings before importing sample app module.
+os.environ.setdefault("FEATURE_FLAG", "true")
+os.environ.setdefault("EXTERNAL_API", "https://example.test")
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_sample_get_endpoint_returns_expected_message() -> None:
+    """Ensure GET /sample returns static sample message."""
+    response = client.get("/sample")
+
+    assert response.status_code == 200
+    assert response.text == "Sample GET endpoint received data"
+
+
+def test_sample_user_endpoint_returns_typed_payload() -> None:
+    """Ensure POST /sample/user returns UserModel payload structure."""
+    response = client.post("/sample/user")
+
+    assert response.status_code == 200
+    # Validate key fields exposed by endpoint contract.
+    assert response.json()["username"] == "testuser"
+    assert response.json()["email"] == "testuser@example.com"


### PR DESCRIPTION
### Motivation
- Provide package manifest for sample app so it can be built and tested independently with standard tooling.
- Add example FastAPI route tests to demonstrate SDK app routing and show how to seed required env vars before app import for isolated test runs.

### Description
- Add `sdk/sample/pyproject.toml` with `hatchling` build-system, runtime deps `fastapi`, `longlink`, `uvicorn`, and `pytest` in `dev` extras plus `pytest` config (`testpaths`, `pythonpath`).
- Add `sdk/sample/tests/routes/test_sample_routes.py` which sets `FEATURE_FLAG` and `EXTERNAL_API` via `os.environ.setdefault` before importing `main.app`, uses `fastapi.testclient.TestClient`, and includes tests for `GET /sample` (checks `response.text`) and `POST /sample/user` (checks JSON fields).
- Run repository formatter as required by SDK workflow (`make format`).

### Testing
- Ran `make format` and it completed successfully.
- Ran `.venv/bin/python -m pytest sdk/sample/tests` and tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a66981948323ba2a47bf3cd93a3e)