### PR TITLE
Load sample XML pages automatically

### DIFF
--- a/sdk/sample/app/pages/__init__.py
+++ b/sdk/sample/app/pages/__init__.py
@@ -1,3 +1,13 @@
-pages = [
-    
-]
+from pathlib import Path
+
+
+def load_pages() -> list[Path]:
+    """Load all XML page definitions shipped with sample application."""
+
+    current_dir = Path(__file__).resolve().parent
+
+    # Collect page files deterministically so page registration order is stable.
+    return sorted(current_dir.glob("*.xml"))
+
+
+pages = load_pages()


### PR DESCRIPTION
### Motivation
- Enable sample app to auto-register shipped XML pages so adding/removing page files doesn't require editing `pages` list in `main.py`.

### Description
- Replace static `pages` list with `load_pages()` helper in `sdk/sample/app/pages/__init__.py` that resolves module directory and returns `sorted(current_dir.glob('*.xml'))`, then export `pages = load_pages()` so existing `app.include_page` loop continues to work.

### Testing
- Ran `make format` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b3874b1c83238ab8b2d3ed106ced)