### PR TITLE
Load .env.sample in DEV mode and enrich Env model; enable tests to use sample env

### DIFF
--- a/sdk/sample/.env.sample
+++ b/sdk/sample/.env.sample
@@ -2,3 +2,5 @@ ENV_APP_KEY=1234
 ENV_DATABASE_URL=sqlite+aiosqlite:///./dev.db
 ENV_STORAGE_ENDPOINT=
 ENV_STORAGE_TOKEN=
+FEATURE_FLAG=true
+EXTERNAL_API=https://example.test

--- a/sdk/sample/app/envs.py
+++ b/sdk/sample/app/envs.py
@@ -1,11 +1,35 @@
+import os
+from pathlib import Path
 from longlink import Enviroments
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+
+def _resolve_env_file() -> Path:
+    """Select sample env source based on DEV flag."""
+
+    sample_root = Path(__file__).resolve().parents[1]
+    # Use development sample env only when DEV flag explicitly enabled.
+    if os.getenv("DEV", "").lower() in {"1", "true", "yes", "on"}:
+        return sample_root / ".env.sample"
+    return sample_root / ".env"
 
 
 class Env(Enviroments):
     """Project-specific environment model."""
 
+    KEY: str = Field(default="longlink", validation_alias="ENV_APP_KEY")
+    DBURL: str | None = Field(default=None, validation_alias="ENV_DATABASE_URL")
+    storage_endpoint: str = Field(
+        default="http://localhost:9000",
+        validation_alias="ENV_STORAGE_ENDPOINT",
+    )
+    storage_secret: str = Field(default="dev", validation_alias="ENV_STORAGE_TOKEN")
     FEATURE_FLAG: bool
     EXTERNAL_API: str
+    model_config = SettingsConfigDict(
+        env_file_encoding="utf-8",
+    )
 
 
-env = Env()
+env = Env(_env_file=_resolve_env_file())

--- a/sdk/sample/tests/conftest.py
+++ b/sdk/sample/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+
+def pytest_configure() -> None:
+    """Enable DEV mode for sample app tests."""
+
+    # Ensure sample app loads `.env.sample` during test imports.
+    os.environ["DEV"] = "true"

--- a/sdk/sample/tests/routes/test_sample_routes.py
+++ b/sdk/sample/tests/routes/test_sample_routes.py
@@ -1,13 +1,7 @@
 """Route tests for sample LongLink app."""
 
-import os
-from fastapi.testclient import TestClient
-
-# Provide required settings before importing sample app module.
-os.environ.setdefault("FEATURE_FLAG", "true")
-os.environ.setdefault("EXTERNAL_API", "https://example.test")
-
 from main import app
+from fastapi.testclient import TestClient
 
 client = TestClient(app)
 

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+
+def pytest_configure() -> None:
+    """Enable DEV mode defaults for SDK test runs."""
+
+    # Force DEV mode for tests so config paths follow development behavior.
+    os.environ["DEV"] = "true"


### PR DESCRIPTION
### Motivation
- Ensure the sample app and SDK tests load development environment variables from `.env.sample` when running in DEV mode. 
- Provide typed settings with sensible defaults and clear env-variable aliases to make configuration robust and explicit. 
- Simplify test setup so tests automatically use the sample env file without manual per-test environment manipulation.

### Description
- Added `_resolve_env_file()` to select `.env.sample` when the `DEV` environment variable is truthy and pass the result to `Env` via `_env_file` during construction. 
- Extended the `Env` model with new typed fields (`KEY`, `DBURL`, `storage_endpoint`, `storage_secret`) using `Field(..., validation_alias=...)` and set `model_config` with `env_file_encoding="utf-8"`. 
- Updated `sdk/sample/.env.sample` to include `FEATURE_FLAG` and `EXTERNAL_API` and fixed newline at end of file. 
- Added `pytest` configuration files `sdk/sample/tests/conftest.py` and `sdk/tests/conftest.py` that set `DEV=true` for test runs, and simplified `sdk/sample/tests/routes/test_sample_routes.py` by removing manual env setup.

### Testing
- Ran `pytest` for the sample app tests and SDK tests with `DEV` enabled via the new `conftest.py` files. 
- All sample route tests in `sdk/sample/tests/routes` passed. 
- No automated test failures were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b3dcd3108323beee23a8077985c0)