### PR TITLE
feat(sdk): add Context dependency object and sample usage

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -3,16 +3,23 @@
 from longlink.app import LongLink
 from longlink.envs import Settings, Enviroments, Environments
 from longlink.router import Router
+from longlink.context import (Context, ContextDep, SessionDep, StorageDep,
+                              get_context)
 from longlink.storage import Storage, get_storage
 from longlink.organization import org
 
 __all__ = [
+    "Context",
+    "ContextDep",
     "Environments",
     "Enviroments",
     "LongLink",
     "Router",
+    "SessionDep",
     "Settings",
     "Storage",
+    "StorageDep",
+    "get_context",
     "get_storage",
     "org",
 ]

--- a/sdk/longlink/context.py
+++ b/sdk/longlink/context.py
@@ -1,0 +1,36 @@
+from typing import Annotated
+from fastapi import Depends, Request
+from sqlmodel import Session
+from longlink.storage import Storage, get_storage
+from longlink.database import get_session
+
+
+class Context:
+    """Request context exposing SDK dependencies with stable aliases."""
+
+    def __init__(self, storage: Storage, session: Session, request: Request):
+        """Store request-scoped resources and compatibility aliases."""
+        self.storage = storage
+        self.session = session
+        self.envs = request.app.state.env
+
+        # Keep concise aliases used by apps migrating from previous SDK names.
+        self.fs = self.storage
+        self.database = self.session
+        self.db = self.database
+
+
+def get_context(
+    request: Request,
+    storage: Storage = Depends(get_storage),
+    session: Session = Depends(get_session),
+) -> Context:
+    """Build request context from storage and DB session dependencies."""
+
+    return Context(storage=storage, session=session, request=request)
+
+
+SessionDep = Annotated[Session, Depends(get_session)]
+StorageDep = Annotated["Storage", Depends(get_storage)]
+ContextDep = Annotated["Context", Depends(get_context)]
+

--- a/sdk/sample/app/routes/sample.py
+++ b/sdk/sample/app/routes/sample.py
@@ -1,14 +1,21 @@
-from longlink import Router
+from fastapi import Depends
+from longlink import Router, Context, get_context
 from app.types import UserModel
 
 router = Router()
 
 
 @router.get("/sample")
-async def sample_get_endpoint():
+async def sample_get_endpoint(ctx: Context = Depends(get_context)):
     """Handle sample GET request."""
 
-    return "Sample GET endpoint received data"
+    return {
+        "message": "Sample GET endpoint received data",
+        "has_storage": ctx.storage is not None,
+        "has_fs_alias": ctx.fs is ctx.storage,
+        "has_db_alias": ctx.db is ctx.database,
+        "env_loaded": ctx.envs is not None,
+    }
 
 
 @router.post("/sample")


### PR DESCRIPTION
### Motivation
- Provide canonical FastAPI request-scoped `Context` object that bundles storage, DB session, and app envs for SDK apps.
- Offer stable runtime aliases and type-friendly dependency helpers to ease migration from older SDK shapes and simplify route signatures.

### Description
- Added `sdk/longlink/context.py` implementing `Context(storage, session, request)` with aliases `ctx.fs`, `ctx.database`, `ctx.db`, and `ctx.envs`, plus `get_context`, `SessionDep`, `StorageDep`, and `ContextDep`.
- Exported `Context`, `ContextDep`, `SessionDep`, `StorageDep`, and `get_context` from `longlink.__init__` so apps can `from longlink import Context, get_context`.
- Updated sample app route `sdk/sample/app/routes/sample.py` to consume `Context` via `Depends(get_context)` and return a payload demonstrating `ctx` fields and aliases.

### Testing
- Ran `make format` (includes `isort` and prettier) and it completed successfully.
- Ran `python -m compileall sdk/longlink/context.py sdk/sample/app/routes/sample.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b645d6388323adce6f2e09210c2b)