### PR TITLE
Load SDK metadata from pyproject project table

### DIFF
--- a/sdk/longlink/cli/build.py
+++ b/sdk/longlink/cli/build.py
@@ -2,6 +2,7 @@ import json
 import click
 from pathlib import Path
 from datetime import UTC, datetime
+from longlink.utils.metadata import load_metadata
 
 DOCKERFILE_TEMPLATE = """FROM python:3.12-slim
 
@@ -18,12 +19,17 @@ CMD ["longlink", "dev"]
 
 
 def create_version() -> str:
+    """Generate timestamp-based version string for build artifacts."""
+
     return datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
 
 
 def build_app(base_path: Path | None = None) -> tuple[Path, Path, str]:
+    """Create Dockerfile and deployment manifest for current app."""
+
     root = (base_path or Path.cwd()).resolve()
     version = create_version()
+    metadata = load_metadata(root / "pyproject.toml")
 
     dockerfile_path = root / "Dockerfile"
     dockerfile_path.write_text(DOCKERFILE_TEMPLATE)
@@ -32,6 +38,7 @@ def build_app(base_path: Path | None = None) -> tuple[Path, Path, str]:
         "version": version,
         "generated_at": datetime.now(UTC).isoformat(),
         "dockerfile": dockerfile_path.name,
+        "metadata": metadata.model_dump(),
     }
 
     manifest_path = root / "manifest.json"

--- a/sdk/longlink/utils/metadata.py
+++ b/sdk/longlink/utils/metadata.py
@@ -1,36 +1,56 @@
-import json
-from typing import Literal
+import tomllib
+from typing import Any, Literal
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import Field, BaseModel
 
 
 class Metadata(BaseModel):
-    """LongLink app metadata model loaded from metadata.json."""
+    """LongLink app metadata model loaded from `pyproject.toml`."""
 
-    name: str = 'Sample LongLink app'
-    description: str = ''
-    type: Literal['tool', 'space', 'process'] = 'tool'
+    name: str = "Sample LongLink app"
+    version: str = "0.1.0"
+    dependencies: list[str] = Field(default_factory=list)
+    description: str = ""
+    type: Literal["tool", "space", "process"] = "tool"
 
 
-def load_metadata() -> Metadata:
-    """Load app metadata from cwd metadata.json with safe defaults."""
+def _read_project_section(pyproject_path: Path) -> dict[str, Any]:
+    """Read and return `project` section from a pyproject file."""
 
-    metadata_file = Path.cwd() / 'metadata.json'
+    with pyproject_path.open("rb") as pyproject_file:
+        payload = tomllib.load(pyproject_file)
 
-    if not metadata_file.exists():
-        print('Warning: metadata.json is missing. Using default metadata values.')
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        return {}
+    return project
+
+
+def load_metadata(pyproject_path: Path | None = None) -> Metadata:
+    """Load app metadata from cwd `pyproject.toml` with safe defaults."""
+
+    source_file = pyproject_path or (Path.cwd() / "pyproject.toml")
+    if not source_file.exists():
+        print("Warning: pyproject.toml is missing. Using default metadata values.")
         return Metadata()
 
     try:
-        # Parse metadata file if present; fallback to defaults on parse/read issues.
-        payload = json.loads(metadata_file.read_text())
-    except (json.JSONDecodeError, OSError):
+        # Parse pyproject project table and map known keys into SDK metadata model.
+        project = _read_project_section(source_file)
+    except (tomllib.TOMLDecodeError, OSError):
         return Metadata()
 
-    if not isinstance(payload, dict):
+    if not project:
         return Metadata()
 
-    return Metadata.model_validate(payload)
+    return Metadata.model_validate(
+        {
+            "name": project.get("name"),
+            "version": project.get("version"),
+            "dependencies": project.get("dependencies"),
+            "description": project.get("description"),
+        }
+    )
 
 
 metadata = load_metadata()


### PR DESCRIPTION
### Motivation

- Replace ad-hoc `metadata.json` lookup with canonical project metadata source so SDK reflects package `pyproject.toml` `project` table.
- Surface app `version` and `dependencies` in SDK metadata so tooling (build/manifest) can use same project values.

### Description

- Parse `pyproject.toml` using `tomllib` and read `project` table via helper `_read_project_section` in `sdk/longlink/utils/metadata.py`.
- Extend `Metadata` Pydantic model with `version` and `dependencies` fields and map `project` keys into the model with safe defaults and fallbacks.
- Make `load_metadata` accept optional `pyproject_path` and return validated `Metadata` instance; print warning and return defaults when file/section missing or invalid.
- Update `build_app` in `sdk/longlink/cli/build.py` to call `load_metadata` and embed `metadata.model_dump()` into generated `manifest.json`, and add short docstrings for changed functions.

### Testing

- Ran `make format` from repo root, formatting step completed successfully.
- Ran `pytest sdk/tests/cli/test_build.py`, test collection failed with `ModuleNotFoundError: No module named 'fastapi'` (environment missing runtime dependency), so automated unit test could not complete.
- Manually validated metadata parsing by running `load_metadata(Path('sdk/pyproject.toml'))` under project `.venv` Python and confirmed `name`, `version`, and dependency count matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b9a10a948323ba5cafa7ce97372e)