### PR TITLE
Fix SDK metadata loading and add focused metadata tests

### DIFF
--- a/sdk/longlink/utils/metadata.py
+++ b/sdk/longlink/utils/metadata.py
@@ -1,3 +1,8 @@
+"""Utilities for loading LongLink app metadata from pyproject files."""
+
+from __future__ import annotations
+
+import os
 import tomllib
 from typing import Any, Literal
 from pathlib import Path
@@ -5,56 +10,73 @@ from pydantic import BaseModel, model_validator
 
 
 class Metadata(BaseModel):
-    """Project metadata loaded from pyproject.toml with defaults and overrides."""
+    """Project metadata loaded from `pyproject.toml` with sane defaults."""
 
-    title: str = "A LongLink App"
+    name: str = "longlink-app"
+    title: str | None = None
     summary: str | None = None
     description: str | None = None
     version: str = "0.0.0"
     terms_of_service: str | None = None
-    contact: dict | None = None
-    license_info: dict | None = None
-    apptype: Literal["tool", "space", "process"] = ""
+    contact: dict[str, Any] | None = None
+    license_info: dict[str, Any] | None = None
+    apptype: Literal["tool", "space", "process"] = "tool"
 
     @model_validator(mode="before")
     @classmethod
-    def load_and_merge(cls, data: Any):
+    def load_and_merge(cls, data: Any) -> dict[str, Any]:
+        """Merge defaults, pyproject metadata, and explicit overrides into one payload."""
+
         data = data or {}
 
-        # 1. Start from defaults (defined on the model)
-        base = cls.model_fields
+        # Start from model defaults so missing fields stay predictable.
+        defaults = {field: cls.model_fields[field].default for field in cls.model_fields}
+        result = dict(defaults)
 
-        result = {
-            field: base[field].default
-            for field in base
-        }
+        pyproject_path = Path("pyproject.toml")
+        if pyproject_path.exists():
+            with pyproject_path.open("rb") as file_handle:
+                toml_data = tomllib.load(file_handle)
 
-        # 2. Load from pyproject.toml if present
-        path = Path("pyproject.toml")
-        if path.exists():
-            with path.open("rb") as f:
-                toml_data = tomllib.load(f)
-
+            # Read LongLink tool section first, then fall back to standard PEP 621 fields.
             tool_data = toml_data.get("tool", {}).get("longlink", {})
+            project_data = toml_data.get("project", {})
 
-            # Optional fallback to PEP 621 project metadata
-            project = toml_data.get("project", {})
+            result.update(
+                {
+                    "name": tool_data.get("name") or project_data.get("name") or result["name"],
+                    "title": tool_data.get("title") or result["title"],
+                    "summary": tool_data.get("summary") or result["summary"],
+                    "description": tool_data.get("description")
+                    or project_data.get("description")
+                    or result["description"],
+                    "version": tool_data.get("version") or project_data.get("version") or result["version"],
+                    "terms_of_service": tool_data.get("terms_of_service") or result["terms_of_service"],
+                    "contact": tool_data.get("contact") or result["contact"],
+                    "license_info": tool_data.get("license_info") or result["license_info"],
+                    "apptype": tool_data.get("apptype") or result["apptype"],
+                }
+            )
 
-            result.update({
-                "title": tool_data.get("title") or project.get("name"),
-                "summary": tool_data.get("summary"),
-                "description": tool_data.get("description") or project.get("description"),
-                "version": tool_data.get("version") or project.get("version"),
-                "terms_of_service": tool_data.get("terms_of_service"),
-                "contact": tool_data.get("contact"),
-                "license_info": tool_data.get("license_info"),
-                "apptype": tool_data.get("apptype", result["apptype"]),
-            })
-
-        # 3. Explicit input overrides everything
+        # Let explicit constructor values win over file-derived values.
         result.update(data)
-
         return result
 
 
-metadata = Metadata()
+def load_metadata(pyproject_path: Path | None = None, **overrides: Any) -> Metadata:
+    """Load metadata from pyproject location with optional explicit override values."""
+
+    if pyproject_path is None:
+        return Metadata(**overrides)
+
+    cwd = Path.cwd()
+    target_path = pyproject_path.resolve()
+
+    # Pick root dir that contains pyproject file and load metadata from that context.
+    project_root = target_path.parent if target_path.is_file() else target_path
+
+    os.chdir(project_root)
+    try:
+        return Metadata(**overrides)
+    finally:
+        os.chdir(cwd)

--- a/sdk/tests/utils/test_metadata.py
+++ b/sdk/tests/utils/test_metadata.py
@@ -1,0 +1,92 @@
+"""Tests for SDK metadata loading helpers."""
+
+from __future__ import annotations
+
+import sys
+import importlib.util
+from pathlib import Path
+
+
+def load_metadata_module():
+    """Load metadata module directly from source file without importing package root."""
+
+    module_path = Path(__file__).resolve().parents[2] / "longlink" / "utils" / "metadata.py"
+
+    # Load module by file path because package root currently imports unrelated subsystems.
+    spec = importlib.util.spec_from_file_location("sdk_metadata_module", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_metadata_uses_project_defaults(tmp_path):
+    """Ensure loader reads project metadata values from pyproject.toml."""
+
+    module = load_metadata_module()
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "demo-app"
+version = "1.2.3"
+description = "Demo description"
+""".strip()
+    )
+
+    metadata = module.load_metadata(pyproject)
+
+    assert metadata.name == "demo-app"
+    assert metadata.version == "1.2.3"
+    assert metadata.description == "Demo description"
+    assert metadata.apptype == "tool"
+
+
+def test_load_metadata_prefers_tool_longlink_section(tmp_path):
+    """Ensure LongLink tool metadata overrides project-level fallback values."""
+
+    module = load_metadata_module()
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "fallback-name"
+version = "0.0.1"
+
+[tool.longlink]
+name = "tool-name"
+version = "9.9.9"
+apptype = "process"
+""".strip()
+    )
+
+    metadata = module.load_metadata(pyproject)
+
+    assert metadata.name == "tool-name"
+    assert metadata.version == "9.9.9"
+    assert metadata.apptype == "process"
+
+
+def test_load_metadata_accepts_explicit_overrides(tmp_path):
+    """Ensure explicit loader kwargs take highest precedence over file values."""
+
+    module = load_metadata_module()
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "base-name"
+version = "0.0.1"
+""".strip()
+    )
+
+    metadata = module.load_metadata(pyproject, name="override-name", apptype="space")
+
+    assert metadata.name == "override-name"
+    assert metadata.apptype == "space"


### PR DESCRIPTION
### Motivation
- Ensure SDK produces stable manifest metadata by exposing `name` and sane `apptype` defaults and by making metadata loading robust for build tooling.
- Provide small, isolated tests that validate metadata precedence without importing full package tree to avoid unrelated init errors.

### Description
- Refactor `sdk/longlink/utils/metadata.py` to add `name` field, make `title` optional, set `apptype` default to `"tool"`, and normalize contact/license types to `dict[str, Any]`.
- Implement `load_metadata(pyproject_path: Path | None, **overrides)` helper that temporarily chdirs into project root to load `pyproject.toml` then restores original working directory.
- Update metadata merge logic to follow clear precedence: model defaults → `pyproject.toml` (`[tool.longlink]` then `[project]`) → explicit overrides.
- Add new tests in `sdk/tests/utils/test_metadata.py` that load the `metadata.py` module by file path and assert project defaults, `tool.longlink` precedence, and explicit override precedence.

### Testing
- Ran formatting via `make format` successfully.
- Ran focused unit tests with `pytest -q sdk/tests/utils/test_metadata.py` and observed `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bdbc8bbc8323bd7e080908164cb8)