### PR TITLE
Fix SDK startup: reorder State dataclass and remove stray migration imports

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter as Router
 from longlink.app import LongLink
 from longlink.state import Context, get_context
-from longlink.storage import Storage, create_storage
 from longlink.utils import *
+from longlink.storage import Storage, create_storage

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -1,10 +1,10 @@
 from fastapi import FastAPI
 from pathlib import Path
 from longlink.state import State, create_state
+from longlink.utils import Page, Settings
 from longlink.routes import routes
 from pydantic_settings import BaseSettings
 from fastapi.staticfiles import StaticFiles
-from longlink.utils import Page, Settings
 from starlette.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/sdk/longlink/database/migrations.py
+++ b/sdk/longlink/database/migrations.py
@@ -3,7 +3,6 @@ import importlib.util
 from alembic import command
 from pathlib import Path
 from alembic.config import Config
-from longlink.database.base import Base, engine
 
 CURRENT_FILE = Path(__file__).resolve()
 MODELS_PATH = Path.cwd() / "src" / "models"

--- a/sdk/longlink/state.py
+++ b/sdk/longlink/state.py
@@ -12,12 +12,10 @@ from longlink.utils.settings import Settings
 @dataclass
 class State:
     """Request-scoped SDK context with app-managed services and aliases."""
-    pages: list[Page] = field(default_factory=list)
-
     engine: Engine
     storage: Storage
     session: Session
-    
+    pages: list[Page] = field(default_factory=list)
 
 
 def create_state(env: Settings) -> State:


### PR DESCRIPTION
### Motivation

- Fix Python 3.14 dataclass init error that caused `longlink dev` to crash with `TypeError: non-default argument 'engine' follows default argument 'pages'`.
- Remove stale import from migrations module that produced `ImportError` during CLI startup and blocked sample app boot.
- Apply formatting/import-order adjustments produced by `make format` to keep package tidy.

### Description

- Reordered fields in `State` dataclass so non-default fields (`engine`, `storage`, `session`) come before defaulted `pages` to satisfy dataclass rules (`sdk/longlink/state.py`).
- Removed unused `Base, engine` import from migration helper to avoid import-time failures (`sdk/longlink/database/migrations.py`).
- Small import-order adjustments in `sdk/longlink/__init__.py` and `sdk/longlink/app.py` produced by formatter to keep imports consistent.

### Testing

- Ran `make build`; build completed successfully (web assets built for `api` and `sdk`).
- Ran `timeout 20 make sample`; dev server started successfully (Uvicorn startup logs present) and was stopped by the timeout used to avoid long-running process.
- Ran `make format`; formatting completed and SDK package reinstalled in editable mode without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36df8446483239e0e33adf19be818)