### PR TITLE
refactor(api): inline audit columns into db models (remove AuditMixin)

### DIFF
--- a/api/src/db/models/__base__.py
+++ b/api/src/db/models/__base__.py
@@ -1,21 +1,3 @@
-from datetime import datetime
-from sqlalchemy import String, DateTime, func
-from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
-
-
-class AuditMixin:
-    """Provide shared audit metadata columns for persisted entities."""
-
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
-    )
-    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -1,10 +1,11 @@
 import uuid
-from sqlalchemy import String
+from datetime import datetime
+from sqlalchemy import String, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base, AuditMixin
+from src.db.models.__base__ import Base
 
 
-class App(Base, AuditMixin):
+class App(Base):
     '''Represent an application installed in the platform.'''
     __tablename__ = 'apps'
 
@@ -13,3 +14,13 @@ class App(Base, AuditMixin):
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
     type: Mapped[str] = mapped_column(String(16), nullable=False, default='tool')
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/api/src/db/models/envs.py
+++ b/api/src/db/models/envs.py
@@ -1,9 +1,10 @@
-from sqlalchemy import Text, String, Integer, ForeignKey
+from datetime import datetime
+from sqlalchemy import Text, String, Integer, DateTime, ForeignKey, func
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base, AuditMixin
+from src.db.models.__base__ import Base
 
 
-class Env(Base, AuditMixin):
+class Env(Base):
     '''Represent an application secret environment variable.
     Envs are stored as secrets and injected in the app container as environment variables.
     '''
@@ -15,3 +16,13 @@ class Env(Base, AuditMixin):
     key: Mapped[str] = mapped_column(String(128), nullable=False)
     value: Mapped[str] = mapped_column(Text, nullable=False)
     appid: Mapped[str] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/api/src/db/models/permissions.py
+++ b/api/src/db/models/permissions.py
@@ -1,10 +1,11 @@
 import uuid
-from sqlalchemy import String, Integer, UniqueConstraint
+from datetime import datetime
+from sqlalchemy import String, Integer, DateTime, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base, AuditMixin
+from src.db.models.__base__ import Base
 
 
-class Permission(Base, AuditMixin):
+class Permission(Base):
     '''Represent the access level granted to one user for one app.'''
     __tablename__ = 'permissions'
     __table_args__ = (
@@ -15,3 +16,13 @@ class Permission(Base, AuditMixin):
     user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     app_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
     level: Mapped[str] = mapped_column(String(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/api/src/db/models/settings.py
+++ b/api/src/db/models/settings.py
@@ -1,9 +1,10 @@
-from sqlalchemy import Text, String, Integer, ForeignKey
+from datetime import datetime
+from sqlalchemy import Text, String, Integer, DateTime, ForeignKey, func
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base, AuditMixin
+from src.db.models.__base__ import Base
 
 
-class Setting(Base, AuditMixin):
+class Setting(Base):
     '''Represent a platform setting at org or app scope.'''
     __tablename__ = 'settings'
 
@@ -13,3 +14,13 @@ class Setting(Base, AuditMixin):
     key: Mapped[str] = mapped_column(String(128), nullable=False)
     value: Mapped[str] = mapped_column(Text, nullable=False)
     appid: Mapped[str | None] = mapped_column(ForeignKey('apps.id', ondelete='CASCADE'), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/api/src/db/models/users.py
+++ b/api/src/db/models/users.py
@@ -1,9 +1,10 @@
-from sqlalchemy import String, Integer
+from datetime import datetime
+from sqlalchemy import String, Integer, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column
-from src.db.models.__base__ import Base, AuditMixin
+from src.db.models.__base__ import Base
 
 
-class User(Base, AuditMixin):
+class User(Base):
     '''Represent a user account authenticated via OIDC.'''
 
     __tablename__ = 'users'
@@ -13,3 +14,13 @@ class User(Base, AuditMixin):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     avatar: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     oidc_subject: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)


### PR DESCRIPTION
### Motivation
- Simplify model structure by removing the shared `AuditMixin` and making audit columns explicit on each model for clearer schema definitions and easier per-model control.
- Keep behavior identical while avoiding inheritance coupling across models and preparing for potential model-specific audit adjustments.

### Description
- Removed the `AuditMixin` definition from `api/src/db/models/__base__.py`, leaving only `Base` exported.
- Inlined audit columns (`created_at`, `updated_at`, `deleted_at`, `created_by`, `updated_by`, `deleted_by`) into the following SQLAlchemy models: `App`, `Env`, `Permission`, `Setting`, and `User`.
- Updated imports and removed `AuditMixin` inheritance from each modified model, and added `datetime`, `DateTime`, and `func` where required.
- Ran repository formatting/cleanup to keep imports and style consistent (`isort`/prettier via `make format`).

### Testing
- Ran `make format` which executed `isort` and code formatting tasks and completed successfully.
- Verified no remaining references to `AuditMixin` under `api/src` with `rg "AuditMixin" api/src -n`, which returned no hits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3707180c483238a6d82696d5d1f95)