### PR TITLE
Fix SDK sample page loading by restoring /pages API behavior

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -27,23 +27,24 @@ class SPAStaticFiles(StaticFiles):
 
 class LongLink(FastAPI):
     """FastAPI app that owns SDK service creation and shared request state."""
-    state: State
+    context: State
 
     def __init__(self, env: BaseSettings | None = None, **kwargs):
         """Build app, initialize managed services, mount routes, and attach static files."""
         super().__init__(**kwargs)
 
         settings = env if isinstance(env, Settings) else Settings()
-        self.state = create_state(settings)
-
-        # Mount static files if the directory exists, serving the SPA frontend and assets
-        static_dir = Path(__file__).resolve().parent / "static"
-        if static_dir.exists():
-            self.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
+        self.context = create_state(settings)
+        self.state.context = self.context
 
         # Register API routes from the router module
         for router in routes:
             self.include_router(router)
+
+        # Mount static files after API routes so `/pages` and other SDK endpoints stay reachable.
+        static_dir = Path(__file__).resolve().parent / "static"
+        if static_dir.exists():
+            self.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
             
         # Enable CORS in development for local frontend access to API routes
         if settings.DEV:
@@ -61,7 +62,27 @@ class LongLink(FastAPI):
 
     def include_page(self, page: str | Path) -> None:
         """Register XML page file for discovery endpoint."""
-        self.state.pages.append(Page(page))
+        page_path = Path(page)
+        candidate_paths: list[Path] = []
+
+        # Resolve non-existent declarations against common app roots used by sample projects.
+        if not page_path.exists():
+            normalized_page_path = (
+                page_path.relative_to(page_path.anchor)
+                if page_path.is_absolute()
+                else page_path
+            )
+            candidate_paths = [
+                Path.cwd() / normalized_page_path,
+                Path.cwd() / "app" / normalized_page_path,
+            ]
+
+        for candidate in candidate_paths:
+            if candidate.exists():
+                page_path = candidate
+                break
+
+        self.context.pages.append(Page(page_path))
 
     def include_issues_page(self) -> None:
         """Register the default issues page if it exists."""

--- a/sdk/longlink/routes/pages.py
+++ b/sdk/longlink/routes/pages.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import Response, APIRouter
 from longlink.state import Context
 
 router = APIRouter()
@@ -7,13 +7,21 @@ router = APIRouter()
 @router.get("/pages")
 async def get_available_pages(ctx: Context) -> list[dict[str, str]]:
     """Return metadata for all registered pages."""
-    return ctx.pages
+    return [
+        {
+            "path": page.path.stem,
+            "name": page.name,
+            "icon": page.metadata.get("icon", "file-text"),
+        }
+        for page in ctx.pages
+    ]
 
 
 @router.get("/pages/{name}")
-async def get_page(name: str, ctx: Context) -> dict:
-    """Retrieve full page schema for a given page name."""
+async def get_page(name: str, ctx: Context) -> Response:
+    """Retrieve raw XML page content for a given page name."""
+    normalized_name = name.strip().lower()
     for page in ctx.pages:
-        if page.name == name:
-            return page.schema
-    return {}
+        if page.path.stem.strip().lower() == normalized_name:
+            return Response(content=page.content, media_type="application/xml")
+    return Response(content="", media_type="application/xml")

--- a/sdk/longlink/utils/page.py
+++ b/sdk/longlink/utils/page.py
@@ -14,6 +14,7 @@ class Page:
     def __init__(self, path: str | Path) -> None:
         """Store XML file path for later parsing operations."""
         self.path = Path(path)
+        self._content: str | None = None
         self._schema: dict[str, Any] | None = None
 
     @property
@@ -22,12 +23,18 @@ class Page:
         return self.metadata.get("name", self.path.stem)
 
     @property
+    def content(self) -> str:
+        """Return raw XML text for delivery to the web runtime."""
+        if self._content is None:
+            with self.path.open("r", encoding="utf-8") as handler:
+                self._content = handler.read()
+        return self._content
+
+    @property
     def schema(self) -> dict[str, Any]:
         """Return full page document as a dict for downstream processing."""
         if self._schema is None:
-            with self.path.open("rb", encoding="utf-8") as handler:
-                content = handler.read()
-                self._schema = xmltodict.parse(content)
+            self._schema = xmltodict.parse(self.content)
         return self._schema
     
     @property


### PR DESCRIPTION
### Motivation
- The SDK sample app showed an empty UI because the `/pages` endpoints were not returning the expected metadata and the SPA static mount shadowed API routes.
- Request dependency resolution failed because the runtime state was not exposed on `app.state.context`, causing `GET /pages` to raise errors.
- Page files were read incorrectly (binary mode with encoding) and sample-style page paths (e.g. `/pages/*.xml`) did not resolve from project sample roots.

### Description
- Expose runtime state on the FastAPI app by creating an internal `context` and setting `app.state.context = self.context` so request dependencies can access the SDK `State` object (updated `sdk/longlink/app.py`).
- Mount SPA static files after registering API routes to avoid `index.html` from shadowing endpoints such as `/pages` (updated `sdk/longlink/app.py`).
- Change the `/pages` discovery endpoint to return normalized metadata (`path`, `name`, `icon`) instead of returning `Page` objects, matching the web runtime expectations (updated `sdk/longlink/routes/pages.py`).
- Change the `/pages/{name}` endpoint to return raw XML (`application/xml`) and match by page path stem (case-insensitive) so the frontend can fetch page contents directly (updated `sdk/longlink/routes/pages.py`).
- Make `Page` read XML in text mode, cache the raw content, and parse the schema from this cached text to fix file-open errors and support direct XML serving (updated `sdk/longlink/utils/page.py`).
- Add resilient page path resolution in `include_page` to resolve sample declarations against common project roots like `cwd` and `cwd/app` so sample apps can register `/pages/*.xml` paths reliably (updated `sdk/longlink/app.py`).

### Testing
- Ran `make format` from the repository root and the formatter completed successfully.
- Ran `make build` from the repository root and the build completed successfully (frontend SDK/api builds and assets generated).
- Ran `make sample` and exercised the running sample service; verified `GET /pages` returns JSON metadata and `GET /pages/dashboard` returns the XML page content; these smoke checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3703e155883239c111dcd4f3fc40e)