### PR TITLE
docs: add SDK Testing guide and add pytest-asyncio to dev deps

### DIFF
--- a/docs/src/sdk/tests/index.md
+++ b/docs/src/sdk/tests/index.md
@@ -1,5 +1,43 @@
-# Test
+# Testing
 
-https://fastapi.tiangolo.com/tutorial/testing/
+You can test LongLink SDK applications with standard `pytest` patterns.
+Use async tests when your test targets async routes, async database operations, or async service calls.
 
-## References
+## Usage
+
+Install test dependencies:
+
+```bash
+pip install pytest pytest-asyncio
+```
+
+Run all tests:
+
+```bash
+pytest
+```
+
+Run one test file:
+
+```bash
+pytest tests/test_app.py
+```
+
+Mark async tests with `pytest.mark.asyncio`:
+
+```py
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_healthcheck(client):
+    response = await client.get('/health')
+
+    assert response.status_code == 200
+```
+
+## Resources
+
+- [FastAPI testing guide](https://fastapi.tiangolo.com/tutorial/testing/)
+- [pytest documentation](https://docs.pytest.org/)
+- [pytest-asyncio documentation](https://pytest-asyncio.readthedocs.io/)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -39,6 +39,7 @@ cli = [
 ]
 dev = [
   "pytest==8.4.2",
+  "pytest-asyncio==0.24.0",
   "isort==8.0.1"
 ]
 

--- a/sdk/sample/pyproject.toml
+++ b/sdk/sample/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "pytest-asyncio",
   "isort"
 ]
 


### PR DESCRIPTION
### Motivation
- Provide clear, actionable testing guidance for the SDK that follows the docs contributing structure and covers async testing needs. 
- Ensure project dev extras include `pytest-asyncio` so async pytest usage in examples can be installed and reproduced. 

### Description
- Replaced the placeholder tests page with a full `docs/src/sdk/tests/index.md` `Testing` guide that includes `Usage`, installation commands, an async `pytest.mark.asyncio` example, and resource links. 
- Added `pytest-asyncio==0.24.0` to SDK dev optional dependencies in `sdk/pyproject.toml`. 
- Added `pytest-asyncio` to the sample app dev optional dependencies in `sdk/sample/pyproject.toml` for consistency. 
- Ran repository formatting to keep code style consistent with `make format`. 

### Testing
- Ran `make format` from the repository root and it completed successfully. 
- Installed SDK dev extras with `uv pip install --python /workspace/longlink/.venv/bin/python -e './sdk[dev]'` to validate dependency wiring and it installed successfully. 
- Executed `/workspace/longlink/.venv/bin/python -m pytest sdk/tests/test_hello.py -q` and the test passed (1 passed) with deprecation warnings from `pytest-asyncio` under Python 3.14.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e372676eb88323a3acbe87781bb01e)