### PR TITLE
Only fallback to SPA index.html for browser HTML navigations (avoid HTML on API endpoints)

### DIFF
--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -21,6 +21,14 @@ class SPAStaticFiles(StaticFiles):
             if exc.status_code != 404:
                 raise
 
+        method = scope.get("method", "").upper()
+        headers = dict(scope.get("headers", []))
+        accept_header = headers.get(b"accept", b"").decode("latin-1").lower()
+
+        # Only serve SPA fallback for browser navigations that explicitly accept HTML.
+        if method != "GET" or "text/html" not in accept_header:
+            raise exc
+
         return await super().get_response("index.html", scope)
 
 


### PR DESCRIPTION
### Motivation
- The SDK served `index.html` as a static SPA fallback for any missing path which caused API requests (for example `/pages`) to receive HTML instead of the expected JSON payload.
- Restricting the SPA fallback to real browser navigations preserves API semantics while still returning the SPA shell for client navigations.

### Description
- Updated `SPAStaticFiles.get_response` in `sdk/longlink/app.py` to inspect the ASGI `scope` and read the request `method` and `Accept` header before returning the SPA fallback.
- The fallback now only returns `index.html` when the request is a `GET` and the `Accept` header includes `text/html`; otherwise the original 404 is re-raised so API handlers can respond appropriately.

### Testing
- Ran repository formatter with `make format` which completed successfully.
- Verified Python syntax by running `python -m compileall sdk/longlink/app.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3730dfd308323be4e5a5069996f22)