### PR TITLE
Fix SDK runtime tab navigation base path

### DIFF
--- a/web/src/sdk/Layout.tsx
+++ b/web/src/sdk/Layout.tsx
@@ -15,6 +15,8 @@ export default function SdkLayout() {
     const { data: pagesResponse, isLoading } = useApiData<AppMetadata | AppNavigationPage[] | string>('/pages');
     const pages = getPagesFromResponse(pagesResponse);
 
+    const sdkBasePath = import.meta.env.MODE === 'sdk' ? '' : '/sdk';
+
     const tabs = isLoading
         ? [
               {
@@ -28,7 +30,7 @@ export default function SdkLayout() {
 
     const activeTabConfig = getActiveTabConfig({
         tabs,
-        locationPath: location.pathname.replace(/^\/sdk/, ''),
+        locationPath: sdkBasePath ? location.pathname.replace(/^\/sdk/, '') : location.pathname,
         basePath: '',
     });
 
@@ -50,7 +52,7 @@ export default function SdkLayout() {
                                     return;
                                 }
                                 const nextPath = nextTab.path ?? '';
-                                navigate(`/sdk${nextPath === '' ? '' : `/${nextPath}`}`);
+                                navigate(`${sdkBasePath}${nextPath === '' ? '' : `/${nextPath}`}`);
                             }}
                         >
                             <TabsList variant="line" className="gap-4">


### PR DESCRIPTION
### Motivation
- When the web app is built and served by the SDK runtime it should navigate using root-relative paths, not the `/sdk` prefix that the unified development server uses, to avoid redirects to `/sdk/...` when the SDK serves the app directly.

### Description
- Update `web/src/sdk/Layout.tsx` to compute `sdkBasePath` from `import.meta.env.MODE` and use it to derive `locationPath` and the `navigate` target instead of hardcoding the `/sdk` prefix.

### Testing
- Ran `make format` from the repository root and it completed successfully.
- Built the SDK web bundle with `cd web && bun run build:sdk` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37953478883238acb08dda1bf4b94)