### PR TITLE
Fix ReactXML resolveValue for whitespace-wrapped `{...}` expressions

### DIFF
--- a/web/src/xml/runtime.tsx
+++ b/web/src/xml/runtime.tsx
@@ -52,11 +52,13 @@ export function interpolate(str: string, ctx: ExecutionContext): string {
  *   so it is parsed as an object literal instead.
  */
 export function resolveValue(value: string, ctx: ExecutionContext): unknown {
-    if (!value.startsWith('{') || !value.endsWith('}')) {
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue.startsWith('{') || !trimmedValue.endsWith('}')) {
         return interpolate(value, ctx);
     }
 
-    const expression = value.slice(1, -1).trim();
+    const expression = trimmedValue.slice(1, -1).trim();
 
     try {
         return evaluate(expression, ctx);
@@ -67,7 +69,7 @@ export function resolveValue(value: string, ctx: ExecutionContext): unknown {
     }
 
     // Re-wrap in parens so `{key: value}` is parsed as an object literal, not a labeled statement.
-    return evaluate(`(${value})`, ctx);
+    return evaluate(`(${trimmedValue})`, ctx);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Some pages crashed with `SyntaxError: Unexpected token ':'` when attribute values that were intended as full `{...}` expressions contained surrounding whitespace and were misclassified as template strings.

### Description
- Trim the incoming attribute string in `web/src/xml/runtime.tsx` before deciding if it's a single `{...}` expression and use the trimmed content for evaluation.
- Use the trimmed inner expression for direct evaluation and re-evaluate the trimmed braced value as `({ ... })` on `SyntaxError` to preserve object-literal parsing.
- Preserve existing template interpolation behavior for non-braced values.

### Testing
- Ran `make format` which completed successfully.
- Ran `bun --cwd web test test/xml/runtime.test.ts` and all tests passed (10 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37d92beac8323901a2915b9bd09a5)