### PR TITLE
Fix SDK default issues page runtime expression parsing

### DIFF
--- a/sdk/longlink/pages/issues.xml
+++ b/sdk/longlink/pages/issues.xml
@@ -1,7 +1,7 @@
 <Page name="Issues" icon="circle-alert">
   <Hero title="Issues" subtitle="Default issue backlog rendered from the SDK predefined page." icon="circle-alert" />
   <Table
-    data='[{"id":"ISS-101","title":"Login form validation fails on empty password","priority":"High","status":"Open","assignee":"Alice"},{"id":"ISS-102","title":"Dashboard widgets load in the wrong order","priority":"Medium","status":"In Progress","assignee":"Bruno"},{"id":"ISS-103","title":"Export endpoint times out for large datasets","priority":"Critical","status":"Blocked","assignee":"Carla"},{"id":"ISS-104","title":"Notification badge is not cleared after read","priority":"Low","status":"Done","assignee":"Diego"}]'
+    data="{[{ id: 'ISS-101', title: 'Login form validation fails on empty password', priority: 'High', status: 'Open', assignee: 'Alice' }, { id: 'ISS-102', title: 'Dashboard widgets load in the wrong order', priority: 'Medium', status: 'In Progress', assignee: 'Bruno' }, { id: 'ISS-103', title: 'Export endpoint times out for large datasets', priority: 'Critical', status: 'Blocked', assignee: 'Carla' }, { id: 'ISS-104', title: 'Notification badge is not cleared after read', priority: 'Low', status: 'Done', assignee: 'Diego' }]}"
   >
     <Column key="id" label="ID" content="{id}" />
     <Column key="title" label="Issue" content="{title}" />


### PR DESCRIPTION
### Motivation
- Visiting the default Issues page produced a `SyntaxError: Unexpected token ':'` because the XML `data` attribute contained a raw JSON string whose inner `{}` sequences were treated as interpolation placeholders by the ReactXML runtime.

### Description
- Update `sdk/longlink/pages/issues.xml` to change the `Table` `data` attribute from a raw JSON string to a single runtime expression block (`{[...]}`) so the runtime evaluates a JavaScript array literal instead of attempting to interpolate inner JSON fragments.

### Testing
- Ran `make format` from the repository root (which runs the JS and Python formatting steps) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39ec951788323931e786f72fdeed1)