### PR TITLE
Use SDK context to save sample data to filesystem and database

### DIFF
--- a/sdk/sample/app/api/sample.py
+++ b/sdk/sample/app/api/sample.py
@@ -1,5 +1,7 @@
+from uuid import uuid4
 from longlink import Router, Context
 from app.types import UserModel
+from app.models.projects import Project, LinkedContact, ProjectStatus
 
 router = Router()
 
@@ -19,10 +21,38 @@ async def sample_get_endpoint(ctx: Context):
 
 
 @router.post("/sample")
-async def sample_post_endpoint():
-    """Handle sample POST request."""
+async def sample_post_endpoint(ctx: Context):
+    """Create sample records in filesystem and database using request context."""
 
-    return "Sample POST endpoint response"
+    project_id = str(uuid4())
+    filename = f"sample-projects/{project_id}.txt"
+    file_contents = f"Created project {project_id} from sample context endpoint."
+
+    # Persist data to the configured filesystem abstraction.
+    ctx.storage.write_bytes(filename, file_contents.encode("utf-8"))
+
+    project = Project(
+        id=project_id,
+        name="Context Storage Demo Project",
+        linked_contact=LinkedContact(
+            id="contact-1",
+            name="Sample Contact",
+            email="sample@example.com",
+        ),
+        status=ProjectStatus.ACTIVE,
+        budget=1000,
+        owner="sample-user",
+    )
+
+    # Persist data to the configured database session abstraction.
+    ctx.session.add(project)
+    ctx.session.commit()
+
+    return {
+        "message": "Sample POST endpoint saved data to filesystem and database",
+        "project_id": project_id,
+        "filesystem_path": filename,
+    }
 
 
 @router.put("/sample")


### PR DESCRIPTION
### Motivation
- Make the sample app explicitly demonstrate how the SDK request `Context` is used to perform side effects across storage and the database so new integrators see a concrete example.

### Description
- Updated `POST /sample` in `sdk/sample/app/api/sample.py` to accept `Context` and import `uuid4` and `Project`, `LinkedContact`, `ProjectStatus` from the sample models.
- The endpoint now generates a `project_id`, writes a text artifact to the configured filesystem using `ctx.storage.write_bytes(...)`, creates a `Project` instance, and persists it via `ctx.session.add(...)` and `ctx.session.commit()`.
- The endpoint response now returns a metadata payload including `project_id` and the `filesystem_path` where the artifact was written.
- Added necessary imports and kept formatting consistent with repository tooling.

### Testing
- Ran repository formatting workflow from the repo root via `make format`, which completed successfully.
- Ran import sorting on the modified file with `python -m isort sdk/sample/app/api/sample.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39f011f04832397c629f62e4ebe07)