### PR TITLE
Re-export database API (Table) from longlink package root

### DIFF
--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -3,3 +3,4 @@ from longlink.app import LongLink
 from longlink.state import Context, get_context
 from longlink.utils import *
 from longlink.storage import Storage, create_storage
+from longlink.database import Base, Table, Database, get_session


### PR DESCRIPTION
### Motivation
- Fix the `ImportError` caused by sample apps doing `from longlink import Table` by exposing the SDK database types at the package top level.

### Description
- Re-exported `Base`, `Table`, `Database`, and `get_session` from `sdk/longlink/__init__.py` so database symbols are available as `from longlink import Table`; the change is in `sdk/longlink/__init__.py`.

### Testing
- Ran `make format` from the repo root and verified the import with `/workspace/longlink/.venv/bin/python -c "from longlink import Table; print(Table.__name__)"`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4eaa4bfe48323ad879e633d1143fc)