### PR TITLE
docs: add SDK build and publish guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default withMermaid(defineConfig({
           { text: 'Routes', link: '/sdk/routes/' },
           { text: 'Storage', link: '/sdk/storage/' },
           { text: 'Database', link: '/sdk/database/' },
+          { text: 'Build and Publish', link: '/sdk/building/' },
           {
             text: 'Pages',
             collapsed: true,

--- a/docs/src/sdk/building/index.md
+++ b/docs/src/sdk/building/index.md
@@ -1,0 +1,135 @@
+# Build and Publish an SDK Application Container
+
+Use `long-ling build` to package your SDK application into a container image for LongLink runtime.
+
+The build flow is designed so the container itself becomes the deployable application artifact. During build, LongLink reads your Python-defined environment contract and your package metadata, then injects both into the generated container artifacts.
+
+## What `long-ling build` does
+
+```bash
+long-ling build
+```
+
+When you run this command, LongLink should:
+
+1. Read application metadata from `pyproject.toml`.
+2. Read required runtime environment variables from your Python environment definition module.
+3. Generate a Dockerfile that includes required runtime configuration hooks.
+4. Build the container image.
+5. Produce container metadata payload with:
+   - Application metadata (same values as `pyproject.toml`)
+   - Required environment variable schema
+
+This ensures the control plane can start the container with the correct metadata and all required environment variables.
+
+## Metadata and environment injection model
+
+Keep a single metadata source in `pyproject.toml`.
+
+LongLink uses that metadata in two places:
+
+- **Inside the application container**: The application can read its own identity and version metadata at runtime.
+- **Inside container metadata for control plane**: The control plane receives the same metadata and required environment variable definitions before container startup.
+
+Use this model to keep build-time metadata, runtime metadata, and deployment metadata consistent.
+
+## GitHub Action: Build image
+
+Use this workflow to build the SDK container on every push.
+
+```yaml
+name: sdk-build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install SDK tooling
+        run: pip install longlink
+
+      - name: Build container
+        run: long-ling build
+```
+
+## GitHub Action: Publish image
+
+Use this workflow to publish after the build succeeds.
+
+```yaml
+name: sdk-publish
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build SDK container
+        run: long-ling build
+
+      - name: Tag and push image
+        run: |
+          docker tag longlink-app ghcr.io/${{ github.repository }}/longlink-app:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}/longlink-app:${{ github.ref_name }}
+```
+
+For production publishing, use immutable tags and keep release metadata aligned with `pyproject.toml` version fields.
+
+## GitLab CI: Build and publish image
+
+Use this pipeline to build and publish to the GitLab container registry.
+
+```yaml
+stages:
+  - build
+  - publish
+
+build_sdk:
+  stage: build
+  image: python:3.12
+  services:
+    - docker:dind
+  script:
+    - pip install longlink
+    - long-ling build
+
+publish_sdk:
+  stage: publish
+  image: docker:stable
+  services:
+    - docker:dind
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+    - docker tag longlink-app "$CI_REGISTRY_IMAGE/longlink-app:$CI_COMMIT_TAG"
+    - docker push "$CI_REGISTRY_IMAGE/longlink-app:$CI_COMMIT_TAG"
+  only:
+    - tags
+```
+
+Set release tags in GitLab to publish immutable images. The control plane should then deploy containers using that published tag plus the generated metadata and required environment variable schema.


### PR DESCRIPTION
### Motivation

- Document how to package an SDK application into a container using `long-ling build` so the container becomes the deployable artifact.
- Explain the model for reading `pyproject.toml` metadata and Python-defined environment contracts and injecting them into the container and control plane metadata.
- Provide CI examples for automated build and publish flows on GitHub Actions and GitLab CI so teams can adopt a standard publishing workflow.

### Description

- Add a new VitePress page at `docs/src/sdk/building/index.md` explaining `long-ling build`, Dockerfile generation, metadata usage (`pyproject.toml`), and environment-variable injection into the built container.
- Include concrete CI examples for a GitHub build workflow, a GitHub publish workflow (GHCR), and a GitLab CI pipeline for build+publish.
- Update `docs/.vitepress/config.ts` to add a sidebar entry `Build and Publish` under Applications SDK so the new page appears in the documentation navigation.
- Run automatic formatting using `make format` to keep repository style consistent.

### Testing

- Ran `make format` from the repository root and it completed successfully.
- No unit tests were added or modified as this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ea82b6148323a27160ba6139600e)