### PR TITLE
Simplify Makefile to use uv and bun directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,28 @@
 .PHONY: up down install format build api web sample docs
 
-SHELL := /bin/bash
-VENV_BIN := $(CURDIR)/.venv/bin
-SYSTEM_PYTHON ?= $(shell command -v python3 2>/dev/null || command -v python 2>/dev/null)
-PYTHON ?= $(if $(wildcard $(VENV_BIN)/python),$(VENV_BIN)/python,$(SYSTEM_PYTHON))
-UV ?= $(shell command -v uv 2>/dev/null)
-LONGLINK ?= $(if $(wildcard $(VENV_BIN)/longlink),$(VENV_BIN)/longlink,longlink)
-
-$(VENV_BIN)/python:
-	@if [ -z "$(UV)" ]; then \
-		echo "uv is required to create .venv"; \
-		exit 1; \
-	fi
+install:
 	uv venv .venv
+	uv pip install --python .venv/bin/python -e './api[dev]'
+	uv pip install --python .venv/bin/python -e './sdk'
+	bun install --cwd web
+	bun install --cwd docs
 
 
-install: $(VENV_BIN)/python
-	uv pip install --python $(PYTHON) -e './api[dev]'
-	uv pip install --python $(PYTHON) -e './sdk'
-	cd web && bun install
-	cd docs && bun install
-
-
-format: $(VENV_BIN)/python
-	uv pip install --python $(PYTHON) -e './api[dev]'
-	uv pip install --python $(PYTHON) -e './sdk'
-	cd web && bun install
-	cd api && $(PYTHON) -m isort .
-	cd sdk && $(PYTHON) -m isort .
-	cd web && bun run format
+format:
+	uv venv .venv
+	uv pip install --python .venv/bin/python -e './api[dev]'
+	uv pip install --python .venv/bin/python -e './sdk'
+	cd api && uv run --python ../.venv/bin/python isort .
+	cd sdk && uv run --python ../.venv/bin/python isort .
+	bun install --cwd web
+	bun run --cwd web format
 	cd web && bunx prettier --write $$(git -C .. ls-files '*.md' '*.yml' '*.yaml' | sed 's#^#../#')
 
 
 build:
-	cd web && bun install
-	cd web && bun run build:api
-	cd web && bun run build:sdk
+	bun install --cwd web
+	bun run --cwd web build:api
+	bun run --cwd web build:sdk
 
 
 up:
@@ -48,17 +35,17 @@ down:
 	k3d cluster delete compute
 
 
-api: $(VENV_BIN)/python
-	cd api && DEV=True $(PYTHON) -m uvicorn main:app --host 0.0.0.0 --port 8000
+api:
+	cd api && DEV=True uv run uvicorn main:app --host 0.0.0.0 --port 8000
 
 
 web:
-	cd web && bun run dev --host 0.0.0.0 --port 5173
+	bun run --cwd web dev --host 0.0.0.0 --port 5173
 
 
-sample: $(VENV_BIN)/python
-	cd sdk/sample && $(LONGLINK) dev
+sample:
+	cd sdk/sample && uv run longlink dev
 
 
 docs:
-	cd docs && bun run dev
+	bun run --cwd docs dev


### PR DESCRIPTION
### Motivation
- Remove Makefile-level path/constants and the dependency-only virtualenv target to simplify developer workflow and avoid brittle variable resolution.
- Make invocations explicit and consistent by calling the `uv` and `bun` CLIs directly from targets.
- Align build/format/dev commands with the repository's current development model and reduce per-developer setup confusion.

### Description
- Replaced `VENV_BIN`/`SYSTEM_PYTHON`/`PYTHON`/`UV`/`LONGLINK` variables and the `$(VENV_BIN)/python` target with direct `uv venv .venv` usage in `install` and `format`.
- Updated `install` to run `uv pip install --python .venv/bin/python -e './api[dev]'` and `uv pip install --python .venv/bin/python -e './sdk'`, and to call `bun install --cwd` for `web` and `docs`.
- Updated `format` to create `.venv`, install the editable packages, run `isort` via `uv run --python ../.venv/bin/python isort .` in `api`/`sdk`, and to run `bun run --cwd web format` followed by `bunx prettier` for docs/markdown files.
- Normalized `build`, `api`, `web`, `sample`, and `docs` targets to call `bun`/`uv` directly (e.g. `bun run --cwd web build:api`, `cd api && DEV=True uv run uvicorn ...`, and `cd sdk/sample && uv run longlink dev`).

### Testing
- Ran `make format` after changes and it completed successfully. 
- An earlier `make format` run failed due to incorrect `bun` invocation which was then corrected and re-run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f55a2d488323826633f4cf211cc9)