### PR TITLE
docs: link control plane and applications in intro

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ LongLink is a platform for building and running applications that manage and con
 
 It enables organizations to create full-code, purpose-built applications that encapsulate data, validation logic, and workflows in a structured and reliable way. Rather than focusing on infrastructure concerns, teams can focus directly on how their business operates.
 
-The platform is conceptually divided into two parts: a control plane that manages the system, and applications that implement business logic and processes.
+The platform is conceptually divided into two parts: the [control plane](/api/) that manages the system, and [applications](/sdk/) that implement business logic and processes.
 
 ## Why
 


### PR DESCRIPTION
### Motivation
- Make the docs landing intro easier to navigate by linking the platform pieces to their respective docs (control plane -> API, applications -> SDK).

### Description
- Updated `docs/src/index.md` so the introduction now links the phrase `control plane` to `/api/` and `applications` to `/sdk/`.

### Testing
- Ran `make format` from the repository root and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f697733483239e95094d41ad9b28)