### PR TITLE
Add automatic docker build/push flow to `longlink build`

### DIFF
--- a/sdk/longlink/cli/build.py
+++ b/sdk/longlink/cli/build.py
@@ -1,5 +1,6 @@
 import json
 import click
+import subprocess
 from pathlib import Path
 from datetime import UTC, datetime
 from longlink.utils.metadata import load_metadata
@@ -24,7 +25,7 @@ def create_version() -> str:
     return datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
 
 
-def build_app(base_path: Path | None = None) -> tuple[Path, Path, str]:
+def build_app(base_path: Path | None = None) -> tuple[Path, Path, str, str]:
     """Create Dockerfile and deployment manifest for current app."""
 
     root = (base_path or Path.cwd()).resolve()
@@ -44,13 +45,53 @@ def build_app(base_path: Path | None = None) -> tuple[Path, Path, str]:
     manifest_path = root / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
 
-    return dockerfile_path, manifest_path, version
+    return dockerfile_path, manifest_path, version, metadata.name
+
+
+def build_image_tag(image_name: str, version: str, registry: str) -> str:
+    """Build a normalized tag for publishing the image to registry."""
+
+    normalized_name = image_name.strip().lower().replace(" ", "-").replace("_", "-")
+    normalized_registry = registry.strip().rstrip("/")
+    return f"{normalized_registry}/{normalized_name}:{version}"
+
+
+def run_docker_build(root: Path, image_tag: str) -> None:
+    """Build Docker image for the current application directory."""
+
+    # Build a local image from generated Dockerfile in the application root.
+    subprocess.run(["docker", "build", "-t", image_tag, "."], cwd=root, check=True)
+
+
+def run_docker_push(image_tag: str) -> None:
+    """Push built Docker image to the configured registry."""
+
+    # Push image tag so k3d cluster workloads can pull it from shared registry.
+    subprocess.run(["docker", "push", image_tag], check=True)
 
 
 @click.command(name="build")
-def build_command():
-    """Create Dockerfile and manifest metadata for deployment."""
-    dockerfile_path, manifest_path, version = build_app()
-    click.echo(f"Build artifacts created for version {version}")
-    click.echo(f"- Dockerfile: {dockerfile_path}")
-    click.echo(f"- Manifest: {manifest_path}")
+@click.option(
+    "--registry",
+    default="localhost:5000",
+    show_default=True,
+    help="Docker registry used for image push (for k3d typically localhost:5000).",
+)
+def build_command(registry: str):
+    """Create Dockerfile, build Docker image, and push image to registry."""
+
+    try:
+        dockerfile_path, manifest_path, version, app_name = build_app()
+        image_tag = build_image_tag(app_name, version, registry)
+
+        run_docker_build(dockerfile_path.parent, image_tag)
+        run_docker_push(image_tag)
+
+        click.echo(f"Build artifacts created for version {version}")
+        click.echo(f"- Dockerfile: {dockerfile_path}")
+        click.echo(f"- Manifest: {manifest_path}")
+        click.echo(f"- Image: {image_tag}")
+    except subprocess.CalledProcessError as error:
+        raise click.ClickException(f"Docker command failed with exit code {error.returncode}") from error
+    except FileNotFoundError as error:
+        raise click.ClickException("Docker CLI is not installed or not available on PATH") from error

--- a/sdk/sample/README.md
+++ b/sdk/sample/README.md
@@ -3,3 +3,36 @@
 Internal ordering system for office hardware: keyboards, mice, monitors, and other equipment.
 
 Employees browse available products, create requisition requests, and track order status.
+
+## Build and publish to a k3d registry
+
+`longlink build` now performs a full container build flow for this sample:
+
+1. Generates `Dockerfile` and `manifest.json` in the project root.
+2. Builds a Docker image tagged with the app name and a timestamp version.
+3. Pushes that image to a Docker registry (default: `localhost:5000`, which is common for local k3d setups).
+
+### Prerequisites
+
+- Docker daemon is running.
+- A k3d registry is available and reachable from Docker.
+
+If you need to create a local registry with k3d:
+
+```bash
+k3d registry create compute-registry --port 5000
+```
+
+### Build and push using default registry
+
+```bash
+longlink build
+```
+
+### Build and push using a custom k3d registry endpoint
+
+```bash
+longlink build --registry my-registry.localhost:5001
+```
+
+After a successful run, the CLI prints the exact image tag that was pushed.


### PR DESCRIPTION
### Motivation

- Enable the SDK sample `longlink build` flow to not only generate build artifacts but also produce a Docker image and publish it to a local k3d-friendly registry, and document how to use that flow in the sample README.

### Description

- Extend `sdk/longlink/cli/build.py` so `build_app` returns the app name and add `build_image_tag`, `run_docker_build`, and `run_docker_push` helpers to build and push images using the Docker CLI. 
- Add a `--registry` option to `longlink build` (default `localhost:5000`) and normalize image tags from app metadata plus a timestamped version. 
- Surface friendly CLI errors for missing Docker or failed Docker commands by catching `FileNotFoundError` and `subprocess.CalledProcessError`. 
- Update `sdk/sample/README.md` with step-by-step instructions for creating a k3d registry and running `longlink build` (default and custom registry examples).

### Testing

- Ran `make format` from the repository root and formatting completed successfully. 
- Ran `cd sdk && uv run --python ../.venv/bin/python longlink build --help` and verified the command prints usage and the new `--registry` option.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e518aced288323becff0faa8a5af00)