### PR TITLE
Use astral-sh/uv base image and switch build runtime to `uv`

### DIFF
--- a/docs/src/sdk/building/index.md
+++ b/docs/src/sdk/building/index.md
@@ -5,8 +5,6 @@
 - Once containerized can be placed in any registry-
 - Can be connected to the control panel and deployed
 
-
 ```bash
 longling build
 ```
-

--- a/sdk/longlink/cli/build.py
+++ b/sdk/longlink/cli/build.py
@@ -5,17 +5,15 @@ from pathlib import Path
 from datetime import UTC, datetime
 from longlink.utils.metadata import load_metadata
 
-DOCKERFILE_TEMPLATE = """FROM python:3.12-slim
+DOCKERFILE_TEMPLATE = """FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 
 WORKDIR /app
 
-COPY . /app
+COPY . .
 
-RUN pip install --no-cache-dir .
+RUN uv sync --frozen
 
-EXPOSE 1707
-
-CMD ["longlink", "dev"]
+CMD ["uv", "run", "python", "-m", "longlink"]
 """
 
 


### PR DESCRIPTION
### Motivation
- Move the build/runtime to the `uv` runtime image to standardize packaging and execution. 
- Replace manual install and custom entrypoint with `uv` tooling to enable frozen sync and consistent runtime invocation. 
- Clean up the SDK docs for the build workflow presentation.

### Description
- Update `DOCKERFILE_TEMPLATE` to use `FROM ghcr.io/astral-sh/uv:python3.12-bookworm` as the base image. 
- Change file copy to `COPY . .`, replace installation with `RUN uv sync --frozen`, and replace the old entrypoint with `CMD ["uv", "run", "python", "-m", "longlink"]` while removing the exposed port line. 
- Leave manifest generation logic intact and continue writing the `Dockerfile` from the template. 
- Tidy `docs/src/sdk/building/index.md` formatting and example command display.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51a733640832395f7f3428bf3dfea)