### PR TITLE
Fix SDK Alembic environment metadata imports

### DIFF
--- a/sdk/longlink/database/env.py
+++ b/sdk/longlink/database/env.py
@@ -1,7 +1,11 @@
 from alembic import context
-from longlink.database.base import Base, engine
+from sqlmodel import SQLModel
+from longlink.database.base import create_engine
+from longlink.utils.settings import Settings
 
-target_metadata = Base.metadata
+settings = Settings()
+engine = create_engine(settings)
+target_metadata = SQLModel.metadata
 
 
 def run_migrations_offline() -> None:


### PR DESCRIPTION
### Motivation
- Alembic's `env.py` attempted to import `Base` and `engine` from `longlink.database.base` which no longer exist, causing `ImportError` during `longlink migrate` in SDK apps. 
- Migrations need to target the SQLModel metadata used by the SDK so autogenerated revisions include current models.

### Description
- Replace the stale `from longlink.database.base import Base, engine` import with `from sqlmodel import SQLModel`, `from longlink.database.base import create_engine`, and `from longlink.utils.settings import Settings` in `sdk/longlink/database/env.py`.
- Initialize `settings = Settings()` and build `engine = create_engine(settings)`, then set `target_metadata = SQLModel.metadata` for Alembic autogeneration and upgrades.
- Leave the existing offline/online migration control flow unchanged so `context.run_migrations()` behavior is preserved.

### Testing
- Ran `make format` which completed successfully. 
- Executed `uv run --python ../../.venv/bin/python longlink migrate` from `sdk/sample` which generated and applied migrations successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5204365ec8323b9052db3df4d9576)