### PR TITLE
Expose native fsspec filesystem via request context

### DIFF
--- a/docs/src/sdk/routes/index.md
+++ b/docs/src/sdk/routes/index.md
@@ -21,9 +21,10 @@ class SampleResponse(BaseModel):
 
 @router.get("/sample", response_model=SampleResponse)
 async def sample(ctx: Context) -> SampleResponse:
-    # Access storage and database context
-    storage = ctx.storage
-    database = ctx.database
+    # Access the native fsspec filesystem from request context
+    fs = ctx.fs()
+    with fs.open("sample.txt", "wb") as file_handle:
+        file_handle.write(b"hello from route")
 
     return SampleResponse(id=1, name="apple")
 

--- a/docs/src/sdk/storage/index.md
+++ b/docs/src/sdk/storage/index.md
@@ -1,19 +1,43 @@
 # Storage
 
-fsspec
-
-The Storage section introduces how application data and files are stored and managed.
-
-This index is the starting point for future Storage subsections.
+LongLink SDK exposes a native `fsspec` filesystem through the request context.
+You can use the filesystem exactly like standard `fsspec` clients.
 
 ## Usage
 
 ```python
-from longlink import
+import fsspec
+from longlink import Router, Context
 
+
+router = Router()
+
+
+@router.post("/files")
+async def create_file(ctx: Context):
+    fs = ctx.fs()
+    with fs.open("reports/example.txt", "wb") as file_handle:
+        file_handle.write(b"hello")
+
+    return {"path": "reports/example.txt"}
 ```
 
-## References
+## Configure S3 credentials
+
+```python
+import fsspec
+
+fs = fsspec.filesystem(
+    "s3",
+    key="YOUR_KEY",
+    secret="YOUR_SECRET",
+)
+```
+
+LongLink builds the same kind of filesystem object internally from app settings,
+then provides it in each request via `ctx.fs()`.
+
+## references
 
 - [fsspec Documentation](https://filesystem-spec.readthedocs.io/en/latest/)
 - [fsspec Github](https://github.com/fsspec/filesystem_spec)

--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -2,5 +2,5 @@ from fastapi import APIRouter as Router
 from longlink.app import LongLink
 from longlink.state import Context, get_context
 from longlink.utils import *
-from longlink.storage import Storage, create_storage
+from longlink.storage import create_storage
 from longlink.database import Base, Table, Database, get_session

--- a/sdk/longlink/state.py
+++ b/sdk/longlink/state.py
@@ -1,8 +1,9 @@
+import fsspec
 from typing import Annotated
 from fastapi import Depends, Request
 from sqlmodel import Session
 from dataclasses import field, dataclass
-from longlink.storage import Storage, create_storage
+from longlink.storage import create_storage
 from sqlalchemy.engine import Engine
 from longlink.utils.page import Page
 from longlink.database.base import create_engine
@@ -13,20 +14,25 @@ from longlink.utils.settings import Settings
 class State:
     """Request-scoped SDK context with app-managed services and aliases."""
     engine: Engine
-    storage: Storage
+    _fs: fsspec.AbstractFileSystem
     session: Session
     pages: list[Page] = field(default_factory=list)
+
+    def fs(self) -> fsspec.AbstractFileSystem:
+        """Return the native fsspec filesystem configured for this application."""
+
+        return self._fs
 
 
 def create_state(env: Settings) -> State:
     """Create SDK state from app settings and managed service factories."""
 
     engine = create_engine(env)
-    storage = create_storage(env)
+    filesystem = create_storage(env)
     session = Session(engine)
     return State(
         engine=engine,
-        storage=storage,
+        _fs=filesystem,
         session=session,
     )
 

--- a/sdk/longlink/storage/__init__.py
+++ b/sdk/longlink/storage/__init__.py
@@ -1,1 +1,1 @@
-from longlink.storage.base import Storage, create_storage
+from longlink.storage.base import create_storage

--- a/sdk/longlink/storage/base.py
+++ b/sdk/longlink/storage/base.py
@@ -2,29 +2,8 @@ import fsspec
 from longlink.utils.settings import Settings
 
 
-class Storage:
-    """Thin wrapper around fsspec filesystem read/write operations."""
-
-    def __init__(self, fs: fsspec.AbstractFileSystem):
-        """Store filesystem client used for IO operations."""
-
-        self.fs = fs
-
-    def write_bytes(self, path: str, data: bytes) -> None:
-        """Write raw bytes to path using configured filesystem backend."""
-
-        with self.fs.open(path, "wb") as file_handle:
-            file_handle.write(data)
-
-    def read_bytes(self, path: str) -> bytes:
-        """Read raw bytes from path using configured filesystem backend."""
-
-        with self.fs.open(path, "rb") as file_handle:
-            return file_handle.read()
-
-
-def create_storage(env: Settings) -> Storage:
-    """Create Storage instance from environment settings."""
+def create_storage(env: Settings) -> fsspec.AbstractFileSystem:
+    """Create fsspec filesystem client from environment settings."""
 
     if env.DEV:
         fs = fsspec.filesystem("file")
@@ -35,5 +14,4 @@ def create_storage(env: Settings) -> Storage:
             secret=env.storage_secret,
             client_kwargs={"endpoint_url": env.storage_endpoint},
         )
-    return Storage(fs)
-
+    return fs

--- a/sdk/sample/app/api/sample.py
+++ b/sdk/sample/app/api/sample.py
@@ -10,12 +10,13 @@ router = Router()
 async def sample_get_endpoint(ctx: Context):
     """Handle sample GET request."""
 
+    filesystem = ctx.fs()
     return {
         "message": "Sample GET endpoint received data",
-        "has_storage": ctx.storage is not None,
-        "has_fs_alias": ctx.fs is ctx.storage,
-        "has_db_alias": ctx.db is ctx.database,
-        "env_loaded": ctx.envs is not None,
+        "filesystem_protocol": filesystem.protocol,
+        "filesystem_type": type(filesystem).__name__,
+        "has_database_session": ctx.session is not None,
+        "has_engine": ctx.engine is not None,
     }
 
 
@@ -27,8 +28,10 @@ async def sample_post_endpoint(ctx: Context):
     filename = f"sample-projects/{project_id}.txt"
     file_contents = f"Created project {project_id} from sample context endpoint."
 
-    # Persist data to the configured filesystem abstraction.
-    ctx.storage.write_bytes(filename, file_contents.encode("utf-8"))
+    # Persist data with native fsspec APIs exposed by the request context.
+    filesystem = ctx.fs()
+    with filesystem.open(filename, "wb") as file_handle:
+        file_handle.write(file_contents.encode("utf-8"))
 
     project = Project(
         id=project_id,


### PR DESCRIPTION
### Motivation

- Keep the SDK a thin integration layer by exposing native `fsspec` APIs instead of wrapping them in a custom storage class.
- Make route code more idiomatic and portable for developers already using `fsspec` by providing the actual filesystem client on the request context.
- Update docs and examples so users know to use `ctx.fs()` and standard `fsspec` usage patterns.

### Description

- Removed the `Storage` wrapper and changed `create_storage` to return a `fsspec.AbstractFileSystem` directly (see `sdk/longlink/storage/base.py`).
- Updated SDK request state to store the filesystem as `_fs` and added an accessor method `fs()` that returns the native `fsspec` filesystem (see `sdk/longlink/state.py`).
- Rewired imports/exports to stop exposing the removed `Storage` class and use `create_storage` returning the filesystem (see `sdk/longlink/__init__.py` and `sdk/longlink/storage/__init__.py`).
- Reworked sample route handlers to use `ctx.fs()` and native `fs.open(...)` read/write patterns, and refreshed docs with `ctx.fs()` usage and an S3 credential snippet (see `sdk/sample/app/api/sample.py`, `docs/src/sdk/routes/index.md`, and `docs/src/sdk/storage/index.md`).

### Testing

- Ran `make format` which completed successfully.
- Ran `uv run --python .venv/bin/python pytest sdk/tests/test_hello.py` and the single test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5212f477c8323b1d56996ecf7f8c5)