### PR TITLE
web: add favicon before breadcrumb links

### DIFF
--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -15,6 +15,9 @@ type SettingResponse = {
     app_id: number | null;
 };
 
+/**
+ * Render the top navigation breadcrumb for organization, app, and profile routes.
+ */
 export function Breadcrumb() {
     const { appId } = useParams();
     const location = useLocation();
@@ -28,6 +31,13 @@ export function Breadcrumb() {
     return (
         <UIBreadcrumb>
             <BreadcrumbList>
+                <BreadcrumbItem>
+                    <img
+                        src="/favicon.ico"
+                        alt="LongLink favicon"
+                        className="size-5 rounded-md border border-white/15 bg-white/5 p-0.5"
+                    />
+                </BreadcrumbItem>
                 <BreadcrumbItem>
                     <BreadcrumbLink
                         render={(props) => (


### PR DESCRIPTION
### Motivation
- Provide a visual favicon at the start of the top breadcrumb so the header mirrors GitHub-style ownership/app identification and improves quick recognition.
- Keep UI changes small and aligned with existing header styling and repository documentation rules.

### Description
- Updated `web/src/components/Breadcrumb.tsx` to insert a `BreadcrumbItem` with an `<img src="/favicon.ico">` before existing breadcrumb links. 
- Added styling classes (`size-5 rounded-md border border-white/15 bg-white/5 p-0.5`) to give the favicon a rounded container and subtle border to match the header aesthetic. 
- Added a short JSDoc comment above the `Breadcrumb` function to satisfy the repository's JS/TS documentation rule.

### Testing
- Ran `make format` from the repository root and it completed successfully. 
- Built the web app with `bun run --cwd web build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e522799b40832382787e1d5cba31ad)