### PR TITLE
sdk: surface no-change message for empty migrations

### DIFF
--- a/sdk/longlink/cli/migrate.py
+++ b/sdk/longlink/cli/migrate.py
@@ -5,6 +5,10 @@ from longlink.database.migrations import migrate, make_migrations
 @click.command(name="migrate")
 def migrate_command():
     """Generate and apply database migrations for the current app."""
-    make_migrations()
+    migration_created = make_migrations()
     migrate()
-    click.echo("Migrations generated and applied successfully.")
+    if migration_created:
+        click.echo("Migrations generated and applied successfully.")
+        return
+
+    click.echo("No migrations were created because no schema changes were detected.")

--- a/sdk/longlink/database/migrations.py
+++ b/sdk/longlink/database/migrations.py
@@ -23,12 +23,41 @@ for py_file in MODELS_PATH.glob("*.py"):
     spec.loader.exec_module(module)
 
 
-def make_migrations() -> None:
-    """Generate new Alembic revision from metadata diff."""
+def make_migrations() -> bool:
+    """Generate new Alembic revision from metadata diff.
+
+    Returns:
+        bool: True when a new migration file is created, otherwise False.
+    """
     cfg = Config()
     cfg.set_main_option("script_location", str(CURRENT_FILE.parent))
     cfg.set_main_option("version_locations", "migrations")
-    command.revision(cfg)
+    migration_created = True
+
+    def _skip_empty_revision(
+        _context: object, _revision: object, directives: list[object]
+    ) -> None:
+        """Skip writing a migration script when autogenerate finds no changes."""
+        nonlocal migration_created
+        if not directives:
+            migration_created = False
+            return
+
+        # The first directive is Alembic's MigrationScript for this revision.
+        script = directives[0]
+        upgrade_ops = getattr(script, "upgrade_ops", None)
+
+        # When no schema operations are detected, prevent file generation.
+        if upgrade_ops is not None and upgrade_ops.is_empty():
+            directives[:] = []
+            migration_created = False
+
+    command.revision(
+        cfg,
+        autogenerate=True,
+        process_revision_directives=_skip_empty_revision,
+    )
+    return migration_created
 
 
 def migrate() -> None:


### PR DESCRIPTION
### Motivation

- Avoid creating empty Alembic revision files when `longlink migrate` detects no schema changes. 
- Provide a clear CLI message to users when no migrations are generated so the outcome is explicit. 

### Description

- Updated `make_migrations()` to run Alembic in autogenerate mode and return a `bool` indicating whether a migration file was created. 
- Added a `process_revision_directives` callback (`_skip_empty_revision`) that inspects Alembic directives and prevents file generation when `upgrade_ops.is_empty()` is true. 
- Updated the `migrate` CLI (`migrate_command`) to inspect the `make_migrations()` return value and print either a success message or `No migrations were created because no schema changes were detected.` accordingly. 

### Testing

- Ran `make format` from the repository root which completed successfully. 
- Compiled the modified Python modules with `python -m compileall longlink/cli/migrate.py longlink/database/migrations.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e526482ac48323b8bce85dfeb7c48b)