### PR TITLE
Fix Breadcrumb crash when organization name is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ make down   # Stop services and remove the cluster
 
 ### Applications SDK
 
-
 ```bash
 make sdk    # Run the web app proxied to the sample app
 make sample # Run the sample APP

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -24,17 +24,13 @@ export function Breadcrumb() {
     const { data: appMetadata } = useApiData<{ name?: string }>(appId ? `/apps/${appId}` : null);
 
     const appName = appId ? appMetadata?.name?.trim() || formatAppName(appId) : undefined;
-    const organizationName = organizationNameData?.value.trim() || 'Organization';
+    const organizationName = organizationNameData?.value?.trim() || 'Organization';
 
     return (
         <UIBreadcrumb>
             <BreadcrumbList>
                 <BreadcrumbItem>
-                    <img
-                        src="/favicon.ico"
-                        alt="LongLink favicon"
-                        className="size-8 rounded-md p-0.5"
-                    />
+                    <img src="/favicon.ico" alt="LongLink favicon" className="size-8 rounded-md p-0.5" />
                 </BreadcrumbItem>
                 <BreadcrumbItem>
                     <BreadcrumbLink


### PR DESCRIPTION
### Motivation
- Prevent a runtime `TypeError` thrown from the `Breadcrumb` component when the `/settings/ORG_NAME` response lacks a `value`, so routes that render the breadcrumb no longer crash.

### Description
- Update `web/src/components/Breadcrumb.tsx` to guard access with optional chaining (`organizationNameData?.value?.trim()`), and apply small formatter-driven cleanup (single-line `img` JSX and README whitespace).

### Testing
- Ran `make format` and `cd web && bun run build`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e542c16928832391debb49c0fc8ef8)