### PR TITLE
Auto-generate App URL on create and remove URL input

### DIFF
--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from pydantic import BaseModel, field_validator
-from src.utils import url
 
 
 class AppType(str, Enum):
@@ -11,15 +10,8 @@ class AppType(str, Enum):
 
 class AppCreate(BaseModel):
     id: str | None = None
-    url: str
     key: str
     image: str
-
-    @field_validator("url", mode="before")
-    @classmethod
-    def normalize_url_field(cls, value: str) -> str:
-        """Normalize URL by ensuring proper scheme and no trailing slash."""
-        return url.normalize(value)
 
     @field_validator("id", mode="before")
     @classmethod

--- a/api/src/pages/applications.xml
+++ b/api/src/pages/applications.xml
@@ -1,5 +1,5 @@
 <Page name="Applications" icon="blocks">
-  <State id="createApp" key="" url="" image="" appId="">
+  <State id="createApp" key="" image="" appId="">
     <Hero
       title="Applications"
       subtitle="Manage applications available to your organization."
@@ -16,7 +16,6 @@
         <Stack gap="12">
           <Input kind="text" label="App id (optional)" value="{createApp.appId}" placeholder="custom-app-id" />
           <Input kind="text" label="App key" value="{createApp.key}" placeholder="sampleapp" />
-          <Input kind="text" label="App URL" value="{createApp.url}" placeholder="http://sampleapp.localhost" />
           <Input
             kind="text"
             label="Image reference"
@@ -30,14 +29,12 @@
             payload='{
               "id": "{createApp.appId}",
               "key": "{createApp.key}",
-              "url": "{createApp.url}",
               "image": "{createApp.image}"
             }'
             onSuccess="
               refetch(applications);
               set(createApp.appId, '');
               set(createApp.key, '');
-              set(createApp.url, '');
               set(createApp.image, '');
             "
           >

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -1,7 +1,6 @@
 import src.db as db
 from fastapi import APIRouter, HTTPException
 from src.env import env
-from src.utils import apps
 from src.models.apps import AppType, AppCreate, AppMetadata, AppResponse
 
 router = APIRouter()
@@ -23,8 +22,10 @@ async def list_apps(type: AppType | None = None) -> list[AppResponse]:
 
 @router.post("/apps")
 async def create_app(payload: AppCreate) -> AppResponse:
-    """Create a new app by fetching its metadata and registering it."""
-    existing_url = await db.apps.get_by_url(payload.url)
+    """Create a new app by provisioning its container and registering it."""
+    app_url = f"http://{payload.key}.localhost"
+
+    existing_url = await db.apps.get_by_url(app_url)
     if existing_url is not None:
         raise HTTPException(status_code=409, detail="App URL already exists")
 
@@ -36,23 +37,6 @@ async def create_app(payload: AppCreate) -> AppResponse:
         existing_id = await db.apps.get_by_uuid(payload.id)
         if existing_id is not None:
             raise HTTPException(status_code=409, detail="App id already exists")
-
-    # Fetch app metadata from the provided URL
-    metadata_response = await apps.raw(
-        f"{payload.url.rstrip('/')}/metadata.json", "GET"
-    )
-    if not metadata_response.is_success:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unable to fetch metadata.json ({metadata_response.status_code})",
-        )
-
-    try:
-        metadata = AppMetadata.model_validate(metadata_response.json())
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=400, detail="App metadata response is invalid"
-        ) from exc
 
     namespace = env.ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE
     pod_name = f"{payload.key}-app".strip().lower()
@@ -71,9 +55,11 @@ async def create_app(payload: AppCreate) -> AppResponse:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     try:
+        # Register the app immediately and let runtime metadata be resolved later.
+        metadata = AppMetadata(name=payload.key, type=AppType.tool)
         app = await db.apps.create(
             metadata.name,
-            url=payload.url,
+            url=app_url,
             key=payload.key,
             app_type=metadata.type,
             app_id=payload.id,


### PR DESCRIPTION
### Motivation
- The app creation UX should not require users to provide an app URL because the runtime will create the URL when the container is started.
- The previous flow blocked creation while fetching `metadata.json` from the provided URL, which made the "Create application" action appear to do nothing when the app runtime was not yet available.

### Description
- Removed the `App URL` state/input and its payload/reset usage from `api/src/pages/applications.xml` so the UI no longer asks users for a URL.
- Updated the `AppCreate` model in `api/src/models/apps.py` to stop requiring a `url` field.
- Changed the create route in `api/src/routes/apps.py` to derive `app_url = f"http://{payload.key}.localhost"`, provision the container first using `db.computes.create_container`, and register the app with the derived URL without blocking on an immediate `metadata.json` fetch by creating a default `AppMetadata(name=payload.key, type=AppType.tool)`.
- Preserved uniqueness checks for URL, key, and id and preserved existing container provisioning error handling.

### Testing
- Ran `make format` which completed successfully.
- Compiled modified Python files with `cd api && uv run --python ../.venv/bin/python -m py_compile src/models/apps.py src/routes/apps.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5444a90b48323bde0a60fd453796d)