### PR TITLE
fix(web): map XML button action props to DOM-safe button behavior

### DIFF
--- a/web/src/xml/components/Button.tsx
+++ b/web/src/xml/components/Button.tsx
@@ -1,4 +1,26 @@
-import { Button } from '@/ui/button';
+import { Button as UIButton } from '@/ui/button';
+
+import type { ActionComponentProps } from '../types';
+
+type XMLButtonProps = Omit<Parameters<typeof UIButton>[0], keyof ActionComponentProps> &
+    Partial<ActionComponentProps> & {
+        _baseUrl?: string;
+    };
+
+/**
+ * XML button adapter that maps action-layer props to DOM-safe button props.
+ */
+function Button({ action, pending = false, _baseUrl: _unusedBaseUrl, onClick, disabled, ...props }: XMLButtonProps) {
+    const handleClick = (event: Parameters<NonNullable<typeof onClick>>[0]) => {
+        onClick?.(event);
+
+        if (!event.defaultPrevented) {
+            void action?.(event as any);
+        }
+    };
+
+    return <UIButton {...props} onClick={handleClick} disabled={Boolean(disabled) || pending} />;
+}
 
 export { Button };
 export default Button;


### PR DESCRIPTION
### Motivation
- The XML runtime injected `action`, `pending`, and `_baseUrl` into components which were being forwarded to a DOM-backed button, causing React warnings and preventing XML action callbacks from running correctly.

### Description
- Replaced the simple passthrough export with an adapter component at `web/src/xml/components/Button.tsx` that filters XML-only props and adapts them for the UI button.
- Wired the injected `action` handler into the button `onClick` so XML action callbacks execute when clicked while preserving any existing `onClick` behavior and honoring `event.preventDefault()`.
- Mapped the injected `pending` boolean to the button `disabled` prop and stopped forwarding `_baseUrl` to the DOM to avoid invalid attribute warnings.
- Added a small type-cast to satisfy the BaseUI event typing during the adapter call site.

### Testing
- Ran `make format` which completed successfully.
- Ran `cd web && bun run build` which completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54c93261c8323b0cf47b9cfebb795)