### PR TITLE
web: prefix XML action requests with runtime API base URL

### DIFF
--- a/web/src/xml/registry.tsx
+++ b/web/src/xml/registry.tsx
@@ -236,7 +236,8 @@ export function action<TComponent extends ComponentType<any>>(Component: TCompon
             setPending(true);
 
             try {
-                const requestUrl = resolvedPath.startsWith('http') ? resolvedPath : resolvedPath;
+                const baseUrl = runtime.ctx.baseUrl ?? '';
+                const requestUrl = resolvedPath.startsWith('http') ? resolvedPath : `${baseUrl}${resolvedPath}`;
                 const response = await fetch(requestUrl, buildRequestInit(method.toUpperCase(), body ?? payload));
 
                 if (!response.ok) {


### PR DESCRIPTION
### Motivation
- XML action handlers were sending relative paths (e.g. `/apps`) to the Vite dev origin, causing requests to hit `http://localhost:5173` and return `404` instead of targeting the control-plane API (e.g. `http://localhost:8000`).

### Description
- Updated request URL construction in `web/src/xml/registry.tsx` to read `baseUrl` from `runtime.ctx.baseUrl` and build `requestUrl` as `resolvedPath.startsWith('http') ? resolvedPath : `${baseUrl}${resolvedPath}``, preserving absolute URLs and routing relative action submissions through the configured API base URL.

### Testing
- Ran `make format` from the repository root and it completed successfully.
- Built the frontend with `bun run --cwd web build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e553972cdc832396c7267496f0348f)