### PR TITLE
Fix JSON action payload content-type in XML registry

### DIFF
--- a/web/src/xml/registry.tsx
+++ b/web/src/xml/registry.tsx
@@ -165,6 +165,22 @@ function buildRequestInit(method: string, body: unknown): RequestInit {
         body instanceof Blob ||
         typeof body === 'string'
     ) {
+        if (typeof body === 'string') {
+            const trimmedBody = body.trim();
+
+            /* Preserve JSON string payloads as application/json for API handlers. */
+            if (
+                (trimmedBody.startsWith('{') && trimmedBody.endsWith('}')) ||
+                (trimmedBody.startsWith('[') && trimmedBody.endsWith(']'))
+            ) {
+                return {
+                    method,
+                    body,
+                    headers: { 'content-type': 'application/json' },
+                };
+            }
+        }
+
         return { method, body };
     }
 


### PR DESCRIPTION
### Motivation
- The XML action builder sent JSON object/array payloads as plain text, causing FastAPI to reject `POST /apps` requests with `422 Unprocessable Content` because the server did not receive a JSON content-type header.

### Description
- Detect trimmed string payloads that appear to be JSON objects or arrays in `buildRequestInit` and set `content-type: application/json` for those cases while preserving passthrough behavior for native body types and non-JSON strings.

### Testing
- Ran `make format` and `bun --cwd web test test/xml/registry.test.ts`, and the registry tests passed (`4 pass, 0 fail`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5559f8d388323bc297cc98ba22fd2)