### PR TITLE
Remove custom app ID support across API, service and UI

### DIFF
--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -66,7 +66,6 @@ class AppsService:
         url: str,
         key: str,
         app_type: str,
-        app_id: str | None = None,
     ) -> App:
         '''Add a new app to the database.'''
 
@@ -85,21 +84,12 @@ class AppsService:
             if existing_key is not None:
                 raise ValueError('App key already exists')
 
-            if app_id is not None:
-                id_statement = select(App).where(App.id == app_id)
-                id_result = await session.execute(id_statement)
-                existing_id = id_result.scalar_one_or_none()
-                if existing_id is not None:
-                    raise ValueError('App id already exists')
-
             app_kwargs: dict[str, str] = {
                 'name': name,
                 'url': url,
                 'key': key,
                 'type': app_type,
             }
-            if app_id is not None:
-                app_kwargs['id'] = app_id
 
             app = App(**app_kwargs)
             session.add(app)

--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -9,18 +9,8 @@ class AppType(str, Enum):
 
 
 class AppCreate(BaseModel):
-    id: str | None = None
     key: str
     image: str
-
-    @field_validator("id", mode="before")
-    @classmethod
-    def normalize_id(cls, value: str | None) -> str | None:
-        """Normalize id by stripping whitespace and converting empty strings to None."""
-        if value is None:
-            return None
-        normalized = value.strip()
-        return normalized or None
 
     @field_validator("image", mode="before")
     @classmethod

--- a/api/src/pages/applications.xml
+++ b/api/src/pages/applications.xml
@@ -1,5 +1,5 @@
 <Page name="Applications" icon="blocks">
-  <State id="createApp" key="" image="" appId="">
+  <State id="createApp" key="" image="">
     <Hero
       title="Applications"
       subtitle="Manage applications available to your organization."
@@ -14,7 +14,6 @@
           </DialogDescription>
         </DialogHeader>
         <Stack gap="12">
-          <Input kind="text" label="App id (optional)" value="{createApp.appId}" placeholder="custom-app-id" />
           <Input kind="text" label="App key" value="{createApp.key}" placeholder="sampleapp" />
           <Input
             kind="text"
@@ -27,13 +26,11 @@
             action="/apps"
             method="POST"
             payload='{
-              "id": "{createApp.appId}",
               "key": "{createApp.key}",
               "image": "{createApp.image}"
             }'
             onSuccess="
               refetch(applications);
-              set(createApp.appId, '');
               set(createApp.key, '');
               set(createApp.image, '');
             "

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -33,11 +33,6 @@ async def create_app(payload: AppCreate) -> AppResponse:
     if existing_key is not None:
         raise HTTPException(status_code=409, detail="App key already exists")
 
-    if payload.id is not None:
-        existing_id = await db.apps.get_by_uuid(payload.id)
-        if existing_id is not None:
-            raise HTTPException(status_code=409, detail="App id already exists")
-
     namespace = env.ENV_PROVISION_COMPUTE_DEFAULT_NAMESPACE
     pod_name = f"{payload.key}-app".strip().lower()
 
@@ -62,7 +57,6 @@ async def create_app(payload: AppCreate) -> AppResponse:
             url=app_url,
             key=payload.key,
             app_type=metadata.type,
-            app_id=payload.id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc


### PR DESCRIPTION
### Motivation
- Simplify application creation by removing optional custom `id` handling and normalization from the model and API surface, consolidating ID generation to the backend.
- Remove redundant uniqueness checks and wiring for a user-provided `id` to reduce complexity and potential conflicts.

### Description
- Removed the `id` field and its `field_validator` from `AppCreate` in `api/src/models/apps.py` and adjusted related normalization logic.
- Updated `api/src/db/services/apps.py` to stop accepting `app_id` in `AppsService.create` and removed duplicate-`id` checks and assignment logic when creating an `App`.
- Updated the create app route in `api/src/routes/apps.py` to stop validating `payload.id` and to stop passing `app_id` into `db.apps.create`.
- Updated the UI page `api/src/pages/applications.xml` to remove the `createApp.appId` state, the input for custom App id, and the `id` property in the POST payload.

### Testing
- Ran the project test suite with `pytest` against the modified API and service layers and all tests passed.
- Verified API create flow and UI create payloads in automated integration tests and observed successful app creation without a user-supplied `id`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e555c1cfe0832385810aed6c32f215)