### PR TITLE
Fix create-application dialog state binding (app key)

### DIFF
--- a/api/src/pages/applications.xml
+++ b/api/src/pages/applications.xml
@@ -1,5 +1,5 @@
 <Page name="Applications" icon="blocks">
-  <State id="createApp" key="" image="">
+  <State id="createApp" appKey="" image="">
     <Hero
       title="Applications"
       subtitle="Manage applications available to your organization."
@@ -14,7 +14,7 @@
           </DialogDescription>
         </DialogHeader>
         <Stack gap="12">
-          <Input kind="text" label="App key" value="{createApp.key}" placeholder="sampleapp" />
+          <Input kind="text" label="App key" value="{createApp.appKey}" placeholder="sampleapp" />
           <Input
             kind="text"
             label="Image reference"
@@ -26,12 +26,12 @@
             action="/apps"
             method="POST"
             payload='{
-              "key": "{createApp.key}",
+              "key": "{createApp.appKey}",
               "image": "{createApp.image}"
             }'
             onSuccess="
               refetch(applications);
-              set(createApp.key, '');
+              set(createApp.appKey, '');
               set(createApp.image, '');
             "
           >


### PR DESCRIPTION
### Motivation
- The create-application dialog used a `key` state field that wasn't bound consistently, causing the POST to `/apps` to omit the app key and produce validation errors.

### Description
- Rename the dialog state field from `key` to `appKey` in `api/src/pages/applications.xml` and update the Input `value`, POST `payload`, and `set(...)` onSuccess bindings so the UI sends both `key` and `image` correctly.

### Testing
- Ran `make format` (which executes `isort` and JS formatters) and the formatting steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e558cc50608323bf59f27db9ba774a)