### PR TITLE
Handle compute API outages gracefully in app creation

### DIFF
--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -2,6 +2,7 @@ import src.db as db
 from fastapi import APIRouter, HTTPException
 from src.env import env
 from src.models.apps import AppType, AppCreate, AppMetadata, AppResponse
+from src.utils.compute import ComputeConnectionError
 
 router = APIRouter()
 
@@ -48,6 +49,11 @@ async def create_app(payload: AppCreate) -> AppResponse:
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ComputeConnectionError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Compute API is unavailable. Check compute service connectivity.",
+        ) from exc
 
     try:
         # Register the app immediately and let runtime metadata be resolved later.

--- a/api/src/utils/compute.py
+++ b/api/src/utils/compute.py
@@ -4,9 +4,14 @@ import re
 import asyncio
 from src.env import env
 from kubernetes import client
+from urllib3.exceptions import HTTPError
 from kubernetes.client.exceptions import ApiException
 
 _NAME_PATTERN = re.compile(r"^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$")
+
+
+class ComputeConnectionError(RuntimeError):
+    """Raised when the control plane cannot connect to the compute API."""
 
 
 async def create(
@@ -61,44 +66,47 @@ def _create_sync(
     with client.ApiClient(configuration) as api_client:
         core = client.CoreV1Api(api_client)
 
-        # Create namespace if it doesn't exist
         try:
-            core.read_namespace(name=namespace)
-        except ApiException as error:
-            if error.status != 404:
-                raise
-            core.create_namespace(
-                body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
+            # Create namespace if it doesn't exist
+            try:
+                core.read_namespace(name=namespace)
+            except ApiException as error:
+                if error.status != 404:
+                    raise
+                core.create_namespace(
+                    body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
+                )
+
+            # Check if pod already exists
+            try:
+                core.read_namespaced_pod(name=pod_name, namespace=namespace)
+                raise ValueError(
+                    f"Container '{pod_name}' already exists in namespace '{namespace}'"
+                )
+            except ApiException as error:
+                if error.status != 404:
+                    raise
+
+            # Build container spec with environment variables and optional port
+            container = client.V1Container(
+                name=pod_name,
+                image=image,
+                command=command,
+                args=args,
+                env=[
+                    client.V1EnvVar(name=name, value=value)
+                    for name, value in env_vars.items()
+                ],
+                ports=[client.V1ContainerPort(container_port=container_port)]
+                if container_port
+                else None,
             )
 
-        # Check if pod already exists
-        try:
-            core.read_namespaced_pod(name=pod_name, namespace=namespace)
-            raise ValueError(
-                f"Container '{pod_name}' already exists in namespace '{namespace}'"
+            pod = client.V1Pod(
+                metadata=client.V1ObjectMeta(name=pod_name, labels={"app": pod_name}),
+                spec=client.V1PodSpec(containers=[container], restart_policy="Always"),
             )
-        except ApiException as error:
-            if error.status != 404:
-                raise
 
-        # Build container spec with environment variables and optional port
-        container = client.V1Container(
-            name=pod_name,
-            image=image,
-            command=command,
-            args=args,
-            env=[
-                client.V1EnvVar(name=name, value=value)
-                for name, value in env_vars.items()
-            ],
-            ports=[client.V1ContainerPort(container_port=container_port)]
-            if container_port
-            else None,
-        )
-
-        pod = client.V1Pod(
-            metadata=client.V1ObjectMeta(name=pod_name, labels={"app": pod_name}),
-            spec=client.V1PodSpec(containers=[container], restart_policy="Always"),
-        )
-
-        core.create_namespaced_pod(namespace=namespace, body=pod)
+            core.create_namespaced_pod(namespace=namespace, body=pod)
+        except HTTPError as error:
+            raise ComputeConnectionError("Unable to reach compute API server") from error


### PR DESCRIPTION
### Motivation
- Creating an app could raise a 500 when the compute API endpoint was unreachable (connection refused), making the error unclear to callers. 
- The change aims to translate transport-level failures into an explicit, actionable `503 Service Unavailable` response so operators know the compute backend is down.

### Description
- Added a `ComputeConnectionError` exception in `api/src/utils/compute.py` and import of `urllib3.exceptions.HTTPError` to detect transport failures. 
- Converted low-level HTTP transport errors from the Kubernetes client into `ComputeConnectionError` in `_create_sync`. 
- Updated `POST /apps` in `api/src/routes/apps.py` to catch `ComputeConnectionError` and return `HTTP 503` with a clear operator-facing message. 
- Changes touch `api/src/utils/compute.py` and `api/src/routes/apps.py` only and keep existing validation/flow intact.

### Testing
- Ran `make format` which completed successfully. 
- Compiled the API with `cd api && uv run --python ../.venv/bin/python -m compileall src` which succeeded with no compile errors. 
- No new automated tests were added per project guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55c8617a883239c8b336355a0c3a8)