### PR TITLE
api: fallback to kubeconfig when compute proxy is unavailable

### DIFF
--- a/api/src/utils/compute.py
+++ b/api/src/utils/compute.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import re
 import asyncio
 from src.env import env
-from kubernetes import client
+from kubernetes import client, config
 from urllib3.exceptions import HTTPError
 from kubernetes.client.exceptions import ApiException
+from kubernetes.config.config_exception import ConfigException
 
 _NAME_PATTERN = re.compile(r"^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$")
 
@@ -57,56 +58,102 @@ def _create_sync(
     container_port: int | None,
 ) -> None:
     """Create namespace and pod using Kubernetes API (runs in thread)."""
+    # Try the explicit API server configuration first because deployments may
+    # provide a dedicated compute endpoint that should take precedence.
     configuration = client.Configuration()
     configuration.host = env.ENV_PROVISION_COMPUTE_API_SERVER_URL
     configuration.username = env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME
     configuration.password = env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD
     configuration.verify_ssl = env.ENV_PROVISION_COMPUTE_VERIFY_SSL
 
-    with client.ApiClient(configuration) as api_client:
-        core = client.CoreV1Api(api_client)
-
-        try:
-            # Create namespace if it doesn't exist
-            try:
-                core.read_namespace(name=namespace)
-            except ApiException as error:
-                if error.status != 404:
-                    raise
-                core.create_namespace(
-                    body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
-                )
-
-            # Check if pod already exists
-            try:
-                core.read_namespaced_pod(name=pod_name, namespace=namespace)
-                raise ValueError(
-                    f"Container '{pod_name}' already exists in namespace '{namespace}'"
-                )
-            except ApiException as error:
-                if error.status != 404:
-                    raise
-
-            # Build container spec with environment variables and optional port
-            container = client.V1Container(
-                name=pod_name,
+    try:
+        with client.ApiClient(configuration) as api_client:
+            _create_namespaced_pod(
+                api_client=api_client,
+                namespace=namespace,
+                pod_name=pod_name,
                 image=image,
                 command=command,
                 args=args,
-                env=[
-                    client.V1EnvVar(name=name, value=value)
-                    for name, value in env_vars.items()
-                ],
-                ports=[client.V1ContainerPort(container_port=container_port)]
-                if container_port
-                else None,
+                env_vars=env_vars,
+                container_port=container_port,
             )
+        return
+    except HTTPError:
+        pass
 
-            pod = client.V1Pod(
-                metadata=client.V1ObjectMeta(name=pod_name, labels={"app": pod_name}),
-                spec=client.V1PodSpec(containers=[container], restart_policy="Always"),
+    # Fall back to kubeconfig to support local development where the Kubernetes
+    # API may be reachable only through kubectl context instead of the proxy URL.
+    try:
+        config.load_kube_config()
+    except ConfigException as error:
+        raise ComputeConnectionError("Unable to reach compute API server") from error
+
+    try:
+        with client.ApiClient() as api_client:
+            _create_namespaced_pod(
+                api_client=api_client,
+                namespace=namespace,
+                pod_name=pod_name,
+                image=image,
+                command=command,
+                args=args,
+                env_vars=env_vars,
+                container_port=container_port,
             )
+    except HTTPError as error:
+        raise ComputeConnectionError("Unable to reach compute API server") from error
 
-            core.create_namespaced_pod(namespace=namespace, body=pod)
-        except HTTPError as error:
-            raise ComputeConnectionError("Unable to reach compute API server") from error
+
+def _create_namespaced_pod(
+    *,
+    api_client: client.ApiClient,
+    namespace: str,
+    pod_name: str,
+    image: str,
+    command: list[str] | None,
+    args: list[str] | None,
+    env_vars: dict[str, str],
+    container_port: int | None,
+) -> None:
+    """Create namespace and pod using a pre-configured Kubernetes API client."""
+    core = client.CoreV1Api(api_client)
+
+    # Create namespace lazily so first app deployment can bootstrap environment.
+    try:
+        core.read_namespace(name=namespace)
+    except ApiException as error:
+        if error.status != 404:
+            raise
+        core.create_namespace(
+            body=client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
+        )
+
+    # Prevent duplicate pod names to keep app key mapping stable.
+    try:
+        core.read_namespaced_pod(name=pod_name, namespace=namespace)
+        raise ValueError(
+            f"Container '{pod_name}' already exists in namespace '{namespace}'"
+        )
+    except ApiException as error:
+        if error.status != 404:
+            raise
+
+    # Build container and pod specs from request parameters.
+    container = client.V1Container(
+        name=pod_name,
+        image=image,
+        command=command,
+        args=args,
+        env=[client.V1EnvVar(name=name, value=value) for name, value in env_vars.items()],
+        ports=[client.V1ContainerPort(container_port=container_port)]
+        if container_port
+        else None,
+    )
+
+    pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(name=pod_name, labels={"app": pod_name}),
+        spec=client.V1PodSpec(containers=[container], restart_policy="Always"),
+    )
+
+    core.create_namespaced_pod(namespace=namespace, body=pod)


### PR DESCRIPTION
### Motivation
- Creating apps could return `503 Service Unavailable` when `ENV_PROVISION_COMPUTE_API_SERVER_URL` was not reachable, blocking local development with an existing `k3d` cluster.
- Allow provisioning to work with a local `kubectl` context (kubeconfig) when the configured proxy/compute URL is down.
- Preserve existing validation and duplicate-pod protections so control-plane semantics remain unchanged.

### Description
- Attempt the configured compute API server first and fall back to loading the local kubeconfig via `config.load_kube_config()` if the proxy call fails.
- Refactored the pod/namespace creation logic into a reusable helper `_create_namespaced_pod(...)` to avoid duplication across connection strategies.
- Added handling for `ConfigException` and maintained raising `ComputeConnectionError` when the compute API cannot be reached.
- Kept name validation and duplicate-pod checks and retained the same pod spec construction and creation behavior.

### Testing
- Ran `make format`, which completed successfully.
- Compiled the updated module with `cd api && uv run --python ../.venv/bin/python -m compileall src/utils/compute.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55dde930083238c6cc6803b3f75ca)