### PR TITLE
chore: isolate api and sdk uv environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
 .PHONY: up down format build api web sample docs
 
 install:
-	test -d .venv || uv venv .venv
-	uv pip install --python .venv/bin/python -e './api[dev]'
-	uv pip install --python .venv/bin/python -e './sdk'
+	cd api && uv sync
+	cd sdk && uv sync
 	bun install --cwd web
 	bun install --cwd docs
 
 
 format: install
-	cd api && uv run --python ../.venv/bin/python isort .
-	cd sdk && uv run --python ../.venv/bin/python isort .
+	cd api && uv run isort .
+	cd sdk && uv run isort .
 	bun run --cwd web format
 	cd web && bunx prettier --write $$(git -C .. ls-files '*.md' '*.yml' '*.yaml' | sed 's#^#../#')
 


### PR DESCRIPTION
### Motivation
- Isolate Python environments per subproject so `api/` and `sdk/` manage their own dependencies and avoid a shared root `.venv`, matching the per-folder install model.

### Description
- Update `Makefile` `install` to run `cd api && uv sync` and `cd sdk && uv sync`, remove the shared root `.venv` flow, and change `format` to run `cd api && uv run isort .` and `cd sdk && uv run isort .`.

### Testing
- Ran `make format`, which executed the updated `install` flow and formatting steps successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fda4ed3083239fa84dcb39f2eeac)