### PR TITLE
Add endpoint to list active cluster containers with app detection

### DIFF
--- a/api/src/db/services/computes.py
+++ b/api/src/db/services/computes.py
@@ -15,6 +15,7 @@ class ComputesService:
         env_vars: dict[str, str],
         container_port: int | None,
     ) -> None:
+        """Create a new container workload in the configured compute cluster."""
         await compute.create(
             namespace=namespace,
             pod_name=pod_name,
@@ -24,3 +25,9 @@ class ComputesService:
             env_vars=env_vars,
             container_port=container_port,
         )
+
+    async def list_active_containers(
+        self, *, namespace: str | None = None
+    ) -> list[dict[str, object]]:
+        """List active containers from the compute cluster."""
+        return await compute.list_active_containers(namespace=namespace)

--- a/api/src/models/computes.py
+++ b/api/src/models/computes.py
@@ -30,3 +30,13 @@ class ComputeContainerCreateResponse(BaseModel):
     pod_name: str
     image: str
     status: str = 'created'
+
+
+class ActiveContainer(BaseModel):
+    namespace: str
+    pod_name: str
+    phase: str
+    images: list[str]
+    is_app: bool
+    app_id: str | None = None
+    app_key: str | None = None

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException
 from src.env import env
 from src.models.apps import AppType, AppCreate, AppMetadata, AppResponse
 from src.utils.compute import ComputeConnectionError
+from src.models.computes import ActiveContainer
 
 router = APIRouter()
 
@@ -18,6 +19,36 @@ async def list_apps(type: AppType | None = None) -> list[AppResponse]:
     return [
         AppResponse(id=app.id, name=app.name, url=app.url, type=app.type)
         for app in registered_apps
+    ]
+
+
+@router.get("/apps/containers")
+async def list_active_containers(namespace: str | None = None) -> list[ActiveContainer]:
+    """List active cluster containers and flag which ones belong to registered apps."""
+    app_registry = await db.apps.list()
+    app_by_pod_name = {f"{app.key}-app": app for app in app_registry}
+
+    try:
+        containers = await db.computes.list_active_containers(namespace=namespace)
+    except ComputeConnectionError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Compute API is unavailable. Check compute service connectivity.",
+        ) from exc
+
+    # Mark each active pod as app or non-app using current app-to-pod naming model.
+    return [
+        ActiveContainer(
+            namespace=str(container["namespace"]),
+            pod_name=str(container["pod_name"]),
+            phase=str(container["phase"]),
+            images=[str(image) for image in container["images"]],
+            is_app=matched_app is not None,
+            app_id=matched_app.id if matched_app else None,
+            app_key=matched_app.key if matched_app else None,
+        )
+        for container in containers
+        for matched_app in [app_by_pod_name.get(str(container["pod_name"]))]
     ]
 
 

--- a/api/src/utils/compute.py
+++ b/api/src/utils/compute.py
@@ -9,6 +9,7 @@ from kubernetes.client.exceptions import ApiException
 from kubernetes.config.config_exception import ConfigException
 
 _NAME_PATTERN = re.compile(r"^[a-z0-9]([-.a-z0-9]{0,61}[a-z0-9])?$")
+_ACTIVE_PHASES = {"Pending", "Running"}
 
 
 class ComputeConnectionError(RuntimeError):
@@ -46,6 +47,11 @@ async def create(
         env_vars,
         container_port,
     )
+
+
+async def list_active_containers(namespace: str | None = None) -> list[dict[str, object]]:
+    """List active Kubernetes pods and their container images."""
+    return await asyncio.to_thread(_list_active_containers_sync, namespace)
 
 
 def _create_sync(
@@ -103,6 +109,69 @@ def _create_sync(
             )
     except HTTPError as error:
         raise ComputeConnectionError("Unable to reach compute API server") from error
+
+
+def _list_active_containers_sync(namespace: str | None) -> list[dict[str, object]]:
+    """Collect active pod details from Kubernetes using available connection options."""
+    # Try explicit compute endpoint first to honor control-plane configuration.
+    configuration = client.Configuration()
+    configuration.host = env.ENV_PROVISION_COMPUTE_API_SERVER_URL
+    configuration.username = env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME
+    configuration.password = env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD
+    configuration.verify_ssl = env.ENV_PROVISION_COMPUTE_VERIFY_SSL
+
+    try:
+        with client.ApiClient(configuration) as api_client:
+            return _list_active_pods(api_client=api_client, namespace=namespace)
+    except HTTPError:
+        pass
+
+    # Fall back to local kubeconfig to support k3d and other local clusters.
+    try:
+        config.load_kube_config()
+    except ConfigException as error:
+        raise ComputeConnectionError("Unable to reach compute API server") from error
+
+    try:
+        with client.ApiClient() as api_client:
+            return _list_active_pods(api_client=api_client, namespace=namespace)
+    except HTTPError as error:
+        raise ComputeConnectionError("Unable to reach compute API server") from error
+
+
+def _list_active_pods(
+    *,
+    api_client: client.ApiClient,
+    namespace: str | None,
+) -> list[dict[str, object]]:
+    """Return active pods from a namespace or all namespaces for a configured API client."""
+    core = client.CoreV1Api(api_client)
+
+    # Query either a specific namespace or all namespaces based on caller input.
+    if namespace:
+        pod_list = core.list_namespaced_pod(namespace=namespace)
+    else:
+        pod_list = core.list_pod_for_all_namespaces()
+
+    active_containers: list[dict[str, object]] = []
+
+    # Keep only active phases so terminated workloads are excluded from UI views.
+    for pod in pod_list.items:
+        pod_phase = pod.status.phase if pod.status and pod.status.phase else "Unknown"
+        if pod_phase not in _ACTIVE_PHASES:
+            continue
+
+        pod_images = [container.image for container in pod.spec.containers or []]
+        active_containers.append(
+            {
+                "namespace": pod.metadata.namespace or "",
+                "pod_name": pod.metadata.name or "",
+                "phase": pod_phase,
+                "images": pod_images,
+            }
+        )
+
+    return active_containers
 
 
 def _create_namespaced_pod(


### PR DESCRIPTION
### Motivation
- Provide the web UI and control plane a way to enumerate active cluster pods and determine which pods are platform apps using the existing naming model.
- Support local development clusters (k3d) and production compute endpoints by using either configured API-server access or kubeconfig fallback.

### Description
- Added a `GET /apps/containers` route that returns a typed list of `ActiveContainer` entries and flags whether each pod belongs to a registered app using the `<app-key>-app` naming convention.
- Introduced `ActiveContainer` Pydantic model in `api/src/models/computes.py` to represent container metadata and ownership fields (`is_app`, `app_id`, `app_key`).
- Extended compute utilities in `api/src/utils/compute.py` with `list_active_containers` which discovers active pods (phases `Pending`/`Running`) and supports both explicit API-server configuration and kubeconfig fallback.
- Exposed `list_active_containers` via the compute service in `api/src/db/services/computes.py` so routes can call through the service layer.

### Testing
- Ran `make format` from repository root which completed successfully.
- Ran the unit test `tests/utils/test_compute.py` via `cd api && uv run --python ../.venv/bin/python pytest tests/utils/test_compute.py`, which failed during collection due to the test environment missing the `pydantic_settings` dependency (failure unrelated to implemented logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fe7434688323aa2da5a0ada062ae)