### PR TITLE
Fix sample app dependency to use local SDK package

### DIFF
--- a/sdk/sample/pyproject.toml
+++ b/sdk/sample/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
   "uvicorn",
 ]
 
+[tool.uv.sources]
+longlink = { path = ".." }
+
 [project.optional-dependencies]
 dev = [
   "pytest",


### PR DESCRIPTION
### Motivation
- The sample app was resolving an external `longlink` package which caused a runtime mismatch (`ImportError: cannot import name 'Router' from 'longlink'`); the intent is to force `uv` to install the in-repo SDK so the sample imports the correct symbols.

### Description
- Add a `tool.uv.sources` entry to `sdk/sample/pyproject.toml` with `longlink = { path = ".." }` so the sample resolves the local SDK while keeping `longlink` listed as a dependency.

### Testing
- Ran `make format`, ran `cd sdk/sample && uv run python -c "from longlink import Router, Context; print('ok')"`, and started `cd sdk/sample && uv run longlink dev` to validate startup; all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6015cda8483238a699347b21dde1f)