### PR TITLE
fix(vscode): add root workspace Python interpreter pointing to api venv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/api/.venv/bin/python",
+  "python.terminal.activateEnvironment": true
+}


### PR DESCRIPTION
### Motivation
- Opening the monorepo root does not pick up `api/.vscode` settings so VS Code prompts for an interpreter, so a root `.vscode/settings.json` is needed to make the editor detect the `api` virtualenv.

### Description
- Add `.vscode/settings.json` that sets `python.defaultInterpreterPath` to `${workspaceFolder}/api/.venv/bin/python` and enables `python.terminal.activateEnvironment` so integrated terminals activate the selected environment.

### Testing
- Ran `make format` from the repository root as required and the formatting/sync steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e602bc4d8c8323a2d5b6f7d08f590b)