### PR TITLE
Remove app type from API and SDK metadata

### DIFF
--- a/api/src/db/models/apps.py
+++ b/api/src/db/models/apps.py
@@ -13,7 +13,6 @@ class App(Base, table=True):
     url: str = Field(unique=True, max_length=255)
     name: str = Field(max_length=100)
     key: str = Field(unique=True, max_length=64)
-    type: str = Field(default='tool', max_length=16)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(
         default_factory=datetime.utcnow,

--- a/api/src/db/services/apps.py
+++ b/api/src/db/services/apps.py
@@ -15,15 +15,6 @@ class AppsService:
             result = await session.execute(statement)
             return list(result.scalars().all())
 
-    async def list_by_type(self, app_type: str) -> list[App]:
-        '''Return all registered apps matching a type.'''
-
-        Session = await get_session()
-        async with Session() as session:
-            statement = select(App).where(App.type == app_type)
-            result = await session.execute(statement)
-            return list(result.scalars().all())
-
     async def get_by_uuid(self, app_uuid: str) -> App | None:
         '''Return a registered app by UUID.'''
 
@@ -65,7 +56,6 @@ class AppsService:
         name: str,
         url: str,
         key: str,
-        app_type: str,
     ) -> App:
         '''Add a new app to the database.'''
 
@@ -88,7 +78,6 @@ class AppsService:
                 'name': name,
                 'url': url,
                 'key': key,
-                'type': app_type,
             }
 
             app = App(**app_kwargs)

--- a/api/src/models/apps.py
+++ b/api/src/models/apps.py
@@ -1,11 +1,4 @@
-from enum import Enum
 from pydantic import BaseModel, field_validator
-
-
-class AppType(str, Enum):
-    tool = "tool"
-    space = "space"
-    process = "process"
 
 
 class AppCreate(BaseModel):
@@ -19,13 +12,7 @@ class AppCreate(BaseModel):
         return value.strip()
 
 
-class AppMetadata(BaseModel):
-    name: str
-    type: AppType = AppType.tool
-
-
 class AppResponse(BaseModel):
     id: str
     name: str
     url: str
-    type: AppType

--- a/api/src/pages/applications.xml
+++ b/api/src/pages/applications.xml
@@ -47,7 +47,6 @@
           <TableRow>
             <TableHead>Name</TableHead>
             <TableHead>URL</TableHead>
-            <TableHead>Type</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -55,7 +54,6 @@
             <TableRow>
               <TableCell>{application.name}</TableCell>
               <TableCell>{application.url}</TableCell>
-              <TableCell>{application.type}</TableCell>
             </TableRow>
           </For>
         </TableBody>

--- a/api/src/routes/apps.py
+++ b/api/src/routes/apps.py
@@ -1,7 +1,7 @@
 import src.db as db
 from fastapi import APIRouter, HTTPException
 from src.env import env
-from src.models.apps import AppType, AppCreate, AppMetadata, AppResponse
+from src.models.apps import AppCreate, AppResponse
 from src.utils.compute import ComputeConnectionError
 from src.models.computes import ActiveContainer
 
@@ -9,15 +9,12 @@ router = APIRouter()
 
 
 @router.get("/apps")
-async def list_apps(type: AppType | None = None) -> list[AppResponse]:
-    """List registered apps, optionally filtered by type."""
-    if type is not None:
-        registered_apps = await db.apps.list_by_type(type)
-    else:
-        registered_apps = await db.apps.list()
+async def list_apps() -> list[AppResponse]:
+    """List registered apps."""
+    registered_apps = await db.apps.list()
 
     return [
-        AppResponse(id=app.id, name=app.name, url=app.url, type=app.type)
+        AppResponse(id=app.id, name=app.name, url=app.url)
         for app in registered_apps
     ]
 
@@ -88,14 +85,12 @@ async def create_app(payload: AppCreate) -> AppResponse:
 
     try:
         # Register the app immediately and let runtime metadata be resolved later.
-        metadata = AppMetadata(name=payload.key, type=AppType.tool)
         app = await db.apps.create(
-            metadata.name,
+            payload.key,
             url=app_url,
             key=payload.key,
-            app_type=metadata.type,
         )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    return AppResponse(id=app.id, name=app.name, url=app.url, type=app.type)
+    return AppResponse(id=app.id, name=app.name, url=app.url)

--- a/api/tests/routes/test_apps_routes.py
+++ b/api/tests/routes/test_apps_routes.py
@@ -2,18 +2,6 @@ import pytest
 from types import SimpleNamespace
 
 
-class _FakeHttpResponse:
-    def __init__(self, payload: dict, status_code: int = 200):
-        """Store fake upstream response payload and status code."""
-        self._payload = payload
-        self.status_code = status_code
-        self.is_success = 200 <= status_code < 300
-
-    def json(self) -> dict:
-        """Return stored JSON payload."""
-        return self._payload
-
-
 @pytest.mark.unit
 def test_list_apps_returns_app_responses(client, monkeypatch):
     """List apps route returns mapped app payloads from database service."""
@@ -22,8 +10,8 @@ def test_list_apps_returns_app_responses(client, monkeypatch):
     async def fake_list():
         """Return two fake apps for list endpoint."""
         return [
-            SimpleNamespace(id="1", name="One", url="https://one", type="tool"),
-            SimpleNamespace(id="2", name="Two", url="https://two", type="space"),
+            SimpleNamespace(id="1", name="One", url="https://one"),
+            SimpleNamespace(id="2", name="Two", url="https://two"),
         ]
 
     monkeypatch.setattr(apps_routes.db.apps, "list", fake_list)
@@ -32,56 +20,37 @@ def test_list_apps_returns_app_responses(client, monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == [
-        {"id": "1", "name": "One", "url": "https://one", "type": "tool"},
-        {"id": "2", "name": "Two", "url": "https://two", "type": "space"},
+        {"id": "1", "name": "One", "url": "https://one"},
+        {"id": "2", "name": "Two", "url": "https://two"},
     ]
 
 
 @pytest.mark.unit
 def test_create_app_registers_metadata_and_returns_app(client, monkeypatch):
-    """Create app route fetches metadata, persists app, triggers org sync."""
+    """Create app route persists app with generated localhost URL."""
     from src.routes import apps as apps_routes
 
     created = {}
 
-    async def fake_raw(url: str, method: str):
-        """Return valid metadata payload for app registration."""
-        created["metadata_url"] = url
-        created["method"] = method
-        return _FakeHttpResponse({"name": "Calendar", "type": "tool"})
-
-    async def fake_create(name: str, url: str, key: str, app_type: str, app_id: str | None):
+    async def fake_create(name: str, url: str, key: str):
         """Persist fake app and return created object."""
         created["create_args"] = {
             "name": name,
             "url": url,
             "key": key,
-            "app_type": app_type,
-            "app_id": app_id,
         }
-        return SimpleNamespace(id="app-1", name=name, url=url, type=app_type)
+        return SimpleNamespace(id="app-1", name=name, url=url)
 
-    async def fake_org(app_id: str):
-        """Capture organization sync app id."""
-        created["org_app_id"] = app_id
-
-    monkeypatch.setattr(apps_routes.apps, "raw", fake_raw)
     monkeypatch.setattr(apps_routes.db.apps, "create", fake_create)
-    monkeypatch.setattr(apps_routes.apps, "org", fake_org)
 
     response = client.post(
         "/apps",
-        json={"id": " external-id ", "url": "example.com/", "key": "k-1"},
+        json={"key": "k-1", "image": "local/test:latest"},
     )
 
     assert response.status_code == 200
     assert response.json() == {
         "id": "app-1",
-        "name": "Calendar",
-        "url": "https://example.com",
-        "type": "tool",
+        "name": "k-1",
+        "url": "http://k-1.localhost",
     }
-    assert created["metadata_url"] == "https://example.com/metadata.json"
-    assert created["method"] == "GET"
-    assert created["create_args"]["app_id"] == "external-id"
-    assert created["org_app_id"] == "app-1"

--- a/sdk/longlink/utils/metadata.py
+++ b/sdk/longlink/utils/metadata.py
@@ -1,6 +1,6 @@
 import os
 import tomllib
-from typing import Any, Literal
+from typing import Any
 from pathlib import Path
 from pydantic import BaseModel, model_validator
 
@@ -16,7 +16,6 @@ class Metadata(BaseModel):
     terms_of_service: str | None = None
     contact: dict[str, Any] | None = None
     license_info: dict[str, Any] | None = None
-    apptype: Literal["tool", "space", "process"] = "tool"
 
     @model_validator(mode="before")
     @classmethod
@@ -50,7 +49,6 @@ class Metadata(BaseModel):
                     "terms_of_service": tool_data.get("terms_of_service") or result["terms_of_service"],
                     "contact": tool_data.get("contact") or result["contact"],
                     "license_info": tool_data.get("license_info") or result["license_info"],
-                    "apptype": tool_data.get("apptype") or result["apptype"],
                 }
             )
 

--- a/sdk/sample/pyproject.toml
+++ b/sdk/sample/pyproject.toml
@@ -40,8 +40,6 @@ testpaths = ["tests"]
 pythonpath = ["."]
 
 [tool.longlink]
-apptype = "tool"
-
 
 [tool.isort]
 from_first = false

--- a/sdk/tests/utils/test_metadata.py
+++ b/sdk/tests/utils/test_metadata.py
@@ -43,7 +43,6 @@ description = "Demo description"
     assert metadata.name == "demo-app"
     assert metadata.version == "1.2.3"
     assert metadata.description == "Demo description"
-    assert metadata.apptype == "tool"
 
 
 def test_load_metadata_prefers_tool_longlink_section(tmp_path):
@@ -61,7 +60,6 @@ version = "0.0.1"
 [tool.longlink]
 name = "tool-name"
 version = "9.9.9"
-apptype = "process"
 """.strip()
     )
 
@@ -69,7 +67,6 @@ apptype = "process"
 
     assert metadata.name == "tool-name"
     assert metadata.version == "9.9.9"
-    assert metadata.apptype == "process"
 
 
 def test_load_metadata_accepts_explicit_overrides(tmp_path):
@@ -86,7 +83,6 @@ version = "0.0.1"
 """.strip()
     )
 
-    metadata = module.load_metadata(pyproject, name="override-name", apptype="space")
+    metadata = module.load_metadata(pyproject, name="override-name")
 
     assert metadata.name == "override-name"
-    assert metadata.apptype == "space"


### PR DESCRIPTION
### Motivation
- Simplify application model by removing the `type`/`apptype` concept from both control-plane API and SDK metadata to reduce surface area and deprecated flows.
- Align UI, persistence, and SDK metadata loading with the updated model that no longer tracks or filters on an app type.

### Description
- Removed `AppType` enum and `type`/`apptype` fields from API Pydantic schemas and SDK `Metadata` model (`api/src/models/apps.py`, `sdk/longlink/utils/metadata.py`).
- Simplified apps routes and DB service to stop accepting, filtering, or persisting an app type (updated `list`/`create` flows and removed `list_by_type` and `app_type` plumbing) (`api/src/routes/apps.py`, `api/src/db/services/apps.py`).
- Removed `type` column from DB model and stopped rendering the Type column in the applications page XML (`api/src/db/models/apps.py`, `api/src/pages/applications.xml`).
- Removed `apptype` from sample project config and updated unit tests to reflect the new model (`sdk/sample/pyproject.toml`, `sdk/tests/utils/test_metadata.py`, `api/tests/routes/test_apps_routes.py`).
- Ran repository formatting as part of the change (`make format`).

### Testing
- Ran `make format` successfully. 
- Ran SDK unit tests with `cd sdk && uv run pytest tests/utils/test_metadata.py` and they passed. 
- Attempted to run API route tests with `cd api && uv run pytest tests/routes/test_apps_routes.py` but the test run fails at import time in this environment with a Pydantic/SQLModel error: `Field 'id' requires a type annotation` (prevents executing the API tests end-to-end in CI-like environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e613f6acfc83239dd7a9d9406e4396)