### PR TITLE
Refactor API /pages routes to use Page utility with xmltodict

### DIFF
--- a/api/src/routes/pages.py
+++ b/api/src/routes/pages.py
@@ -1,10 +1,9 @@
-import xmltodict
 from typing import List
 from fastapi import APIRouter, HTTPException
 from pathlib import Path
 from pydantic import BaseModel
+from src.utils.page import Page
 from fastapi.responses import Response
-from xml.parsers.expat import ExpatError
 
 router = APIRouter()
 
@@ -18,27 +17,6 @@ class PageInfo(BaseModel):
     icon: str = "file-text"
 
 
-def parse_page_attributes(xml_content: str) -> dict[str, str]:
-    """Extract normalized attributes from root <Page> tag."""
-    try:
-        parsed_xml = xmltodict.parse(xml_content)
-    except ExpatError:
-        return {}
-
-    page_node = parsed_xml.get("Page")
-    if not isinstance(page_node, dict):
-        return {}
-
-    # Normalize root attribute names from xmltodict keys like @name, @icon.
-    attributes: dict[str, str] = {}
-    for key, value in page_node.items():
-        if not key.startswith("@") or not isinstance(value, str):
-            continue
-        attributes[key.removeprefix("@").lower()] = value
-
-    return attributes
-
-
 def get_all_pages() -> List[PageInfo]:
     """Scan pages directory and return metadata for each XML page."""
     pages: List[PageInfo] = []
@@ -48,12 +26,12 @@ def get_all_pages() -> List[PageInfo]:
     page_order = ["applications"]
 
     for page_file in sorted(PAGES_DIR.glob("*.xml")):
-        attrs = parse_page_attributes(page_file.read_text(encoding="utf-8"))
+        page = Page(page_file)
         pages.append(
             PageInfo(
-                name=attrs.get("name", page_file.stem.replace("-", " ").title()),
+                name=page.metadata.get("name", page_file.stem.replace("-", " ").title()),
                 path=page_file.stem,
-                icon=attrs.get("icon", "file-text"),
+                icon=page.metadata.get("icon", "file-text"),
             )
         )
 
@@ -88,7 +66,5 @@ async def get_page(page_name: str) -> Response:
     if not page_path.is_file() or page_path.parent != PAGES_DIR.resolve():
         raise HTTPException(status_code=404, detail="Page not found")
 
-    return Response(
-        content=page_path.read_text(encoding="utf-8"),
-        media_type="application/xml",
-    )
+    page = Page(page_path)
+    return Response(content=page.content, media_type="application/xml")

--- a/api/src/utils/page.py
+++ b/api/src/utils/page.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import xmltodict
+from typing import Any
+from pathlib import Path
+from xml.parsers.expat import ExpatError
+
+
+class Page:
+    """Load and parse XML page definitions stored on disk."""
+
+    def __init__(self, path: str | Path) -> None:
+        """Initialize page helper with a file path."""
+        self.path = Path(path)
+        self._content: str | None = None
+        self._schema: dict[str, Any] | None = None
+
+    @property
+    def content(self) -> str:
+        """Return raw XML content."""
+        if self._content is None:
+            with self.path.open("r", encoding="utf-8") as file:
+                self._content = file.read()
+        return self._content
+
+    @property
+    def schema(self) -> dict[str, Any]:
+        """Return parsed XML schema using xmltodict."""
+        if self._schema is None:
+            try:
+                self._schema = xmltodict.parse(self.content)
+            except ExpatError:
+                self._schema = {}
+        return self._schema
+
+    @property
+    def metadata(self) -> dict[str, str]:
+        """Extract normalized metadata from the root <Page> element."""
+        page_node = self.schema.get("Page")
+        if not isinstance(page_node, dict):
+            return {}
+
+        metadata: dict[str, str] = {}
+
+        # Normalize root attributes from xmltodict keys such as @name and @icon.
+        for key, value in page_node.items():
+            if not key.startswith("@") or not isinstance(value, str):
+                continue
+            normalized_value = value.strip()
+            if not normalized_value:
+                continue
+            metadata[key.removeprefix("@").lower()] = normalized_value
+
+        return metadata


### PR DESCRIPTION
### Motivation
- Centralize XML page parsing and metadata extraction into a reusable utility following the SDK pattern to reduce duplication and improve robustness.
- Ensure XML parsing uses `xmltodict` with safe handling of malformed documents so the control plane can list and serve page definitions reliably.

### Description
- Add `api/src/utils/page.py` which provides a `Page` helper that loads raw XML, parses the document via `xmltodict`, handles parse errors, and exposes normalized root metadata via `metadata`.
- Update `api/src/routes/pages.py` to use the `Page` helper for listing pages and serving page content, replacing the previous inline `parse_page_attributes` logic.
- Preserve existing page name normalization and path safety checks and keep responses as `application/xml` for the `GET /pages` and `GET /pages/{page_name}` endpoints.

### Testing
- Ran repository formatting via `make format` which completed successfully and fixed import ordering and formatting issues.
- No automated unit tests were added or modified as per contributing guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e615b7b0ac83239fb3f17ab43ebf67)