### PR TITLE
Use hidden `.static` directory for bundled frontend assets

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 COPY api /app
 RUN pip install --no-cache-dir .
-COPY --from=web-builder /api/static /app/static
+COPY --from=web-builder /api/.static /app/.static
 
 EXPOSE 8000
 

--- a/api/main.py
+++ b/api/main.py
@@ -49,7 +49,7 @@ app.add_middleware(
 for router in routers:
     app.include_router(router)
 
-static_dir = Path(__file__).resolve().parent / "static"
+static_dir = Path(__file__).resolve().parent / ".static"
 if static_dir.exists():
     app.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
 

--- a/sdk/longlink/app.py
+++ b/sdk/longlink/app.py
@@ -55,7 +55,7 @@ class LongLink(FastAPI):
             self.include_router(router)
 
         # Mount static files after API routes so `/pages` and other SDK endpoints stay reachable.
-        static_dir = Path(__file__).resolve().parent / "static"
+        static_dir = Path(__file__).resolve().parent / ".static"
         if static_dir.exists():
             self.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
             

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,13 +7,9 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '');
 
     const isSdkBuild = mode === 'sdk';
-    const isApiBuild = mode === 'api';
-
     const buildOutDir = isSdkBuild
-        ? path.resolve(__dirname, '../sdk/longlink/static')
-        : isApiBuild
-          ? path.resolve(__dirname, '../api/static')
-          : path.resolve(__dirname, './dist');
+        ? path.resolve(__dirname, '../sdk/longlink/.static')
+        : path.resolve(__dirname, '../api/.static');
 
     const devServerPort = env.VITE_DEV_PORT ? parseInt(env.VITE_DEV_PORT) : 5173;
 


### PR DESCRIPTION
### Motivation
- Align frontend build output with a hidden directory convention and ensure the backend and SDK load the same artifact path.
- Simplify `vite` build routing so SDK and API builds consistently write to application static roots.

### Description
- Change the static assets directory from `static` to hidden `.static` in the API runtime by updating `api/main.py` and the `Dockerfile` copy path to use `.static`.
- Update the SDK FastAPI app in `sdk/longlink/app.py` to mount `.static` instead of `static` for serving the SPA files.
- Update `web/vite.config.ts` to emit builds into `../sdk/longlink/.static` for SDK mode and `../api/.static` for API mode and remove the unused `isApiBuild` branch.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6167edb7083238ec67ef25f2a4c3e)