### PR TITLE
Improve PostgreSQL database creation flow

### DIFF
--- a/api/src/utils/database.py
+++ b/api/src/utils/database.py
@@ -1,7 +1,11 @@
 import asyncio
 import psycopg2
 from src.env import env
-from psycopg2 import sql
+from psycopg2 import sql, errors
+
+
+class DatabaseAlreadyExistsError(ValueError):
+    """Raised when trying to create a database that already exists."""
 
 
 async def create(database_name: str) -> None:
@@ -21,20 +25,15 @@ def _create_sync(database_name: str) -> None:
     if env.ENV_PROVISION_DATABASE_SSLMODE:
         connection_kwargs["sslmode"] = env.ENV_PROVISION_DATABASE_SSLMODE
 
-    admin_connection = psycopg2.connect(**connection_kwargs)
     try:
-        admin_connection.autocommit = True
-        with admin_connection.cursor() as cursor:
-            # Guard against duplicate DB names before CREATE DATABASE.
-            cursor.execute(
-                "SELECT 1 FROM pg_database WHERE datname = %s", (database_name,)
-            )
-            if cursor.fetchone() is not None:
-                raise ValueError(f"Database '{database_name}' already exists")
-
-            # Use SQL identifier escaping to prevent injection in DB name.
-            cursor.execute(
-                sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name))
-            )
-    finally:
-        admin_connection.close()
+        with psycopg2.connect(**connection_kwargs) as admin_connection:
+            admin_connection.autocommit = True
+            with admin_connection.cursor() as cursor:
+                # Use SQL identifier escaping to prevent injection in DB name.
+                cursor.execute(
+                    sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name))
+                )
+    except errors.DuplicateDatabase as error:
+        raise DatabaseAlreadyExistsError(
+            f"Database '{database_name}' already exists"
+        ) from error


### PR DESCRIPTION
### Motivation
- Remove a race condition introduced by a pre-check before creating a database by relying on the database server to signal duplicates.  
- Make connection and cursor lifecycle handling more idiomatic and robust using context managers.  
- Provide tighter error classification for duplicate-database cases instead of raising a generic `ValueError`.

### Description
- Removed the `SELECT ... FROM pg_database` pre-check and now attempt `CREATE DATABASE` directly using `sql.Identifier(database_name)` to keep name escaping.  
- Switched to context-managed connection and cursor usage with `with psycopg2.connect(...) as admin_connection:` and set `admin_connection.autocommit = True` for the `CREATE DATABASE` call.  
- Added `DatabaseAlreadyExistsError` and map `psycopg2.errors.DuplicateDatabase` to this specific exception for clearer error handling.  
- Updated imports to include `psycopg2.errors` and cleaned up resource management in `api/src/utils/database.py`.

### Testing
- Ran `make format` from the repository root and it completed successfully.  
- No additional automated tests were added per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e622532e3483239b252085d2e51ce5)