### PR TITLE
Fix sample Docker build with local longlink path dependency

### DIFF
--- a/sdk/longlink/cli/build.py
+++ b/sdk/longlink/cli/build.py
@@ -1,5 +1,7 @@
+import os
 import json
 import click
+import tomllib
 import subprocess
 from pathlib import Path
 from datetime import UTC, datetime
@@ -7,9 +9,9 @@ from longlink.utils.metadata import load_metadata
 
 DOCKERFILE_TEMPLATE = """FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 
-WORKDIR /app
+WORKDIR {workdir}
 
-COPY . .
+COPY . /workspace
 
 RUN uv sync --frozen
 
@@ -23,27 +25,58 @@ def create_version() -> str:
     return datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
 
 
-def build_app(base_path: Path | None = None) -> tuple[Path, Path, str, str]:
+def resolve_docker_paths(root: Path) -> tuple[Path, str]:
+    """Resolve Docker build context and in-container working directory."""
+
+    # Read local uv source paths so Docker context includes editable dependencies.
+    pyproject = root / "pyproject.toml"
+    pyproject_data = tomllib.loads(pyproject.read_text())
+    uv_sources = pyproject_data.get("tool", {}).get("uv", {}).get("sources", {})
+
+    source_paths: list[Path] = [root]
+    for source_config in uv_sources.values():
+        if isinstance(source_config, dict) and "path" in source_config:
+            source_paths.append((root / source_config["path"]).resolve())
+
+    # Use a shared build context so relative source paths remain valid in container.
+    common_root = Path(os.path.commonpath(source_paths))
+    workdir = "/workspace"
+    if root != common_root:
+        relative_root = root.relative_to(common_root)
+        workdir = f"/workspace/{relative_root.as_posix()}"
+
+    return common_root, workdir
+
+
+def render_dockerfile(workdir: str) -> str:
+    """Render Dockerfile content for a specific in-container workdir."""
+
+    return DOCKERFILE_TEMPLATE.format(workdir=workdir)
+
+
+def build_app(base_path: Path | None = None) -> tuple[Path, Path, str, str, Path]:
     """Create Dockerfile and deployment manifest for current app."""
 
     root = (base_path or Path.cwd()).resolve()
     version = create_version()
     metadata = load_metadata(root / "pyproject.toml")
+    build_context, workdir = resolve_docker_paths(root)
 
     dockerfile_path = root / "Dockerfile"
-    dockerfile_path.write_text(DOCKERFILE_TEMPLATE)
+    dockerfile_path.write_text(render_dockerfile(workdir))
 
     manifest = {
         "version": version,
         "generated_at": datetime.now(UTC).isoformat(),
         "dockerfile": dockerfile_path.name,
+        "build_context": str(build_context),
         "metadata": metadata.model_dump(),
     }
 
     manifest_path = root / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
 
-    return dockerfile_path, manifest_path, version, metadata.name
+    return dockerfile_path, manifest_path, version, metadata.name, build_context
 
 
 def build_image_tag(image_name: str, version: str, registry: str) -> str:
@@ -54,11 +87,14 @@ def build_image_tag(image_name: str, version: str, registry: str) -> str:
     return f"{normalized_registry}/{normalized_name}:{version}"
 
 
-def run_docker_build(root: Path, image_tag: str) -> None:
+def run_docker_build(dockerfile_path: Path, build_context: Path, image_tag: str) -> None:
     """Build Docker image for the current application directory."""
 
-    # Build a local image from generated Dockerfile in the application root.
-    subprocess.run(["docker", "build", "-t", image_tag, "."], cwd=root, check=True)
+    # Build from a context that includes local path dependencies referenced by uv.
+    subprocess.run(
+        ["docker", "build", "-f", str(dockerfile_path), "-t", image_tag, str(build_context)],
+        check=True,
+    )
 
 
 def run_docker_push(image_tag: str) -> None:
@@ -79,10 +115,10 @@ def build_command(registry: str):
     """Create Dockerfile, build Docker image, and push image to registry."""
 
     try:
-        dockerfile_path, manifest_path, version, app_name = build_app()
+        dockerfile_path, manifest_path, version, app_name, build_context = build_app()
         image_tag = build_image_tag(app_name, version, registry)
 
-        run_docker_build(dockerfile_path.parent, image_tag)
+        run_docker_build(dockerfile_path, build_context, image_tag)
         run_docker_push(image_tag)
 
         click.echo(f"Build artifacts created for version {version}")

--- a/sdk/sample/README.md
+++ b/sdk/sample/README.md
@@ -12,6 +12,10 @@ Employees browse available products, create requisition requests, and track orde
 2. Builds a Docker image tagged with the app name and a timestamp version.
 3. Pushes that image to a Docker registry (default: `localhost:5000`, which is common for local k3d setups).
 
+Because this sample depends on the local SDK package (`longlink` via `tool.uv.sources`),
+the generated Docker build now uses the `sdk/` directory as build context. This keeps the
+relative dependency path valid while still using the `sdk/sample/Dockerfile` file.
+
 ### Prerequisites
 
 - Docker daemon is running.
@@ -25,11 +29,15 @@ k3d registry create compute-registry --port 5000
 
 ### Build and push using default registry
 
+From `sdk/sample`:
+
 ```bash
 longlink build
 ```
 
 ### Build and push using a custom k3d registry endpoint
+
+From `sdk/sample`:
 
 ```bash
 longlink build --registry my-registry.localhost:5001


### PR DESCRIPTION
### Motivation
- The sample app's container build was failing during `uv sync --frozen` because the sample Docker build used `sdk/sample` as the build context while the project depends on the local `longlink` package via `tool.uv.sources`, causing the editable path to resolve incorrectly in-container.
- The change aims to make the generated Dockerfile and `docker build` invocation preserve relative local source paths so `uv` can build editable dependencies inside the container.

### Description
- Compute the Docker build context and in-container `WORKDIR` by reading `tool.uv.sources` from the app `pyproject.toml` in `sdk/longlink/cli/build.py` and render the Dockerfile with the appropriate `WORKDIR`.
- Change the generated Dockerfile to `COPY . /workspace` and make `run_docker_build` call `docker build -f <Dockerfile> <build_context>` so the sibling `longlink` dependency is included in the build context.
- Include `build_context` in the generated `manifest.json` and update function signatures to return the computed context.
- Document the sample build behavior and add instruction to run `longlink build` from `sdk/sample` in `sdk/sample/README.md`.

### Testing
- Ran `make format` from the repo root and it completed successfully.
- Executed `cd sdk/sample && uv run python - <<'PY' ... from longlink.cli.build import build_app; build_app(Path.cwd())` to generate and inspect `Dockerfile` and `manifest.json`, and the command succeeded and produced the expected outputs.
- Executed `cd sdk/sample && uv run python - <<'PY' ... from longlink.cli.build import resolve_docker_paths; resolve_docker_paths(Path.cwd())` to validate computed build context and workdir, and the command returned the expected paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62a155d84832399b551224f0dabcb)