### PR TITLE
api: return in-cluster service URL when provisioning compute pod

### DIFF
--- a/api/src/utils/compute.py
+++ b/api/src/utils/compute.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import kr8s.asyncio as kr8s_asyncio
 from src.env import env
 from urllib.parse import ParseResult, quote, urlparse
-from kr8s.asyncio.objects import Pod, Namespace
+from kr8s.asyncio.objects import Pod, Service, Namespace
+
+
+class ComputeConnectionError(RuntimeError):
+    """Raised when the control plane cannot connect to the compute API."""
 
 
 async def create(
@@ -15,18 +20,22 @@ async def create(
     args: list[str] | None,
     env_vars: dict[str, str],
     container_port: int | None,
-    ) -> None:
-    """Create a Kubernetes pod in the specified namespace."""
-    # Try the explicit API server configuration first because deployments may
-    # provide a dedicated compute endpoint that should take precedence.
+) -> str:
+    """Create a namespaced pod and service, then return in-cluster service URL."""
+    # Build an authenticated URL so the compute API can be reached by admin credentials.
     compute_api_server_url = _build_authenticated_compute_url(
         api_server_url=env.ENV_PROVISION_COMPUTE_API_SERVER_URL,
         username=env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME,
         password=env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD,
     )
 
-    await _create_namespaced_pod(
-        api=await kr8s_asyncio.api(url=compute_api_server_url),
+    try:
+        api = await kr8s_asyncio.api(url=compute_api_server_url)
+    except Exception as exc:  # pragma: no cover - depends on runtime connectivity.
+        raise ComputeConnectionError("Failed to connect to compute API") from exc
+
+    return await _create_namespaced_pod(
+        api=api,
         namespace=namespace,
         pod_name=pod_name,
         image=image,
@@ -47,18 +56,25 @@ async def _create_namespaced_pod(
     args: list[str] | None,
     env_vars: dict[str, str],
     container_port: int | None,
-) -> None:
-    """Create namespace and pod using a pre-configured Kubernetes API client."""
+) -> str:
+    """Create namespace, pod, and service, then return in-cluster DNS URL."""
+    if container_port is None:
+        raise ValueError("container_port is required to expose the app service")
 
+    # Ensure namespace exists before creating the pod.
     namespace_obj = await Namespace({"metadata": {"name": namespace}}, api=api)
-    await namespace_obj.create()
+    try:
+        await namespace_obj.create()
+    except Exception:
+        # Namespace might already exist and is safe to ignore.
+        pass
 
-    # Build container and pod specs from request parameters.
     container_spec: dict[str, object] = {
         "name": pod_name,
         "image": image,
         "env": [{"name": name, "value": value} for name, value in env_vars.items()],
     }
+
     if command:
         container_spec["command"] = command
     if args:
@@ -75,6 +91,36 @@ async def _create_namespaced_pod(
         api=api,
     )
     await pod.create()
+
+    # Wait until the pod is healthy before creating or reusing the service.
+    await pod.wait("condition=Ready", timeout=60)
+
+    service = await Service(
+        {
+            "metadata": {"name": pod_name},
+            "spec": {
+                "selector": {"app": pod_name},
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": container_port,
+                        "targetPort": container_port,
+                    }
+                ],
+                "type": "ClusterIP",
+            },
+        },
+        namespace=namespace,
+        api=api,
+    )
+
+    try:
+        await service.create()
+    except Exception:
+        # Service may already exist for this app name.
+        pass
+
+    return f"http://{pod_name}.{namespace}.svc.cluster.local:{container_port}"
 
 
 def _build_authenticated_compute_url(
@@ -101,3 +147,21 @@ def _build_authenticated_compute_url(
         query=parsed_url.query,
         fragment=parsed_url.fragment,
     ).geturl()
+
+
+async def _example_main() -> None:
+    """Run a sample deployment with explicit values requested by the task."""
+    url = await create(
+        namespace="default",
+        pod_name="sampleapp",
+        image="localhost:5000/sampleapp:20260419_185022",
+        command=None,
+        args=None,
+        env_vars={},
+        container_port=8000,
+    )
+    print(url)
+
+
+if __name__ == "__main__":
+    asyncio.run(_example_main())


### PR DESCRIPTION
### Motivation
- The compute provisioning flow should return a usable in-cluster service endpoint for newly created app pods and surface connectivity failures to the compute API explicitly.
- The platform requires the container port to match the app port and FastAPI apps to be reachable on `0.0.0.0:<port>`, so provisioning must create a service that exposes the pod on the requested port.

### Description
- Updated `api/src/utils/compute.py` to return a `str` URL in the form `http://<pod>.<namespace>.svc.cluster.local:<port>` instead of returning `None` after provisioning. 
- Added `ComputeConnectionError` and wrapped compute API client creation so connection failures raise a clear error. 
- Implemented namespaced provisioning that ensures the `Namespace` exists (ignoring already-exists), creates the `Pod`, waits for `condition=Ready`, and creates or reuses a `ClusterIP` `Service` bound to the supplied `container_port`. 
- Enforced that `container_port` is required (raising `ValueError` if omitted) and added an executable example under `if __name__ == "__main__":` that provisions the sample image `localhost:5000/sampleapp:20260419_185022` in `default` as `sampleapp:8000`.

### Testing
- Ran formatting via `make format` from the repo root and it completed successfully. 
- Attempted a targeted test run with an incorrect path using `cd api && uv run pytest api/tests/utils/test_compute.py` which reported no tests because the path was invalid. 
- Ran the intended targeted test `cd api && uv run pytest tests/utils/test_compute.py` but collection errored due to a missing test environment dependency (`ModuleNotFoundError: No module named 'sniffio'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62bb472708323abfc63724a2d08ec)