### PR TITLE
api: retry compute pod provisioning against HTTPS endpoints

### DIFF
--- a/api/src/utils/compute.py
+++ b/api/src/utils/compute.py
@@ -28,22 +28,35 @@ async def create(
         username=env.ENV_PROVISION_COMPUTE_ADMIN_USERNAME,
         password=env.ENV_PROVISION_COMPUTE_ADMIN_PASSWORD,
     )
+    candidate_urls = [compute_api_server_url]
 
-    try:
-        api = await kr8s_asyncio.api(url=compute_api_server_url)
-    except Exception as exc:  # pragma: no cover - depends on runtime connectivity.
-        raise ComputeConnectionError("Failed to connect to compute API") from exc
+    # Retry with HTTPS when compute endpoint is TLS-only but configuration still uses HTTP.
+    if urlparse(compute_api_server_url).scheme == "http":
+        candidate_urls.append(_with_https_scheme(compute_api_server_url))
 
-    return await _create_namespaced_pod(
-        api=api,
-        namespace=namespace,
-        pod_name=pod_name,
-        image=image,
-        command=command,
-        args=args,
-        env_vars=env_vars,
-        container_port=container_port,
-    )
+    last_error: Exception | None = None
+    for candidate_url in candidate_urls:
+        try:
+            api = await kr8s_asyncio.api(
+                url=candidate_url,
+                bypass_tls_verify=not env.ENV_PROVISION_COMPUTE_VERIFY_SSL,
+            )
+            return await _create_namespaced_pod(
+                api=api,
+                namespace=namespace,
+                pod_name=pod_name,
+                image=image,
+                command=command,
+                args=args,
+                env_vars=env_vars,
+                container_port=container_port,
+            )
+        except Exception as exc:  # pragma: no cover - depends on runtime connectivity.
+            last_error = exc
+            if "Client sent an HTTP request to an HTTPS server" not in str(exc):
+                raise
+
+    raise ComputeConnectionError("Failed to connect to compute API") from last_error
 
 
 async def _create_namespaced_pod(
@@ -142,6 +155,19 @@ def _build_authenticated_compute_url(
     return ParseResult(
         scheme=parsed_url.scheme,
         netloc=authenticated_netloc,
+        path=parsed_url.path,
+        params=parsed_url.params,
+        query=parsed_url.query,
+        fragment=parsed_url.fragment,
+    ).geturl()
+
+
+def _with_https_scheme(url: str) -> str:
+    """Return URL with HTTPS scheme while preserving all remaining parts."""
+    parsed_url = urlparse(url)
+    return ParseResult(
+        scheme="https",
+        netloc=parsed_url.netloc,
         path=parsed_url.path,
         params=parsed_url.params,
         query=parsed_url.query,


### PR DESCRIPTION
### Motivation
- Running the compute provisioning sample failed with `Client sent an HTTP request to an HTTPS server`, which indicates caller config may use `http://` while the compute gateway requires TLS. 
- The provisioning flow should be resilient to this mismatch and honor `ENV_PROVISION_COMPUTE_VERIFY_SSL` for TLS verification behavior. 
- Provide a clear error type when the control plane cannot reach the compute API after retry attempts.

### Description
- Updated `api/src/utils/compute.py` so `create()` builds a candidate URL list and retries with an HTTPS variant when the configured URL uses `http://` by adding `_with_https_scheme()`; the retry loop attempts each candidate. 
- Wired TLS verification into the kr8s client by passing `bypass_tls_verify=not env.ENV_PROVISION_COMPUTE_VERIFY_SSL` to `kr8s_asyncio.api()` and surface a consistent `ComputeConnectionError` when retries are exhausted. 
- Added helper ` _with_https_scheme()` to replace the URL scheme while preserving host/path/query/fragment, and only ignore the HTTP->HTTPS error text to continue retrying.

### Testing
- Ran repository formatting with `make format` from repo root, which completed successfully. 
- Ran the repo formatting steps that invoke `uv sync`/`isort` as part of `make format`, which completed without errors. 
- Performed an import/smoke check via `uv run python - <<'PY' ...` in `api`, which failed due to a missing runtime dependency (`sniffio`) in the environment and is unrelated to the code change; no runtime API calls were validated end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63965dd108323b022928c11eec895)