### PR TITLE
Fix LongLink product-name casing in user-facing web menu label

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br />
 <br />
 
-# Introduction 
+# Introduction
 
 A platform for building applications that manage workflows, data, and validation processes.
 

--- a/web/src/xml/components/Menu.tsx
+++ b/web/src/xml/components/Menu.tsx
@@ -137,7 +137,7 @@ export function Menu(_props: MenuProps) {
     if (!sections.length) return null;
 
     return (
-        <BaseMenu value={activeValue} onValueChange={setActiveValue} ariaLabel="Longlink menu">
+        <BaseMenu value={activeValue} onValueChange={setActiveValue} ariaLabel="LongLink menu">
             <aside className="w-64">
                 <MenuList>
                     {sections.map((section) => (


### PR DESCRIPTION
### Motivation
- Ensure consistent, user-facing branding by correcting product-name casing to `LongLink` in rendered UI and docs.

### Description
- Change the web menu aria label in `web/src/xml/components/Menu.tsx` from `Longlink menu` to `LongLink menu` and run repository formatting which normalized a trailing-whitespace issue in `README.md`.

### Testing
- Ran `rg -n "Longlink" web docs sdk --glob '!**/node_modules/**'` to locate occurrences and `make format` to apply project formatting; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75caf82248323ac6f4ea8ec7ff562)