### PR TITLE
docs: align SDK testing examples with repository test layout

### DIFF
--- a/docs/src/sdk/testing.md
+++ b/docs/src/sdk/testing.md
@@ -18,16 +18,16 @@ uv pip install .[dev]
 
 ## Usage
 
-You can execute all tests or target a specific test file using the following commands:
+You can execute all tests or target a specific test file using the following commands. Use `tests/unit` for fast, isolated checks and `tests/integration` for end-to-end behavior across components:
 
 ```bash
 pytest
-pytest tests/test_app.py
+pytest tests/unit/cli/test_init.py
 ```
 
 ## Example
 
-Asynchronous Testing with `pytest`
+Illustrative snippet: asynchronous testing with `pytest`
 
 ```py
 import pytest
@@ -39,7 +39,7 @@ async def test_healthcheck(client):
     assert response.status_code == 200
 ```
 
-Testing with FastAPI [`TestClient`](https://fastapi.tiangolo.com/tutorial/testing/)
+Illustrative snippet: testing with FastAPI [`TestClient`](https://fastapi.tiangolo.com/tutorial/testing/)
 
 ```py
 from app import app


### PR DESCRIPTION
### Motivation

- Make the SDK testing docs realistic by using an example test path that matches the repository's layout and developer workflow.
- Clarify how tests are organized so readers know to prefer `tests/unit` for fast checks and `tests/integration` for end-to-end behavior.

### Description

- Replaced the single-file example `pytest tests/test_app.py` with a repository-aligned example `pytest tests/unit/cli/test_init.py` in `docs/src/sdk/testing.md`.
- Kept the generic `pytest` invocation while adding a one-line explanation of the `tests/unit` vs `tests/integration` split.
- Labeled the asyncio and FastAPI examples as illustrative snippets and preserved the valid example code for `pytest-asyncio` and FastAPI `TestClient`.

### Testing

- Ran `make format` from the repository root and the formatting step completed successfully.
- Verified the updated file `docs/src/sdk/testing.md` reflects the intended changes and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75c9d11248323a8f7cda61bb8b385)