### PR TITLE
docs(sdk): fix build page grammar and CLI command typo

### DIFF
--- a/docs/src/sdk/building.md
+++ b/docs/src/sdk/building.md
@@ -1,10 +1,10 @@
 # Building
 
-- Applications can be build using docker
-- `longling build` generate the `Dockerfile` and the `manifest.json`
-- Once containerized can be placed in any registry-
-- Can be connected to the control panel and deployed
+- Applications can be built using Docker.
+- `longlink build` generates the `Dockerfile` and the `manifest.json`.
+- Once containerized, applications can be pushed to any registry.
+- Applications can be connected to the control plane and deployed.
 
 ```bash
-longling build
+longlink build
 ```


### PR DESCRIPTION
### Motivation
- Correct grammar and capitalization in the SDK build doc to improve clarity and professionalism.
- Fix the CLI command typo so documentation matches the SDK CLI implementation and reduces user confusion.
- Make the registry sentence explicit to clarify deployment workflow.

### Description
- Updated `docs/src/sdk/building.md` to replace "Applications can be build using docker" with "Applications can be built using Docker.".
- Replaced all occurrences of `longling build` with `longlink build`, including the code block using ``longlink build``.
- Changed the verb from "generate" to "generates" and removed the trailing hyphen by making the registry sentence explicit as "Once containerized, applications can be pushed to any registry.".
- Verified wording is consistent with the SDK CLI command registered in `sdk/longlink/cli/build.py`.

### Testing
- Ran `make format`, which executed formatting steps including `isort` and Prettier, and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75c8aa24c8323a446cf26bd368be6)