### PR TITLE
Rename Longlink -> LongLink and align SDK export name

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,12 +3,12 @@ import { Navigate, RouterProvider, createBrowserRouter } from 'react-router';
 import { useIsFetching, useIsMutating } from '@tanstack/react-query';
 import { Toaster } from '@/ui/sonner';
 import Layout from './Layout';
-import Longlink from './pages/Longlink';
+import LongLink from './pages/Longlink';
 import OrganizationPage from './pages/OrganizationPage';
 import Login from './pages/Login';
 import NotFound from './pages/NotFound';
 import SdkLayout from './sdk/Layout';
-import SdkLonglink from './sdk/Longlink';
+import SdkLongLink from './sdk/Longlink';
 import { RequireAuth } from '@/components/Auth';
 
 const buildMode = import.meta.env.MODE;
@@ -43,7 +43,7 @@ const sdkRoutes = [
     {
         path: '/',
         element: <SdkLayout />,
-        children: [{ path: '*', element: <SdkLonglink /> }],
+        children: [{ path: '*', element: <SdkLongLink /> }],
     },
 ];
 
@@ -58,7 +58,7 @@ const apiRoutes = [
             { path: 'example', element: <OrganizationPage page="example" /> },
             {
                 path: 'applications/:appId/*',
-                element: <Longlink />,
+                element: <LongLink />,
             },
         ],
     },

--- a/web/src/pages/Longlink.tsx
+++ b/web/src/pages/Longlink.tsx
@@ -8,7 +8,7 @@ type AppMetadata = {
     pages?: Array<AppNavigationPage & { content?: string }>;
 };
 
-type LonglinkProps = {
+type LongLinkProps = {
     appId?: string;
 };
 
@@ -17,7 +17,7 @@ type LonglinkProps = {
  */
 const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
 
-export default function Longlink({ appId: appIdOverride }: LonglinkProps) {
+export default function LongLink({ appId: appIdOverride }: LongLinkProps) {
     const { appId: routeAppId, '*': wildcardPath } = useParams();
     const appId = appIdOverride ?? routeAppId;
     const normalizedRoutePath = normalizePath(wildcardPath ?? '');

--- a/web/src/sdk/Longlink.tsx
+++ b/web/src/sdk/Longlink.tsx
@@ -12,7 +12,7 @@ type AppMetadata = {
 
 const normalizePath = (path: string) => path.replace(/^\/+|\/+$/g, '');
 
-export default function SdkLonglink() {
+export default function SdkLongLink() {
     const { '*': wildcardPath } = useParams();
     const normalizedRoutePath = normalizePath(wildcardPath ?? '');
 


### PR DESCRIPTION
### Motivation
- Normalize component and prop type naming to PascalCase and make SDK/runtime exports consistent for clearer imports and code readability.

### Description
- Renamed `LonglinkProps` to `LongLinkProps` and the default-exported page component `Longlink` to `LongLink` in `web/src/pages/Longlink.tsx`.
- Updated imports and JSX usage in `web/src/App.tsx` to import `LongLink` and render `<LongLink />` for the API route.
- Aligned SDK runtime naming by renaming `SdkLonglink` to `SdkLongLink` in `web/src/sdk/Longlink.tsx` and updating the corresponding import/usage in `web/src/App.tsx`.
- Applied repository formatting to clean up imports and code style after the rename using the project formatter.

### Testing
- Ran `make format`, which executed `isort` and `prettier` across the repo, and completed successfully.
- No unit tests were added or run per repository contributing guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bb2b59d883238bb4bd50c85f2055)