### PR TITLE
Simplify role rank lookup

### DIFF
--- a/api/src/utils/roles.py
+++ b/api/src/utils/roles.py
@@ -14,12 +14,14 @@ def rank(value: RoleName | None) -> int:
     if value is None:
         return 0
 
+    role_type = type(value)
+
     # Platform roles resolve through their own rank scale.
-    if type(value) is PlatformRoles:
+    if role_type is PlatformRoles:
         return PlatformRoleRanks[value.name].value
 
     # Organization and application roles share the same rank scale.
-    if type(value) in {OrganizationRoles, ApplicationRoles}:
+    if role_type in {OrganizationRoles, ApplicationRoles}:
         return Ranks[value.name].value
 
     raise ValueError(f"Unknown role '{value}'")


### PR DESCRIPTION
## Summary

Simplifies the `rank()` utility by resolving the role type once and reusing it for the existing comparisons.

This removes repeated `type()` calls. The function’s behavior, return values, and error handling remain unchanged.

## Testing

- Verified all platform, organization, and application roles
- Verified `None` handling
- Verified unknown roles still raise `ValueError`
- Confirmed the module compiles successfully
- Confirmed `git diff --check` passes