### PR TITLE
refactor: remove redundant code

### DIFF
--- a/api/src/database/services/applications.py
+++ b/api/src/database/services/applications.py
@@ -77,10 +77,10 @@ async def create(
 
     # Create the Application after validating its Organization lifecycle state.
     # Resolve the parent before taking locks in aggregate order.
-    current = await session.get(Organization, organization_id)
-    if current is None:
+    compute_id = await session.scalar(select(col(Organization.compute_id)).where(col(Organization.id) == organization_id))
+    if compute_id is None:
         raise NotFoundError("Organization not found")
-    compute = await session.get(ComputeRegistry, current.compute_id, with_for_update=True)
+    compute = await session.get(ComputeRegistry, compute_id, with_for_update=True)
     organization_result = await session.scalars(select(Organization).where(Organization.id == organization_id).with_for_update())
     organization = organization_result.one_or_none()
     if compute is None or organization is None:

--- a/api/src/database/services/operations.py
+++ b/api/src/database/services/operations.py
@@ -25,9 +25,13 @@ async def discover(session: AsyncSession) -> Sequence[tuple[OperationKind, UUID,
     """Discover release reconciliation targets in dependency order."""
 
     # Reconcile every present resource and clean up every tombstone.
-    result = await session.scalars(select(ComputeRegistry).order_by(col(ComputeRegistry.id)))
-    compute_rows = result.all()
-    result = await session.scalars(select(Organization).order_by(col(Organization.compute_id), col(Organization.id)))
+    result = await session.execute(select(col(ComputeRegistry.id)).order_by(col(ComputeRegistry.id)))
+    compute_ids = result.scalars().all()
+    result = await session.execute(
+        select(col(Organization.id), col(Organization.deleted_at), col(Organization.compute_id)).order_by(
+            col(Organization.compute_id), col(Organization.id)
+        )
+    )
     organization_rows = result.all()
     result = await session.execute(
         select(col(Application.id), col(Application.deleted_at), col(Organization.compute_id))
@@ -37,14 +41,14 @@ async def discover(session: AsyncSession) -> Sequence[tuple[OperationKind, UUID,
     )
     application_rows = result.all()
 
-    targets = [(OperationKind.compute_create, compute.id, compute.id) for compute in compute_rows]
+    targets = [(OperationKind.compute_create, compute_id, compute_id) for compute_id in compute_ids]
     targets.extend(
         (
-            OperationKind.organization_delete if organization.deleted_at is not None else OperationKind.organization_create,
-            organization.id,
-            organization.compute_id,
+            OperationKind.organization_delete if deleted_at is not None else OperationKind.organization_create,
+            organization_id,
+            compute_id,
         )
-        for organization in organization_rows
+        for organization_id, deleted_at, compute_id in organization_rows
     )
     targets.extend(
         (OperationKind.application_delete if deleted_at is not None else OperationKind.application_create, application_id, compute_id)

--- a/api/src/database/services/organizations.py
+++ b/api/src/database/services/organizations.py
@@ -131,8 +131,7 @@ async def purge(session: AsyncSession, organization_id: UUID) -> None:
         return
     if organization.deleted_at is None:
         raise RuntimeError("Active organizations cannot be purged")
-    application_id = await session.scalar(select(Application.id).where(Application.organization_id == organization_id).limit(1))
-    if application_id is not None:
+    if await session.scalar(select(Application.id).where(Application.organization_id == organization_id).limit(1)) is not None:
         raise RuntimeError("Organization applications must be purged first")
     await session.execute(delete(OrganizationInvitation).where(OrganizationInvitation.organization_id == organization_id))
     await session.execute(delete(UserOrganization).where(UserOrganization.organization_id == organization_id))

--- a/api/src/utils/urls.py
+++ b/api/src/utils/urls.py
@@ -48,10 +48,9 @@ def database(database_url: str) -> DatabaseConnection:
 
         ssl_check_hostname = parsed_url.query.get("ssl_check_hostname")
         if ssl_check_hostname is not None:
-            expected = sslmode == "VERIFY_IDENTITY"
             if not isinstance(ssl_check_hostname, str) or ssl_check_hostname not in {"true", "false"}:
                 raise ValueError("MySQL database URL has an invalid ssl_check_hostname")
-            if (ssl_check_hostname == "true") != expected:
+            if (ssl_check_hostname == "true") != (sslmode == "VERIFY_IDENTITY"):
                 raise ValueError("MySQL ssl_check_hostname conflicts with ssl-mode")
 
         normalized_url = parsed_url.difference_update_query(tls_parameters)

--- a/sdk/longlink/__init__.py
+++ b/sdk/longlink/__init__.py
@@ -2,5 +2,4 @@ from . import database
 from .app import LongLink
 from .context import Context, data
 from .utils.xml import Element
-from .utils.settings import Envs
 from .utils.environments import Environments

--- a/sdk/longlink/models/__init__.py
+++ b/sdk/longlink/models/__init__.py
@@ -1,1 +1,0 @@
-from .icons import Icon

--- a/sdk/longlink/utils/__init__.py
+++ b/sdk/longlink/utils/__init__.py
@@ -1,3 +1,1 @@
-from longlink.utils.xml import Element
 from longlink.utils.settings import Envs
-from longlink.utils.environments import Environments

--- a/web/src/hooks/use-user.tsx
+++ b/web/src/hooks/use-user.tsx
@@ -101,7 +101,6 @@ export function useUpdateUser() {
                 (value) => zUserProfile.parse(value)
             ),
         onSuccess: (user) => {
-            storeThemePreferences(user);
             queryClient.setQueryData(userProfileQueryKey, user);
         },
     });

--- a/web/src/platform/org/Settings.tsx
+++ b/web/src/platform/org/Settings.tsx
@@ -1,7 +1,7 @@
 import { z } from 'zod';
+import { useState } from 'react';
 import { useLocation } from 'react-router';
 import { Text } from '@astryxdesign/core/Text';
-import { useState, type ReactNode } from 'react';
 import { Avatar } from '@astryxdesign/core/Avatar';
 import { Banner } from '@astryxdesign/core/Banner';
 import { HStack } from '@astryxdesign/core/HStack';
@@ -38,57 +38,6 @@ const organizationAvatarSchema = z.union([
     z.literal(''),
     z.url().refine((value) => ['http:', 'https:'].includes(new URL(value).protocol)),
 ]);
-
-/** Renders the organization storage usage table. */
-function StorageSettings({
-    columns,
-    description,
-    emptyState,
-    idKey,
-    isOrganizationLoading,
-    organizationError,
-    organizationId,
-    title,
-}: {
-    columns: TableColumn<OrganizationStorageUsageResponse>[];
-    description: string;
-    emptyState: ReactNode;
-    idKey: keyof OrganizationStorageUsageResponse & string;
-    isOrganizationLoading: boolean;
-    organizationError: Error | null;
-    organizationId: string;
-    title: string;
-}) {
-    const { data, error, isLoading } = useApiQuery<OrganizationStorageUsageResponse | null>(
-        organizationId ? platformApiPath(`/organizations/${organizationId}/storage`) : null,
-        {
-            parse: (value) => zOrganizationStorageUsageResponse.nullable().parse(value),
-            retry: false,
-        }
-    );
-    return (
-        <VStack gap={4}>
-            <VStack gap={1}>
-                <Heading level={2}>{title}</Heading>
-                <Text type="supporting">{description}</Text>
-            </VStack>
-            {isOrganizationLoading || isLoading ? null : organizationError ? (
-                <Banner status="error" title={organizationError.message} />
-            ) : error ? (
-                <Banner status="error" title={error.message} />
-            ) : (
-                <Table
-                    columns={columns}
-                    data={data ? [data] : []}
-                    density="compact"
-                    emptyState={emptyState}
-                    hasHover
-                    idKey={idKey}
-                />
-            )}
-        </VStack>
-    );
-}
 
 /** Renders the organization settings page body. */
 export default function Settings({
@@ -137,14 +86,16 @@ export default function Settings({
         }
     );
     const databaseResourceError = error ?? databaseError;
-    const ownerCell = (
-        <HStack gap={3} align="center">
-            <Avatar src={organizationAvatar} name={organizationName} size="md" />
-            <VStack gap={1}>
-                <Text weight="semibold">{organizationName}</Text>
-                <Text type="supporting">Organization</Text>
-            </VStack>
-        </HStack>
+    const {
+        data: storageUsage,
+        error: storageError,
+        isLoading: isStorageLoading,
+    } = useApiQuery<OrganizationStorageUsageResponse | null>(
+        section === 'storage' && organizationId ? platformApiPath(`/organizations/${organizationId}/storage`) : null,
+        {
+            parse: (value) => zOrganizationStorageUsageResponse.nullable().parse(value),
+            retry: false,
+        }
     );
     const storageColumns: TableColumn<OrganizationStorageUsageResponse>[] = [
         {
@@ -165,7 +116,15 @@ export default function Settings({
             key: 'owner',
             header: 'Owner',
             width: proportional(1),
-            renderCell: () => ownerCell,
+            renderCell: () => (
+                <HStack gap={3} align="center">
+                    <Avatar src={organizationAvatar} name={organizationName} size="md" />
+                    <VStack gap={1}>
+                        <Text weight="semibold">{organizationName}</Text>
+                        <Text type="supporting">Organization</Text>
+                    </VStack>
+                </HStack>
+            ),
         },
     ];
 
@@ -328,16 +287,26 @@ export default function Settings({
                 ) : null}
 
                 {section === 'storage' ? (
-                    <StorageSettings
-                        columns={storageColumns}
-                        description="Review storage usage for this organization."
-                        emptyState={<EmptyState title="No storage resources found." isCompact />}
-                        idKey="bucket_name"
-                        isOrganizationLoading={isLoading}
-                        organizationError={error}
-                        organizationId={organizationId}
-                        title="Storage"
-                    />
+                    <VStack gap={4}>
+                        <VStack gap={1}>
+                            <Heading level={2}>Storage</Heading>
+                            <Text type="supporting">Review storage usage for this organization.</Text>
+                        </VStack>
+                        {isLoading || isStorageLoading ? null : error ? (
+                            <Banner status="error" title={error.message} />
+                        ) : storageError ? (
+                            <Banner status="error" title={storageError.message} />
+                        ) : (
+                            <Table
+                                columns={storageColumns}
+                                data={storageUsage ? [storageUsage] : []}
+                                density="compact"
+                                emptyState={<EmptyState title="No storage resources found." isCompact />}
+                                hasHover
+                                idKey="bucket_name"
+                            />
+                        )}
+                    </VStack>
                 ) : null}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove unused SDK re-exports and namespace initializer
- load only scalar fields needed by application and operation workflows
- eliminate duplicate theme persistence and inline single-use storage settings UI

## Verification
- uv run ruff check and focused API tests
- SDK ruff, focused tests, package build, and import check
- vp check and vp run typecheck