### PR TITLE
fix(web): accept pasted docker pull commands

### DIFF
--- a/web/src/components/dialogs/CreateApplication.tsx
+++ b/web/src/components/dialogs/CreateApplication.tsx
@@ -232,7 +232,13 @@ export default function CreateApplication({ organizationId }: { organizationId: 
                                                                 isRequired
                                                                 placeholder="ghcr.io/longlink/dashboard:latest"
                                                                 onBlur={field.handleBlur}
-                                                                onChange={field.handleChange}
+                                                                onChange={(value) =>
+                                                                    field.handleChange(
+                                                                        value.startsWith('docker pull ')
+                                                                            ? value.slice('docker pull '.length)
+                                                                            : value
+                                                                    )
+                                                                }
                                                             />
                                                         )}
                                                     </form.Field>


### PR DESCRIPTION
## Summary
- strip a leading `docker pull ` command from the application image field
- inspect and create applications with the resulting image reference
- retain API-side image reference validation

## Testing
- `vp check`
- `vp run typecheck`

Closes #812